### PR TITLE
feat(settings): add on_page_change callback to Settings widget

### DIFF
--- a/crates/story/src/stories/settings_story.rs
+++ b/crates/story/src/stories/settings_story.rs
@@ -61,6 +61,7 @@ pub struct SettingsStory {
     focus_handle: FocusHandle,
     group_variant: GroupBoxVariant,
     size: Size,
+    last_page_index: usize,
 }
 
 struct OpenURLSettingField {
@@ -121,6 +122,7 @@ impl SettingsStory {
             focus_handle: cx.focus_handle(),
             group_variant: GroupBoxVariant::Outline,
             size: Size::default(),
+            last_page_index: 0,
         }
     }
 
@@ -455,9 +457,20 @@ impl Focusable for SettingsStory {
 
 impl Render for SettingsStory {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let entity = cx.entity();
         Settings::new("app-settings")
             .with_size(self.size)
             .with_group_variant(self.group_variant)
+            .default_selected_index(gpui_component::setting::SelectIndex {
+                page_ix: self.last_page_index,
+                group_ix: None,
+            })
+            .on_page_change(move |ix, cx| {
+                entity.update(cx, |this, cx| {
+                    this.last_page_index = ix;
+                    cx.notify();
+                });
+            })
             .pages(self.setting_pages(window, cx))
     }
 }

