### PR TITLE
lsp: only notify if hover state changed

### DIFF
--- a/crates/ui/src/input/lsp/mod.rs
+++ b/crates/ui/src/input/lsp/mod.rs
@@ -191,9 +191,13 @@ impl InputState {
     }
 
     pub(crate) fn clear_hover_state(&mut self, cx: &mut Context<InputState>) {
+        let had_definition = !self.hover_definition.is_empty();
+        let had_popover = self.hover_popover.is_some();
         self.hover_definition.clear();
         self.hover_popover = None;
         self.lsp._hover_task = Task::ready(Ok(()));
-        cx.notify();
+        if had_definition || had_popover {
+            cx.notify();
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #2239, which added clear_hover_state. That method always calls cx.notify(), but on_mouse_move calls it on every mouse move outside the input bounds, where hover state is normally already empty. The input was re-rendering on mouse movement anywhere else in the window for no reason.

Now it only notifies when a hover definition or popover was actually cleared. The _hover_task reset stays unconditional so an in-flight hover request is still cancelled during the 150ms debounce in handle_hover_popover, before any popover exists.

How to Test

Open the code editor story (cargo run, Input Story > Code Editor).

Hover a symbol until the popover shows, then move off it, and out of the editor. It should dismiss both times. Cmd-hover a symbol for the go-to-definition underline and confirm that clears too. Hover a symbol and leave the editor within 150ms; the popover should not appear afterwards.

Checklist

- [x] I have read the CONTRIBUTING (../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed cargo run for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)