### PR TITLE
tab: Add max_width to TabBar

### DIFF
--- a/crates/story/src/stories/tabs_story.rs
+++ b/crates/story/src/stories/tabs_story.rs
@@ -1,13 +1,16 @@
 use gpui::{
     Action, App, AppContext, Context, Entity, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, ParentElement, Render, Styled, Window,
+    IntoElement, ParentElement, Render, Styled, Subscription, Window,
+    prelude::FluentBuilder as _, px,
 };
 use serde::Deserialize;
 
 use gpui_component::{
     ActiveTheme as _, Icon, IconName, Selectable as _, Sizable, Size,
     button::{Button, ButtonGroup, ButtonVariants},
+    checkbox::Checkbox,
     h_flex,
+    slider::{Slider, SliderEvent, SliderState},
     tab::{Tab, TabBar},
     v_flex,
 };
@@ -18,6 +21,8 @@ use crate::{ChangeStorySize, section, story_toolbar};
 #[action(namespace = tabs_story, no_json)]
 struct ToggleMoreMenu;
 
+const MAX_WIDTH_START: f32 = 110.;
+
 pub struct TabsStory {
     focus_handle: FocusHandle,
     active_tab_ix: usize,
@@ -26,6 +31,10 @@ pub struct TabsStory {
     dynamic_next_tab_id: usize,
     size: Size,
     menu: bool,
+    max_width_enabled: bool,
+    max_width: f32,
+    max_width_slider: Entity<SliderState>,
+    _max_width_subscription: Subscription,
 }
 
 impl super::Story for TabsStory {
@@ -48,6 +57,21 @@ impl TabsStory {
     }
 
     fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
+        let max_width_slider = cx.new(|_| {
+            SliderState::new()
+                .min(40.)
+                .max(150.)
+                .default_value(MAX_WIDTH_START)
+                .step(2.)
+        });
+        let max_width_subscription =
+            cx.subscribe(&max_width_slider, |this, _, event: &SliderEvent, cx| {
+                if let SliderEvent::Change(value) = event {
+                    this.max_width = value.start();
+                    cx.notify();
+                }
+            });
+
         Self {
             focus_handle: cx.focus_handle(),
             active_tab_ix: 0,
@@ -56,6 +80,10 @@ impl TabsStory {
             dynamic_next_tab_id: 3,
             size: Size::default(),
             menu: false,
+            max_width_enabled: false,
+            max_width: MAX_WIDTH_START,
+            max_width_slider,
+            _max_width_subscription: max_width_subscription,
         }
     }
 
@@ -98,6 +126,9 @@ impl Focusable for TabsStory {
 
 impl Render for TabsStory {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let max_width_enabled = self.max_width_enabled;
+        let max_width = px(self.max_width);
+
         v_flex()
             .w_full()
             .gap_3()
@@ -119,11 +150,30 @@ impl Render for TabsStory {
                 },
             ))
             .child(
+                h_flex()
+                    .gap_3()
+                    .items_center()
+                    .child(
+                        Checkbox::new("max-tab-width")
+                            .label("Max tab width")
+                            .checked(self.max_width_enabled)
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.max_width_enabled = !this.max_width_enabled;
+                                cx.notify();
+                            })),
+                    )
+                    .when(max_width_enabled, |this| {
+                        this.child(Slider::new(&self.max_width_slider).w_32())
+                            .child(format!("{:.0}px", self.max_width))
+                    }),
+            )
+            .child(
                 section("Tabs").w_full().child(
                     TabBar::new("tabs")
                         .w_full()
                         .with_size(self.size)
                         .menu(self.menu)
+                        .when(max_width_enabled, |this| this.max_width(max_width))
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -174,6 +224,7 @@ impl Render for TabsStory {
                         .underline()
                         .with_size(self.size)
                         .menu(self.menu)
+                        .when(max_width_enabled, |this| this.max_width(max_width))
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -195,6 +246,7 @@ impl Render for TabsStory {
                         .pill()
                         .with_size(self.size)
                         .menu(self.menu)
+                        .when(max_width_enabled, |this| this.max_width(max_width))
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -216,6 +268,7 @@ impl Render for TabsStory {
                         .outline()
                         .with_size(self.size)
                         .menu(self.menu)
+                        .when(max_width_enabled, |this| this.max_width(max_width))
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -237,6 +290,7 @@ impl Render for TabsStory {
                         .segmented()
                         .with_size(self.size)
                         .menu(self.menu)
+                        .when(max_width_enabled, |this| this.max_width(max_width))
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -275,6 +329,7 @@ impl Render for TabsStory {
                             .w_full()
                             .segmented()
                             .with_size(self.size)
+                            .when(max_width_enabled, |this| this.max_width(max_width))
                             .selected_index(self.dynamic_active_tab_ix)
                             .on_click(cx.listener(|this, ix: &usize, window, cx| {
                                 this.set_dynamic_active_tab(*ix, window, cx);
@@ -304,6 +359,7 @@ impl Render for TabsStory {
                             .w_full()
                             .segmented()
                             .with_size(self.size)
+                            .when(max_width_enabled, |this| this.max_width(max_width))
                             .selected_index(self.active_tab_ix)
                             .on_click(cx.listener(|this, ix: &usize, window, cx| {
                                 this.set_active_tab(*ix, window, cx);

--- a/crates/story/src/stories/tabs_story.rs
+++ b/crates/story/src/stories/tabs_story.rs
@@ -1,15 +1,13 @@
 use gpui::{
     Action, App, AppContext, Context, Entity, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, ParentElement, Render, SharedString, Styled, Window, prelude::FluentBuilder as _,
-    px,
+    IntoElement, ParentElement, Render, Styled, Window, prelude::FluentBuilder as _, px,
 };
 use serde::Deserialize;
 
 use gpui_component::{
-    ActiveTheme as _, Icon, IconName, IndexPath, Selectable as _, Sizable, Size,
+    ActiveTheme as _, Icon, IconName, Selectable as _, Sizable, Size,
     button::{Button, ButtonGroup, ButtonVariants},
     h_flex,
-    select::{Select, SelectState},
     tab::{Tab, TabBar},
     v_flex,
 };
@@ -19,6 +17,10 @@ use crate::{ChangeStorySize, section, story_toolbar};
 #[derive(Action, Clone, PartialEq, Eq, Deserialize)]
 #[action(namespace = tabs_story, no_json)]
 struct ToggleMoreMenu;
+
+#[derive(Action, Clone, PartialEq, Eq, Deserialize)]
+#[action(namespace = tabs_story, no_json)]
+struct SetMaxTabWidth(usize);
 
 /// The max tab widths to choose from in the story, `None` leaves tabs uncapped.
 const MAX_WIDTHS: [Option<f32>; 5] = [None, Some(60.), Some(90.), Some(120.), Some(160.)];
@@ -31,7 +33,7 @@ pub struct TabsStory {
     dynamic_next_tab_id: usize,
     size: Size,
     menu: bool,
-    max_width_select: Entity<SelectState<Vec<SharedString>>>,
+    max_width_ix: usize,
 }
 
 impl super::Story for TabsStory {
@@ -53,22 +55,7 @@ impl TabsStory {
         cx.new(|cx| Self::new(window, cx))
     }
 
-    fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let max_width_select = cx.new(|cx| {
-            SelectState::new(
-                MAX_WIDTHS
-                    .iter()
-                    .map(|width| match width {
-                        Some(width) => SharedString::from(format!("{width:.0}px")),
-                        None => SharedString::from("Unlimited"),
-                    })
-                    .collect::<Vec<_>>(),
-                Some(IndexPath::default()),
-                window,
-                cx,
-            )
-        });
-
+    fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
         Self {
             focus_handle: cx.focus_handle(),
             active_tab_ix: 0,
@@ -77,7 +64,7 @@ impl TabsStory {
             dynamic_next_tab_id: 3,
             size: Size::default(),
             menu: false,
-            max_width_select,
+            max_width_ix: 0,
         }
     }
 
@@ -120,12 +107,11 @@ impl Focusable for TabsStory {
 
 impl Render for TabsStory {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let max_width = self
-            .max_width_select
-            .read(cx)
-            .selected_index(cx)
-            .and_then(|ix| MAX_WIDTHS.get(ix.row).copied().flatten())
-            .map(px);
+        let max_width = MAX_WIDTHS[self.max_width_ix].map(px);
+        let max_width_label = |width: Option<f32>| match width {
+            Some(width) => format!("{width:.0}px"),
+            None => "Unlimited".into(),
+        };
 
         v_flex()
             .w_full()
@@ -138,21 +124,39 @@ impl Render for TabsStory {
                 this.menu = !this.menu;
                 cx.notify();
             }))
-            .child(story_toolbar(self.size).dropdown_child(
-                Button::new("tabs-options").label("Options"),
-                {
-                    let menu = self.menu;
-                    move |popup, _, _| {
-                        popup.menu_with_check("More menu", menu, Box::new(ToggleMoreMenu))
-                    }
-                },
-            ))
+            .on_action(cx.listener(|this, action: &SetMaxTabWidth, _, cx| {
+                this.max_width_ix = action.0;
+                cx.notify();
+            }))
             .child(
-                h_flex()
-                    .gap_3()
-                    .items_center()
-                    .child("Max tab width")
-                    .child(Select::new(&self.max_width_select).w_32()),
+                story_toolbar(self.size)
+                    .dropdown_child(
+                        Button::new("tabs-max-width").label(format!(
+                            "Max width: {}",
+                            max_width_label(MAX_WIDTHS[self.max_width_ix])
+                        )),
+                        {
+                            let max_width_ix = self.max_width_ix;
+                            move |menu, _, _| {
+                                MAX_WIDTHS
+                                    .iter()
+                                    .enumerate()
+                                    .fold(menu, |menu, (ix, width)| {
+                                        menu.menu_with_check(
+                                            max_width_label(*width),
+                                            ix == max_width_ix,
+                                            Box::new(SetMaxTabWidth(ix)),
+                                        )
+                                    })
+                            }
+                        },
+                    )
+                    .dropdown_child(Button::new("tabs-options").label("Options"), {
+                        let menu = self.menu;
+                        move |popup, _, _| {
+                            popup.menu_with_check("More menu", menu, Box::new(ToggleMoreMenu))
+                        }
+                    }),
             )
             .child(
                 section("Tabs").w_full().child(

--- a/crates/story/src/stories/tabs_story.rs
+++ b/crates/story/src/stories/tabs_story.rs
@@ -1,16 +1,16 @@
 use gpui::{
     Action, App, AppContext, Context, Entity, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, ParentElement, Render, Styled, Subscription, Window,
+    IntoElement, ParentElement, Render, SharedString, Styled, Window,
     prelude::FluentBuilder as _, px,
 };
 use serde::Deserialize;
 
 use gpui_component::{
-    ActiveTheme as _, Icon, IconName, Selectable as _, Sizable, Size,
+    ActiveTheme as _, Icon, IconName, IndexPath, Selectable as _, Sizable, Size,
     button::{Button, ButtonGroup, ButtonVariants},
     checkbox::Checkbox,
     h_flex,
-    slider::{Slider, SliderEvent, SliderState},
+    select::{Select, SelectState},
     tab::{Tab, TabBar},
     v_flex,
 };
@@ -21,7 +21,7 @@ use crate::{ChangeStorySize, section, story_toolbar};
 #[action(namespace = tabs_story, no_json)]
 struct ToggleMoreMenu;
 
-const MAX_WIDTH_START: f32 = 110.;
+const MAX_WIDTHS: [f32; 4] = [60., 90., 120., 160.];
 
 pub struct TabsStory {
     focus_handle: FocusHandle,
@@ -32,9 +32,7 @@ pub struct TabsStory {
     size: Size,
     menu: bool,
     max_width_enabled: bool,
-    max_width: f32,
-    max_width_slider: Entity<SliderState>,
-    _max_width_subscription: Subscription,
+    max_width_select: Entity<SelectState<Vec<SharedString>>>,
 }
 
 impl super::Story for TabsStory {
@@ -56,21 +54,18 @@ impl TabsStory {
         cx.new(|cx| Self::new(window, cx))
     }
 
-    fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
-        let max_width_slider = cx.new(|_| {
-            SliderState::new()
-                .min(40.)
-                .max(150.)
-                .default_value(MAX_WIDTH_START)
-                .step(2.)
+    fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let max_width_select = cx.new(|cx| {
+            SelectState::new(
+                MAX_WIDTHS
+                    .iter()
+                    .map(|width| SharedString::from(format!("{width:.0}px")))
+                    .collect::<Vec<_>>(),
+                Some(IndexPath::new(1)),
+                window,
+                cx,
+            )
         });
-        let max_width_subscription =
-            cx.subscribe(&max_width_slider, |this, _, event: &SliderEvent, cx| {
-                if let SliderEvent::Change(value) = event {
-                    this.max_width = value.start();
-                    cx.notify();
-                }
-            });
 
         Self {
             focus_handle: cx.focus_handle(),
@@ -81,9 +76,7 @@ impl TabsStory {
             size: Size::default(),
             menu: false,
             max_width_enabled: false,
-            max_width: MAX_WIDTH_START,
-            max_width_slider,
-            _max_width_subscription: max_width_subscription,
+            max_width_select,
         }
     }
 
@@ -127,7 +120,12 @@ impl Focusable for TabsStory {
 impl Render for TabsStory {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let max_width_enabled = self.max_width_enabled;
-        let max_width = px(self.max_width);
+        let max_width = px(self
+            .max_width_select
+            .read(cx)
+            .selected_index(cx)
+            .and_then(|ix| MAX_WIDTHS.get(ix.row).copied())
+            .unwrap_or(MAX_WIDTHS[0]));
 
         v_flex()
             .w_full()
@@ -163,8 +161,7 @@ impl Render for TabsStory {
                             })),
                     )
                     .when(max_width_enabled, |this| {
-                        this.child(Slider::new(&self.max_width_slider).w_32())
-                            .child(format!("{:.0}px", self.max_width))
+                        this.child(Select::new(&self.max_width_select).w_24())
                     }),
             )
             .child(

--- a/crates/story/src/stories/tabs_story.rs
+++ b/crates/story/src/stories/tabs_story.rs
@@ -8,7 +8,6 @@ use serde::Deserialize;
 use gpui_component::{
     ActiveTheme as _, Icon, IconName, IndexPath, Selectable as _, Sizable, Size,
     button::{Button, ButtonGroup, ButtonVariants},
-    checkbox::Checkbox,
     h_flex,
     select::{Select, SelectState},
     tab::{Tab, TabBar},
@@ -21,7 +20,8 @@ use crate::{ChangeStorySize, section, story_toolbar};
 #[action(namespace = tabs_story, no_json)]
 struct ToggleMoreMenu;
 
-const MAX_WIDTHS: [f32; 4] = [60., 90., 120., 160.];
+/// The max tab widths to choose from in the story, `None` leaves tabs uncapped.
+const MAX_WIDTHS: [Option<f32>; 5] = [None, Some(60.), Some(90.), Some(120.), Some(160.)];
 
 pub struct TabsStory {
     focus_handle: FocusHandle,
@@ -31,7 +31,6 @@ pub struct TabsStory {
     dynamic_next_tab_id: usize,
     size: Size,
     menu: bool,
-    max_width_enabled: bool,
     max_width_select: Entity<SelectState<Vec<SharedString>>>,
 }
 
@@ -59,9 +58,12 @@ impl TabsStory {
             SelectState::new(
                 MAX_WIDTHS
                     .iter()
-                    .map(|width| SharedString::from(format!("{width:.0}px")))
+                    .map(|width| match width {
+                        Some(width) => SharedString::from(format!("{width:.0}px")),
+                        None => SharedString::from("Unlimited"),
+                    })
                     .collect::<Vec<_>>(),
-                Some(IndexPath::new(1)),
+                Some(IndexPath::default()),
                 window,
                 cx,
             )
@@ -75,7 +77,6 @@ impl TabsStory {
             dynamic_next_tab_id: 3,
             size: Size::default(),
             menu: false,
-            max_width_enabled: false,
             max_width_select,
         }
     }
@@ -119,13 +120,12 @@ impl Focusable for TabsStory {
 
 impl Render for TabsStory {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let max_width_enabled = self.max_width_enabled;
-        let max_width = px(self
+        let max_width = self
             .max_width_select
             .read(cx)
             .selected_index(cx)
-            .and_then(|ix| MAX_WIDTHS.get(ix.row).copied())
-            .unwrap_or(MAX_WIDTHS[0]));
+            .and_then(|ix| MAX_WIDTHS.get(ix.row).copied().flatten())
+            .map(px);
 
         v_flex()
             .w_full()
@@ -148,21 +148,11 @@ impl Render for TabsStory {
                 },
             ))
             .child(
-                h_flex()
-                    .gap_3()
-                    .items_center()
-                    .child(
-                        Checkbox::new("max-tab-width")
-                            .label("Max tab width")
-                            .checked(self.max_width_enabled)
-                            .on_click(cx.listener(|this, _, _, cx| {
-                                this.max_width_enabled = !this.max_width_enabled;
-                                cx.notify();
-                            })),
-                    )
-                    .when(max_width_enabled, |this| {
-                        this.child(Select::new(&self.max_width_select).w_24())
-                    }),
+                h_flex().gap_3().items_center().child(
+                    Select::new(&self.max_width_select)
+                        .w_48()
+                        .title_prefix("Max tab width: "),
+                ),
             )
             .child(
                 section("Tabs").w_full().child(
@@ -170,7 +160,7 @@ impl Render for TabsStory {
                         .w_full()
                         .with_size(self.size)
                         .menu(self.menu)
-                        .when(max_width_enabled, |this| this.max_width(max_width))
+                        .when_some(max_width, |this, max_width| this.max_width(max_width))
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -221,7 +211,7 @@ impl Render for TabsStory {
                         .underline()
                         .with_size(self.size)
                         .menu(self.menu)
-                        .when(max_width_enabled, |this| this.max_width(max_width))
+                        .when_some(max_width, |this, max_width| this.max_width(max_width))
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -243,7 +233,7 @@ impl Render for TabsStory {
                         .pill()
                         .with_size(self.size)
                         .menu(self.menu)
-                        .when(max_width_enabled, |this| this.max_width(max_width))
+                        .when_some(max_width, |this, max_width| this.max_width(max_width))
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -265,7 +255,7 @@ impl Render for TabsStory {
                         .outline()
                         .with_size(self.size)
                         .menu(self.menu)
-                        .when(max_width_enabled, |this| this.max_width(max_width))
+                        .when_some(max_width, |this, max_width| this.max_width(max_width))
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -287,7 +277,7 @@ impl Render for TabsStory {
                         .segmented()
                         .with_size(self.size)
                         .menu(self.menu)
-                        .when(max_width_enabled, |this| this.max_width(max_width))
+                        .when_some(max_width, |this, max_width| this.max_width(max_width))
                         .selected_index(self.active_tab_ix)
                         .on_click(cx.listener(|this, ix: &usize, window, cx| {
                             this.set_active_tab(*ix, window, cx);
@@ -326,7 +316,7 @@ impl Render for TabsStory {
                             .w_full()
                             .segmented()
                             .with_size(self.size)
-                            .when(max_width_enabled, |this| this.max_width(max_width))
+                            .when_some(max_width, |this, max_width| this.max_width(max_width))
                             .selected_index(self.dynamic_active_tab_ix)
                             .on_click(cx.listener(|this, ix: &usize, window, cx| {
                                 this.set_dynamic_active_tab(*ix, window, cx);
@@ -356,7 +346,7 @@ impl Render for TabsStory {
                             .w_full()
                             .segmented()
                             .with_size(self.size)
-                            .when(max_width_enabled, |this| this.max_width(max_width))
+                            .when_some(max_width, |this, max_width| this.max_width(max_width))
                             .selected_index(self.active_tab_ix)
                             .on_click(cx.listener(|this, ix: &usize, window, cx| {
                                 this.set_active_tab(*ix, window, cx);

--- a/crates/story/src/stories/tabs_story.rs
+++ b/crates/story/src/stories/tabs_story.rs
@@ -1,7 +1,7 @@
 use gpui::{
     Action, App, AppContext, Context, Entity, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, ParentElement, Render, SharedString, Styled, Window,
-    prelude::FluentBuilder as _, px,
+    IntoElement, ParentElement, Render, SharedString, Styled, Window, prelude::FluentBuilder as _,
+    px,
 };
 use serde::Deserialize;
 
@@ -148,11 +148,11 @@ impl Render for TabsStory {
                 },
             ))
             .child(
-                h_flex().gap_3().items_center().child(
-                    Select::new(&self.max_width_select)
-                        .w_48()
-                        .title_prefix("Max tab width: "),
-                ),
+                h_flex()
+                    .gap_3()
+                    .items_center()
+                    .child("Max tab width")
+                    .child(Select::new(&self.max_width_select).w_32()),
             )
             .child(
                 section("Tabs").w_full().child(

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -750,13 +750,6 @@ impl RenderOnce for Tab {
             inner_content.into_any_element()
         };
 
-        // Under `max_width` the label is the only part that gives way, so
-        // hold the prefix and suffix (e.g. a close button) at their full size.
-        let fixed = move |element: AnyElement| match max_width {
-            Some(_) => div().flex_shrink_0().child(element).into_any_element(),
-            None => element,
-        };
-
         self.base
             .id(self.ix)
             .selected(self.selected)
@@ -849,9 +842,23 @@ impl RenderOnce for Tab {
                         ),
                 )
             })
-            .when_some(self.prefix, |this, prefix| this.child(fixed(prefix)))
+            // Under `max_width` the label is the only part that gives way, so
+            // hold the prefix and suffix (e.g. a close button) at their full size.
+            .when_some(self.prefix, |this, prefix| {
+                this.child(
+                    div()
+                        .when_some(max_width, |this, _| this.flex_shrink_0())
+                        .child(prefix),
+                )
+            })
             .child(inner_element)
-            .when_some(self.suffix, |this, suffix| this.child(fixed(suffix)))
+            .when_some(self.suffix, |this, suffix| {
+                this.child(
+                    div()
+                        .when_some(max_width, |this, _| this.flex_shrink_0())
+                        .child(suffix),
+                )
+            })
             .when_some(self.on_click.clone(), |this, on_click| {
                 this.on_click(move |event, window, cx| on_click(event, window, cx))
             })

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -411,6 +411,7 @@ pub struct Tab {
     /// tab switch. Used to key the selected tab's text color fade so it
     /// restarts in sync with the indicator slide.
     pub(super) indicator_epoch: u64,
+    pub(super) max_width: Option<Pixels>,
     on_click: Option<Rc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
 }
 
@@ -463,6 +464,7 @@ impl Default for Tab {
             suffix: None,
             variant: TabVariant::default(),
             size: Size::default(),
+            max_width: None,
             on_click: None,
         }
     }
@@ -563,6 +565,12 @@ impl Tab {
     /// Set if the tab bar has a prefix.
     pub(crate) fn tab_bar_prefix(mut self, tab_bar_prefix: bool) -> Self {
         self.tab_bar_prefix = Some(tab_bar_prefix);
+        self
+    }
+
+    /// Set the maximum width of the tab, see [`super::TabBar::max_width`].
+    pub(super) fn max_width(mut self, max_width: Option<Pixels>) -> Self {
+        self.max_width = max_width;
         self
     }
 }
@@ -687,6 +695,8 @@ impl RenderOnce for Tab {
             && self.indicator_epoch > 0;
         let fg_from = self.variant.normal(cx).fg;
         let fg_to = tab_style.fg;
+        // Icon-only tabs are fixed-size and exempt from `max_width`.
+        let max_width = self.max_width.filter(|_| self.icon.is_none());
 
         let inner_content = h_flex()
             .flex_1()
@@ -697,7 +707,12 @@ impl RenderOnce for Tab {
             .justify_center()
             .overflow_hidden()
             .margins(inner_margins)
-            .flex_shrink_0()
+            // Normally the label decides the tab width, so it never shrinks. With
+            // `max_width` it is the one part that gives way.
+            .map(|this| match max_width {
+                Some(_) => this.flex_auto(),
+                None => this.flex_shrink_0(),
+            })
             .map(|this| match self.icon {
                 Some(icon) => this
                     .w(inner_height * 1.25)
@@ -709,9 +724,12 @@ impl RenderOnce for Tab {
                     })),
                 None => this
                     .paddings(inner_paddings)
-                    .map(|this| match self.label {
-                        Some(label) => this.child(label),
-                        None => this,
+                    .map(|this| match (self.label, max_width) {
+                        // Text always takes its natural width, so it needs a box
+                        // that is allowed to shrink to ellipsize inside of.
+                        (Some(label), Some(_)) => this.child(div().truncate().child(label)),
+                        (Some(label), None) => this.child(label),
+                        (None, _) => this,
                     })
                     .children(self.children),
             })
@@ -730,6 +748,13 @@ impl RenderOnce for Tab {
                 .into_any_element()
         } else {
             inner_content.into_any_element()
+        };
+
+        // Under `max_width` the label is the only part that gives way, so
+        // hold the prefix and suffix (e.g. a close button) at their full size.
+        let fixed = move |element: AnyElement| match max_width {
+            Some(_) => div().flex_shrink_0().child(element).into_any_element(),
+            None => element,
         };
 
         self.base
@@ -762,7 +787,12 @@ impl RenderOnce for Tab {
             })
             .relative()
             .flex()
-            .flex_wrap()
+            // Wrapping would move the overflow onto a clipped second line instead
+            // of letting the label shrink, so a capped tab lays out on one line.
+            .map(|this| match max_width {
+                Some(max_width) => this.flex_nowrap().max_w(max_width),
+                None => this.flex_wrap(),
+            })
             .gap_1()
             .items_center()
             .flex_shrink_0()
@@ -819,9 +849,9 @@ impl RenderOnce for Tab {
                         ),
                 )
             })
-            .when_some(self.prefix, |this, prefix| this.child(prefix))
+            .when_some(self.prefix, |this, prefix| this.child(fixed(prefix)))
             .child(inner_element)
-            .when_some(self.suffix, |this, suffix| this.child(suffix))
+            .when_some(self.suffix, |this, suffix| this.child(fixed(suffix)))
             .when_some(self.on_click.clone(), |this, on_click| {
                 this.on_click(move |event, window, cx| on_click(event, window, cx))
             })
@@ -831,18 +861,171 @@ impl RenderOnce for Tab {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tab::TabBar;
+    use gpui::{Context, Render, TestAppContext, VisualTestContext};
+
+    const VARIANTS: [TabVariant; 5] = [
+        TabVariant::Tab,
+        TabVariant::Outline,
+        TabVariant::Pill,
+        TabVariant::Segmented,
+        TabVariant::Underline,
+    ];
+
+    const LONG_LABEL: &str = "Account Settings & Preferences";
+
+    /// One [`TabBar`], optionally capped, holding the tab `build` returns.
+    struct TabBarTest {
+        variant: TabVariant,
+        max_width: Option<Pixels>,
+        build: fn(Tab) -> Tab,
+    }
+
+    impl Render for TabBarTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            TabBar::new("tabs")
+                .with_variant(self.variant)
+                .selected_index(0)
+                .when_some(self.max_width, |this, width| this.max_width(width))
+                .child((self.build)(
+                    Tab::new().debug_selector(|| "tab".to_string()),
+                ))
+        }
+    }
+
+    fn show(
+        cx: &mut TestAppContext,
+        variant: TabVariant,
+        max_width: Option<Pixels>,
+        build: fn(Tab) -> Tab,
+    ) -> &mut VisualTestContext {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| TabBarTest {
+            variant,
+            max_width,
+            build,
+        });
+        cx.run_until_parked();
+        cx
+    }
+
+    /// Outer width of a labelled tab in every variant, capped or not.
+    fn variant_widths(
+        cx: &mut TestAppContext,
+        build: fn(Tab) -> Tab,
+        max_width: Option<Pixels>,
+    ) -> Vec<Pixels> {
+        VARIANTS
+            .into_iter()
+            .map(|variant| {
+                show(cx, variant, max_width, build)
+                    .debug_bounds("tab")
+                    .expect("tab not rendered")
+                    .size
+                    .width
+            })
+            .collect()
+    }
 
     #[gpui::test]
-    fn a11y_label_defaults_to_visible_label(_cx: &mut gpui::TestAppContext) {
+    fn a11y_label_defaults_to_visible_label(_cx: &mut TestAppContext) {
         let tab = Tab::new().label("Account");
 
         assert_eq!(tab.a11y_label(), Some("Account".into()));
     }
 
     #[gpui::test]
-    fn explicit_a11y_label_overrides_visible_label(_cx: &mut gpui::TestAppContext) {
+    fn explicit_a11y_label_overrides_visible_label(_cx: &mut TestAppContext) {
         let tab = Tab::new().label("Acct").aria_label("Account settings");
 
         assert_eq!(tab.a11y_label(), Some("Account settings".into()));
+    }
+
+    #[gpui::test]
+    fn max_width_leaves_short_tabs_untouched(cx: &mut TestAppContext) {
+        // The box the cap wraps the label in must not report a different
+        // intrinsic width than the bare label it replaces.
+        let build: fn(Tab) -> Tab = |tab| tab.label("Go");
+
+        let uncapped = variant_widths(cx, build, None);
+        let capped = variant_widths(cx, build, Some(px(200.)));
+
+        assert_eq!(uncapped, capped, "a tab under the cap must not be resized");
+    }
+
+    #[gpui::test]
+    fn max_width_caps_long_tabs(cx: &mut TestAppContext) {
+        let build: fn(Tab) -> Tab = |tab| tab.label(LONG_LABEL);
+
+        let uncapped = variant_widths(cx, build, None);
+        let capped = variant_widths(cx, build, Some(px(120.)));
+
+        for (variant, (uncapped, capped)) in
+            VARIANTS.into_iter().zip(uncapped.into_iter().zip(capped))
+        {
+            assert!(
+                uncapped > px(120.),
+                "{variant:?} is not long enough to exercise the cap ({uncapped:?})"
+            );
+            assert!(
+                capped <= px(120.),
+                "{variant:?} width {capped:?} exceeds max_width"
+            );
+        }
+    }
+
+    #[gpui::test]
+    fn max_width_keeps_prefix_and_suffix_intact(cx: &mut TestAppContext) {
+        let cx = show(cx, TabVariant::Segmented, Some(px(140.)), |tab| {
+            tab.prefix(Icon::new(IconName::BookOpen))
+                .label(LONG_LABEL)
+                .suffix(div().size(px(16.)).debug_selector(|| "suffix".to_string()))
+        });
+
+        let tab = cx.debug_bounds("tab").expect("tab not rendered");
+        let suffix = cx.debug_bounds("suffix").expect("suffix not rendered");
+
+        assert!(tab.size.width <= px(140.));
+        assert_eq!(
+            suffix.size.width,
+            px(16.),
+            "the label should absorb the truncation, not the suffix"
+        );
+        assert!(
+            suffix.right() <= tab.right(),
+            "suffix must stay within the tab"
+        );
+        // A wrapping tab pushes the suffix onto a second line, which the fixed
+        // tab height then clips: it keeps its size and stays inside the tab,
+        // but lands back at the left edge instead of after the label.
+        assert!(
+            suffix.left() > tab.center().x,
+            "suffix must follow the label, not wrap below it"
+        );
+    }
+
+    /// Icon-only tabs are sized to a square by construction, so the cap has to
+    /// leave them alone however narrow it is.
+    #[gpui::test]
+    fn max_width_exempts_icon_only_tabs(cx: &mut TestAppContext) {
+        let build: fn(Tab) -> Tab = |tab| tab.icon(Icon::new(IconName::BookOpen));
+        let width = |cx: &mut TestAppContext, max_width| {
+            show(cx, TabVariant::Tab, max_width, build)
+                .debug_bounds("tab")
+                .expect("tab not rendered")
+                .size
+                .width
+        };
+
+        let uncapped = width(cx, None);
+        assert!(
+            uncapped > px(16.),
+            "the cap has to be narrower than the icon tab to be meaningful"
+        );
+        assert_eq!(
+            width(cx, Some(px(16.))),
+            uncapped,
+            "an icon-only tab must ignore max_width"
+        );
     }
 }

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -51,6 +51,7 @@ pub struct TabBar {
     variant: TabVariant,
     size: Size,
     menu: bool,
+    max_width: Option<Pixels>,
     on_click: Option<Rc<dyn Fn(&usize, &mut Window, &mut App) + 'static>>,
 }
 
@@ -72,6 +73,7 @@ impl TabBar {
             selected_index: None,
             on_click: None,
             menu: false,
+            max_width: None,
         }
     }
 
@@ -108,6 +110,14 @@ impl TabBar {
     /// Set whether to show the menu button when tabs overflow, default is false.
     pub fn menu(mut self, menu: bool) -> Self {
         self.menu = menu;
+        self
+    }
+
+    /// Set the maximum width of each tab. Labels longer than this width are
+    /// truncated with an ellipsis. Does not apply to icon-only tabs. The
+    /// overflow menu still shows the full label.
+    pub fn max_width(mut self, width: impl Into<Pixels>) -> Self {
+        self.max_width = Some(width.into());
         self
     }
 
@@ -417,6 +427,7 @@ impl RenderOnce for TabBar {
         let on_click = self.on_click.clone();
         let tabs = self.base;
         let mut rendered_tabs = Vec::with_capacity(self.children.len());
+        let max_width = self.max_width;
 
         for (ix, child) in self.children.into_iter().enumerate() {
             item_metas.push((child.label.clone(), child.icon.clone(), child.disabled));
@@ -424,6 +435,7 @@ impl RenderOnce for TabBar {
             let mut tab = child
                 .ix(ix)
                 .tab_bar_prefix(tab_bar_prefix)
+                .max_width(max_width)
                 .with_variant(self.variant)
                 .with_size(self.size);
             tab.indicator_active = has_indicator;

--- a/website/docs/components/tabs.md
+++ b/website/docs/components/tabs.md
@@ -194,6 +194,32 @@ TabBar::new("tabs-with-menu")
     .child(Tab::new().label("Settings"))
 ```
 
+### Maximum Tab Width
+
+Use `max_width` to cap the width of each tab. For tabs created with `.label()`, text longer than the limit is truncated with an ellipsis automatically. Icon-only tabs (`.icon()`) are not affected. Prefix and suffix elements (e.g. a close button) are never truncated — the label yields space first. The *more* menu (when enabled) still shows the full label text.
+
+Tabs built from custom children (via `.child()`) are only given the width limit; add `truncate()` yourself to the part that should shrink.
+
+```rust
+use gpui::{div, px};
+
+TabBar::new("tabs-with-max-width")
+    .max_width(px(100.))
+    .menu(true)
+    .selected_index(0)
+    .child(Tab::new().label("Account Settings & Preferences"))
+    .child(Tab::new().label("Documents & Files"))
+    .child(Tab::new().label("Appearance & Themes"))
+    .child(
+        Tab::new().child(
+            h_flex()
+                .gap_1()
+                .child(Icon::new(IconName::Bot))
+                .child(div().truncate().child("Custom Child Tab")),
+        ),
+    )
+```
+
 ### Scrollable Tabs
 
 ```rust
@@ -247,6 +273,7 @@ TabBar::new("custom-tabs")
 | `last_empty_space(element)` | Custom element for empty space at the end          |
 | `track_scroll(handle)`      | Enable scrolling with a scroll handle              |
 | `with_menu(bool)`           | Enable dropdown menu for tab selection             |
+| `max_width(width)`      | Set maximum width of each tab; truncates           |
 
 ### TabBar Variants
 

--- a/website/zh-CN/docs/components/tabs.md
+++ b/website/zh-CN/docs/components/tabs.md
@@ -187,6 +187,32 @@ TabBar::new("tabs-with-menu")
     .child(Tab::new().label("Settings"))
 ```
 
+### 最大标签宽度
+
+使用 `max_width` 限制每个标签的最大宽度。通过 `.label()` 创建的标签会自动截断超长文本并显示省略号。仅图标的标签（`.icon()`）不受此限制。前缀和后缀元素（例如关闭按钮）不会被截断——标签文本会优先让出空间。如果启用了溢出菜单，下拉项仍会显示完整标签文本。
+
+通过 `.child()` 传入自定义内容的标签只会应用宽度限制，需要自行在应当收缩的部分调用 `truncate()`。
+
+```rust
+use gpui::{div, px};
+
+TabBar::new("tabs-with-max-width")
+    .max_width(px(100.))
+    .menu(true)
+    .selected_index(0)
+    .child(Tab::new().label("Account Settings & Preferences"))
+    .child(Tab::new().label("Documents & Files"))
+    .child(Tab::new().label("Appearance & Themes"))
+    .child(
+        Tab::new().child(
+            h_flex()
+                .gap_1()
+                .child(Icon::new(IconName::Bot))
+                .child(div().truncate().child("Custom Child Tab")),
+        ),
+    )
+```
+
 ## API 参考
 
 ### TabBar
@@ -203,6 +229,7 @@ TabBar::new("tabs-with-menu")
 | `last_empty_space(element)` | 自定义尾部空白区域 |
 | `track_scroll(handle)` | 配合滚动句柄启用可滚动标签栏 |
 | `with_menu(bool)` | 启用下拉菜单选择 |
+| `max_width(width)` | 设置每个标签的最大宽度；超长文本自动截断 |
 
 ### TabBar 变体
 


### PR DESCRIPTION
## Description

Adds `max_tab_width` to `TabBar`, capping each tab rendered width. Labels set via `.label()` truncate with an ellipsis past the limit; icon-only tabs are unaffected. Tabs with `.child()` content get the width constraint but handle their own truncation. The overflow menu still shows full labels.

## Screenshot

| Before | After |
| ------ | ----- |
| <img width="1712" height="1242" alt="image" src="https://github.com/user-attachments/assets/d7a1d81e-7aed-4889-835b-9c7b980a571f" /> | <img width="1712" height="1242" alt="image" src="https://github.com/user-attachments/assets/82630c9d-54e6-4253-bb90-4f4cd489eb42" /> |

## How to Test

1. `cargo run` and open the Tabs story.
2. Toggle “Max tab width”; the enabled value is fixed at 110px.
3. Confirm long labels truncate, short labels keep their intrinsic width, custom children remain constrained, and the overflow menu shows full text.
4. Run `cargo test -p gpui-component tab::`.

## Checklist

- [x] Read CONTRIBUTING and followed the guidelines.
- [x] Reviewed changes, confirmed AI-generated code is accurate.
- [x] Passed Story compilation and tab tests.
- [ ] Tested macOS, Windows, Linux performance (if platform-specific).