### PR TITLE
input: gutter cursor style + line hitbox accessors

### DIFF
--- a/crates/ui/src/input/element.rs
+++ b/crates/ui/src/input/element.rs
@@ -2127,8 +2127,25 @@ impl Element for TextElement {
             cx,
         );
 
+        // When the mode shows line numbers, set the mouse cursor to
+        // Arrow over the gutter so it does not read as the editor's
+        // text-insertion area.
+        let has_line_numbers = self.state.read(cx).mode.line_number();
+        if has_line_numbers {
+            window.set_cursor_style(
+                gpui::CursorStyle::Arrow,
+                &prepaint.fold_icon_layout.line_number_hitbox,
+            );
+        }
+
+        let line_number_hitbox = if has_line_numbers {
+            Some(prepaint.fold_icon_layout.line_number_hitbox.clone())
+        } else {
+            None
+        };
         self.state.update(cx, |state, cx| {
             state.last_layout = Some(prepaint.last_layout.clone());
+            state.line_number_hitbox = line_number_hitbox;
             state.last_bounds = Some(bounds);
             state.last_cursor = Some(state.cursor());
             state.set_input_bounds(input_bounds, cx);

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -357,6 +357,12 @@ pub struct InputState {
     /// The marked range is the temporary insert text on IME typing.
     pub(super) ime_marked_range: Option<Selection>,
     pub(super) last_layout: Option<LastLayout>,
+    /// The hitbox covering the line-number gutter region from the last
+    /// paint (Sub-epic E P4). Available whenever the mode shows line
+    /// numbers; consumed via [`InputState::line_number_hitbox`] so
+    /// downstream click routing can map mouse events back to gutter
+    /// rows without re-reading the layout.
+    pub(super) line_number_hitbox: Option<gpui::Hitbox>,
     pub(super) last_cursor: Option<usize>,
     /// The input container bounds
     pub(super) input_bounds: Bounds<Pixels>,
@@ -492,6 +498,7 @@ impl InputState {
             validate: None,
             mode: InputMode::default(),
             last_layout: None,
+            line_number_hitbox: None,
             last_bounds: None,
             last_selected_range: None,
             last_cursor: None,
@@ -704,6 +711,39 @@ impl InputState {
     #[inline]
     pub fn diagnostics_mut(&mut self) -> Option<&mut DiagnosticSet> {
         self.mode.diagnostics_mut()
+    }
+
+    /// Hitbox covering the gutter (line-number column) from the most
+    /// recent paint. Provided as a primitive for consumer-side
+    /// click routing. Returns `None` until at least one frame has
+    /// painted or when the mode does not show line numbers.
+    #[inline]
+    pub fn line_number_hitbox(&self) -> Option<&gpui::Hitbox> {
+        self.line_number_hitbox.as_ref()
+    }
+
+    /// Bounds, in window coordinates, of buffer line `row` from the
+    /// most recent paint. Useful for placing pop-ups or hitboxes
+    /// against a specific line without re-reading the layout. Returns
+    /// `None` when `row` is outside the visible range, when the layout
+    /// has no entry for the row (folded), or when no paint has run yet.
+    pub fn visible_line_bounds(&self, row: u32) -> Option<Bounds<Pixels>> {
+        let layout = self.last_layout.as_ref()?;
+        let row = row as usize;
+
+        let mut offset_y = layout.visible_top;
+        for (line, &buffer_line) in layout.lines.iter().zip(layout.visible_buffer_lines.iter()) {
+            let height = layout.line_height * line.wrapped_lines.len() as f32;
+            if buffer_line == row {
+                let last_bounds = self.last_bounds?;
+                return Some(Bounds::new(
+                    last_bounds.origin + point(px(0.), offset_y),
+                    gpui::size(last_bounds.size.width, height),
+                ));
+            }
+            offset_y += height;
+        }
+        None
     }
 
     /// Set placeholder


### PR DESCRIPTION
## Problem

Two small gaps for editors that show a line-number gutter:

1. The mouse cursor stays a text I-beam over the gutter, so the
   line-number column reads as part of the text-insertion area even
   though it isn't.
2. A consumer has no way to find where the gutter is on screen, or where
   a given buffer line is, without re-deriving layout — which it needs
   for things like click-to-select-line, breakpoint toggles, or placing
   a popover next to a specific line.

## Solution

**Gutter cursor.** When the mode shows line numbers, paint sets
`CursorStyle::Arrow` over the line-number hitbox so the gutter no longer
reads as the text-insertion area. Gated on `InputMode::line_number()`, so
single-line and auto-grow inputs are unaffected.

**Two read-only accessors on `InputState`:**

```rust
pub fn line_number_hitbox(&self) -> Option<&Hitbox>;
pub fn visible_line_bounds(&self, row: u32) -> Option<Bounds<Pixels>>;
```

- `line_number_hitbox()` exposes the gutter hitbox captured during the
  last paint.
- `visible_line_bounds(row)` returns the on-screen bounds of a buffer row
  from the last layout, soft-wrap aware.

Both are primitives for consumer-side click routing. The only behavior
change is the mouse cursor over the gutter (which previously had no
special cursor); everything else is strictly additive.