--- a/crates/ui/src/setting/settings.rs
+++ b/crates/ui/src/setting/settings.rs
@@ -273,31 +273,6 @@ pub struct SelectIndex {
     pub group_ix: Option<usize>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use gpui::px;
-
-    #[test]
-    fn test_settings_builder() {
-        let settings = Settings::new("test-settings")
-            .sidebar_width(px(200.0))
-            .default_selected_index(SelectIndex {
-                page_ix: 1,
-                group_ix: None,
-            })
-            .on_page_change(|_, _| {})
-            .page(SettingPage::new("General"))
-            .page(SettingPage::new("Advanced"));
-
-        assert_eq!(settings.sidebar_width, px(200.0));
-        assert_eq!(settings.default_selected_index.page_ix, 1);
-        assert!(settings.default_selected_index.group_ix.is_none());
-        assert!(settings.on_page_change.is_some());
-        assert_eq!(settings.pages.len(), 2);
-    }
-}
-
 impl RenderOnce for Settings {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let state = window.use_keyed_state(self.id.clone(), cx, |window, cx| {

--- a/crates/ui/src/setting/settings.rs
+++ b/crates/ui/src/setting/settings.rs
@@ -11,7 +11,7 @@ use gpui::{
     RenderOnce, StyleRefinement, Styled, Window, div, prelude::FluentBuilder as _, px, relative,
 };
 use rust_i18n::t;
-use std::sync::Arc;
+use std::rc::Rc;
 
 /// The settings structure containing multiple pages for app settings.
 ///
@@ -35,7 +35,7 @@ pub struct Settings {
     sidebar_style: StyleRefinement,
     default_selected_index: SelectIndex,
     header_style: StyleRefinement,
-    on_page_change: Option<Arc<dyn Fn(usize, &mut App) + 'static>>,
+    on_page_change: Option<Rc<dyn Fn(usize, &mut App) + 'static>>,
 }
 
 impl Settings {
@@ -103,7 +103,7 @@ impl Settings {
     /// The first argument is the zero-based page index. This is useful for persisting
     /// the last-visited page so it can be restored via [`Self::default_selected_index`].
     pub fn on_page_change(mut self, f: impl Fn(usize, &mut App) + 'static) -> Self {
-        self.on_page_change = Some(Arc::new(f));
+        self.on_page_change = Some(Rc::new(f));
         self
     }
 
@@ -165,7 +165,7 @@ impl Settings {
         &self,
         state: &Entity<SettingsState>,
         pages: &Vec<SettingPage>,
-        on_page_change: Option<Arc<dyn Fn(usize, &mut App) + 'static>>,
+        on_page_change: Option<Rc<dyn Fn(usize, &mut App) + 'static>>,
         _: &mut Window,
         cx: &mut App,
     ) -> impl IntoElement {
@@ -271,6 +271,31 @@ pub struct RenderOptions {
 pub struct SelectIndex {
     pub page_ix: usize,
     pub group_ix: Option<usize>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::px;
+
+    #[test]
+    fn test_settings_builder() {
+        let settings = Settings::new("test-settings")
+            .sidebar_width(px(200.0))
+            .default_selected_index(SelectIndex {
+                page_ix: 1,
+                group_ix: None,
+            })
+            .on_page_change(|_, _| {})
+            .page(SettingPage::new("General"))
+            .page(SettingPage::new("Advanced"));
+
+        assert_eq!(settings.sidebar_width, px(200.0));
+        assert_eq!(settings.default_selected_index.page_ix, 1);
+        assert!(settings.default_selected_index.group_ix.is_none());
+        assert!(settings.on_page_change.is_some());
+        assert_eq!(settings.pages.len(), 2);
+    }
 }
 
 impl RenderOnce for Settings {

--- a/crates/ui/src/setting/settings.rs
+++ b/crates/ui/src/setting/settings.rs
@@ -11,6 +11,7 @@ use gpui::{
     RenderOnce, StyleRefinement, Styled, Window, div, prelude::FluentBuilder as _, px, relative,
 };
 use rust_i18n::t;
+use std::sync::Arc;
 
 /// The settings structure containing multiple pages for app settings.
 ///
@@ -34,6 +35,7 @@ pub struct Settings {
     sidebar_style: StyleRefinement,
     default_selected_index: SelectIndex,
     header_style: StyleRefinement,
+    on_page_change: Option<Arc<dyn Fn(usize, &mut App) + 'static>>,
 }
 
 impl Settings {
@@ -48,6 +50,7 @@ impl Settings {
             sidebar_style: StyleRefinement::default(),
             default_selected_index: SelectIndex::default(),
             header_style: StyleRefinement::default(),
+            on_page_change: None,
         }
     }
 
@@ -92,6 +95,15 @@ impl Settings {
     /// Set the style refinement for the header.
     pub fn header_style(mut self, style: &StyleRefinement) -> Self {
         self.header_style = style.clone();
+        self
+    }
+
+    /// Set a callback invoked when the user selects a top-level page in the sidebar.
+    ///
+    /// The first argument is the zero-based page index. This is useful for persisting
+    /// the last-visited page so it can be restored via [`Self::default_selected_index`].
+    pub fn on_page_change(mut self, f: impl Fn(usize, &mut App) + 'static) -> Self {
+        self.on_page_change = Some(Arc::new(f));
         self
     }
 
@@ -153,6 +165,7 @@ impl Settings {
         &self,
         state: &Entity<SettingsState>,
         pages: &Vec<SettingPage>,
+        on_page_change: Option<Arc<dyn Fn(usize, &mut App) + 'static>>,
         _: &mut Window,
         cx: &mut App,
     ) -> impl IntoElement {
@@ -182,6 +195,7 @@ impl Settings {
                         .active(is_page_active)
                         .on_click({
                             let state = state.clone();
+                            let on_page_change = on_page_change.clone();
                             move |_, _, cx| {
                                 state.update(cx, |state, cx| {
                                     state.selected_index = SelectIndex {
@@ -189,7 +203,10 @@ impl Settings {
                                         ..Default::default()
                                     };
                                     cx.notify();
-                                })
+                                });
+                                if let Some(f) = &on_page_change {
+                                    f(page_ix, cx);
+                                }
                             }
                         })
                         .when(page.groups.len() > 1, |this| {
@@ -288,7 +305,7 @@ impl RenderOnce for Settings {
             .child(
                 resizable_panel()
                     .size(self.sidebar_width)
-                    .child(self.render_sidebar(&state, &filtered_pages, window, cx)),
+                    .child(self.render_sidebar(&state, &filtered_pages, self.on_page_change.clone(), window, cx)),
             )
             .child(resizable_panel().child(self.render_active_page(
                 &state,


### PR DESCRIPTION
## Description

`Settings` stores its selected page in `SettingsState`, which is `pub(super)` and cannot be read by consumers. The only external control point is `default_selected_index`, which only applies on first initialization.

This makes it impossible to implement patterns like restoring the last-visited settings page when a user navigates away and returns — a common need for any app that lazily shows/hides the settings view.

This PR adds an optional `on_page_change` callback that fires whenever the user selects a top-level page in the sidebar:

Note: I opted to test this in the story since it did not appear unit style tests were favored in the repo, specifically this settings/ directory. I can add a test [(back)](https://github.com/longbridge/gpui-component/pull/2398/changes/74b4e2198301d3c75b3205d82440a82dc54104ec#diff-fa6be2b2f5381f4c82c71b35729c7ef6b7c37ee37176d8c000211d0b3bed539cL276-L300) in settings/ if that is preferable.

```rust
Settings::new("my-settings")
    .default_selected_index(SelectIndex { page_ix: last_page, group_ix: None })
    .on_page_change(move |page_ix, cx| {
        // store page_ix externally; pass it back via default_selected_index on next render
    })
```

## Screenshot

not applicable.

## Break Changes

none.

## How to Test

1. Create a Settings widget with .on_page_change(|ix, _cx| println!("page: {ix}"))
2. Click between pages in the sidebar — callback should fire with the correct zero-based index
3. Confirm existing Settings usage without .on_page_change compiles and behaves identically

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
