### PR TITLE
Notification: Generalize conversions

### DIFF
--- a/crates/ui/src/notification.rs
+++ b/crates/ui/src/notification.rs
@@ -90,14 +90,14 @@ impl From<SharedString> for Notification {
     }
 }
 
-impl From<&'static str> for Notification {
-    fn from(s: &'static str) -> Self {
+impl From<&str> for Notification {
+    fn from(s: &str) -> Self {
         Self::new().message(s)
     }
 }
 
-impl From<Cow<'static, str>> for Notification {
-    fn from(s: Cow<'static, str>) -> Self {
+impl<'a> From<Cow<'a, str>> for Notification {
+    fn from(s: Cow<'a, str>) -> Self {
         Self::new().message(s)
     }
 }

--- a/crates/ui/src/notification.rs
+++ b/crates/ui/src/notification.rs
@@ -1,5 +1,6 @@
 use std::{
     any::TypeId,
+    borrow::Cow,
     collections::{HashMap, VecDeque},
     rc::Rc,
     time::Duration,
@@ -95,14 +96,17 @@ impl From<&'static str> for Notification {
     }
 }
 
-impl From<(NotificationType, &'static str)> for Notification {
-    fn from((type_, content): (NotificationType, &'static str)) -> Self {
-        Self::new().message(content).with_type(type_)
+impl From<Cow<'static, str>> for Notification {
+    fn from(s: Cow<'static, str>) -> Self {
+        Self::new().message(s)
     }
 }
 
-impl From<(NotificationType, SharedString)> for Notification {
-    fn from((type_, content): (NotificationType, SharedString)) -> Self {
+impl<T> From<(NotificationType, T)> for Notification
+where
+    T: Into<SharedString>,
+{
+    fn from((type_, content): (NotificationType, T)) -> Self {
         Self::new().message(content).with_type(type_)
     }
 }
@@ -171,7 +175,7 @@ impl Notification {
     ///
     /// ```rs
     /// struct MyNotificationKind;
-    /// let notification = Notification::new("Hello").id::<MyNotificationKind>();
+    /// let notification = Notification::new().message("Hello").id::<MyNotificationKind>();
     /// ```
     pub fn id<T: Sized + 'static>(mut self) -> Self {
         self.id = TypeId::of::<T>().into();


### PR DESCRIPTION
Closes #[issue number]

## Description

This PR generalizes `Notification` construction by broadening the accepted string types in its `From` implementations.

- Adds `From<Cow<'a, str>>` so notifications can be created from borrowed or owned string data.
- Replaces the separate typed-message impls with a single generic `From<(NotificationType, T)> where T: Into<SharedString>`.
- Keeps existing behavior unchanged while removing duplicated conversion code.

This makes the notification API easier to use with different string sources and reduces boilerplate in `crates/ui/src/notification.rs`.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
