### PR TITLE
editor: Add to option to keep completion menu at original position.

### DIFF
--- a/crates/ui/src/input/popovers/completion_menu.rs
+++ b/crates/ui/src/input/popovers/completion_menu.rs
@@ -177,6 +177,9 @@ pub struct CompletionMenu {
     /// The offset of the first character that triggered the completion.
     pub(crate) trigger_start_offset: Option<usize>,
     query: SharedString,
+    /// Screen position the popover is pinned to for a completion session.
+    /// Cleared on `hide` and when a new session starts.
+    anchor: Option<Point<Pixels>>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -220,6 +223,7 @@ impl CompletionMenu {
                 open: false,
                 trigger_start_offset: None,
                 query: SharedString::default(),
+                anchor: None,
                 _subscriptions,
             }
         })
@@ -328,6 +332,7 @@ impl CompletionMenu {
     pub(crate) fn hide(&mut self, cx: &mut Context<Self>) {
         self.open = false;
         self.trigger_start_offset = None;
+        self.anchor = None;
         cx.notify();
     }
 
@@ -335,6 +340,8 @@ impl CompletionMenu {
     pub(crate) fn update_query(&mut self, start_offset: usize, query: impl Into<SharedString>) {
         if self.trigger_start_offset.is_none() {
             self.trigger_start_offset = Some(start_offset);
+            // New session: re-pin on the next render.
+            self.anchor = None;
         }
         self.query = query.into();
     }
@@ -368,7 +375,13 @@ impl CompletionMenu {
         cx.notify();
     }
 
-    fn origin(&self, cx: &App) -> Option<Point<Pixels>> {
+    fn origin(&mut self, cx: &App) -> Option<Point<Pixels>> {
+        // Keep the popover where the session opened so it stays put as the
+        // query is typed.
+        if let Some(anchor) = self.anchor {
+            return Some(anchor);
+        }
+
         let editor = self.editor.read(cx);
         let Some(last_layout) = editor.last_layout.as_ref() else {
             return None;
@@ -377,12 +390,12 @@ impl CompletionMenu {
             return None;
         };
 
-        let scroll_origin = self.editor.read(cx).scroll_handle.offset();
+        let scroll_origin = editor.scroll_handle.offset();
 
-        Some(
-            scroll_origin + cursor_origin - editor.input_bounds.origin
-                + Point::new(-px(4.), last_layout.line_height + px(4.)),
-        )
+        let anchor = scroll_origin + cursor_origin - editor.input_bounds.origin
+            + Point::new(-px(4.), last_layout.line_height + px(4.));
+        self.anchor = Some(anchor);
+        Some(anchor)
     }
 }
 


### PR DESCRIPTION
## Description

The completion popover recomputes its position from the live caret bounds on every render, so it slides right as you type the query, reading as jittery.

This pins the popover to where the completion session opened and keeps it there until the session ends (`hide`) or a new one begins, matching the behavior of editors like VS Code and Zed.

## Screenshot

**Before**
<img width="640" height="146" alt="sticky suggestion before" src="https://github.com/user-attachments/assets/5babfb9f-6b08-4891-ad19-146325435219" />

**After**
<img width="640" height="146" alt="sticky suggestion after" src="https://github.com/user-attachments/assets/2eeab6cf-342d-4365-a631-592536167567" />


## Break Changes

None

## How to Test

1. `cargo run --example editor`
2. In the editor, type a word that triggers the completion popover (e.g. start typing so the menu appears).
3. Keep typing to extend the word.

**Before:** the popover slides right, tracking the caret.
**After:** the popover stays pinned where the completion opened.

Dismissing (Esc) and re-triggering elsewhere re-pins it at the new location.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
