### PR TITLE
menu: Fix render nested submenus with increasing paint priority

### DIFF
--- a/crates/story/src/stories/menu_story.rs
+++ b/crates/story/src/stories/menu_story.rs
@@ -214,9 +214,30 @@ impl Render for MenuStory {
                                         .link("Zed", "https://zed.dev")
                                     })
                                     .separator()
-                                    .submenu("Other Links", window, cx, |menu, _, _| {
+                                    .submenu("Other Links", window, cx, |menu, window, cx| {
                                         menu.link("Crates", "https://crates.io")
                                             .link("Rust Docs", "https://docs.rs")
+                                            .separator()
+                                            .submenu(
+                                                "Nested",
+                                                window,
+                                                cx,
+                                                |menu, window, cx| {
+                                                    menu.link("Docs.rs", "https://docs.rs")
+                                                        .separator()
+                                                        .submenu(
+                                                            "Deeper",
+                                                            window,
+                                                            cx,
+                                                            |menu, _, _| {
+                                                                menu.link(
+                                                                    "GPUI",
+                                                                    "https://gpui.rs",
+                                                                )
+                                                            },
+                                                        )
+                                                },
+                                            )
                                     })
                             }),
                     )
@@ -258,11 +279,56 @@ impl Render for MenuStory {
                                             Box::new(ToggleCheck),
                                         )
                                         .separator()
-                                        .submenu("Settings", window, cx, move |menu, _, _| {
+                                        // Deeply nested submenus to verify each
+                                        // level paints above the shallower ones and
+                                        // the background content behind them.
+                                        .submenu("Settings", window, cx, move |menu, window, cx| {
                                             menu.menu("Info 0", Box::new(Info(0)))
                                                 .separator()
                                                 .menu("Item 1", Box::new(Info(1)))
                                                 .menu("Item 2", Box::new(Info(2)))
+                                                .separator()
+                                                .submenu(
+                                                    "More",
+                                                    window,
+                                                    cx,
+                                                    move |menu, window, cx| {
+                                                        menu.menu("More Item 1", Box::new(Info(1)))
+                                                            .menu("More Item 2", Box::new(Info(2)))
+                                                            .separator()
+                                                            .submenu(
+                                                                "Even More",
+                                                                window,
+                                                                cx,
+                                                                move |menu, window, cx| {
+                                                                    menu.menu(
+                                                                        "Deep Item 1",
+                                                                        Box::new(Info(1)),
+                                                                    )
+                                                                    .menu(
+                                                                        "Deep Item 2",
+                                                                        Box::new(Info(2)),
+                                                                    )
+                                                                    .separator()
+                                                                    .submenu(
+                                                                        "Deepest",
+                                                                        window,
+                                                                        cx,
+                                                                        move |menu, _, _| {
+                                                                            menu.menu(
+                                                                                "Leaf 1",
+                                                                                Box::new(Info(1)),
+                                                                            )
+                                                                            .menu(
+                                                                                "Leaf 2",
+                                                                                Box::new(Info(2)),
+                                                                            )
+                                                                        },
+                                                                    )
+                                                                },
+                                                            )
+                                                    },
+                                                )
                                         })
                                         .separator()
                                         .menu("Search All", Box::new(SearchAll))

--- a/crates/ui/src/menu/popup_menu.rs
+++ b/crates/ui/src/menu/popup_menu.rs
@@ -8,7 +8,7 @@ use gpui::{
     Action, Anchor, AnyElement, App, AppContext, Bounds, Context, DismissEvent, Edges, Entity,
     EventEmitter, FocusHandle, Focusable, InteractiveElement, IntoElement, KeyBinding,
     ParentElement, Pixels, Render, Role, ScrollHandle, SharedString, StatefulInteractiveElement,
-    Styled, WeakEntity, Window, anchored, div, prelude::FluentBuilder, px, rems,
+    Styled, WeakEntity, Window, anchored, deferred, div, prelude::FluentBuilder, px, rems,
 };
 use gpui::{ClickEvent, Half, MouseDownEvent, OwnedMenuItem, Point, Subscription};
 
@@ -300,6 +300,13 @@ pub struct PopupMenu {
     // This will update on render
     submenu_anchor: (Anchor, Pixels),
 
+    /// Paint priority for this menu layer. The top-level menu starts at 1 and
+    /// each nested submenu increments it, so deeper levels are always drawn on
+    /// top of shallower ones. This fixes background content (e.g. the
+    /// underlying list) bleeding through multi-level submenus, which happens
+    /// when nested `anchored` popovers share the same paint order.
+    priority: usize,
+
     _subscriptions: Vec<Subscription>,
 }
 
@@ -321,6 +328,7 @@ impl PopupMenu {
             external_link_icon: true,
             size: Size::default(),
             submenu_anchor: (Anchor::TopLeft, Pixels::ZERO),
+            priority: 1,
             _subscriptions: vec![],
         }
     }
@@ -648,8 +656,10 @@ impl PopupMenu {
     ) -> Self {
         let submenu = PopupMenu::build(window, cx, f);
         let parent_menu = cx.entity().downgrade();
+        let parent_priority = self.priority;
         submenu.update(cx, |view, _| {
             view.parent_menu = Some(parent_menu);
+            view.priority = parent_priority + 1;
         });
 
         self.menu_items.push(
@@ -1257,18 +1267,21 @@ impl PopupMenu {
                         let (anchor, left) = self.submenu_anchor;
                         let is_bottom_pos =
                             matches!(anchor, Anchor::BottomLeft | Anchor::BottomRight);
-                        anchored()
-                            .anchor(anchor)
-                            .child(
-                                div()
-                                    .id("submenu")
-                                    .occlude()
-                                    .when(is_bottom_pos, |this| this.bottom_0())
-                                    .when(!is_bottom_pos, |this| this.top_neg_1())
-                                    .left(left)
-                                    .child(menu.clone()),
-                            )
-                            .snap_to_window_with_margin(Edges::all(EDGE_PADDING))
+                        deferred(
+                            anchored()
+                                .anchor(anchor)
+                                .child(
+                                    div()
+                                        .id("submenu")
+                                        .occlude()
+                                        .when(is_bottom_pos, |this| this.bottom_0())
+                                        .when(!is_bottom_pos, |this| this.top_neg_1())
+                                        .left(left)
+                                        .child(menu.clone()),
+                                )
+                                .snap_to_window_with_margin(Edges::all(EDGE_PADDING)),
+                        )
+                        .with_priority(self.priority + 1)
                     })
                 }),
         }
@@ -1314,7 +1327,7 @@ impl Render for PopupMenu {
             radius: cx.theme().radius.min(px(8.)),
         };
 
-        v_flex()
+        let menu = v_flex()
             .id("popup-menu")
             .role(Role::Menu)
             .key_context(CONTEXT)
@@ -1356,7 +1369,9 @@ impl Render for PopupMenu {
             .when(self.scrollable, |this| {
                 // TODO: When the menu is limited by `overflow_y_scroll`, the sub-menu will cannot be displayed.
                 this.vertical_scrollbar(&self.scroll_handle)
-            })
+            });
+
+        deferred(menu).with_priority(self.priority)
     }
 }
 

--- a/crates/ui/src/menu/popup_menu.rs
+++ b/crates/ui/src/menu/popup_menu.rs
@@ -305,6 +305,12 @@ pub struct PopupMenu {
     /// top of shallower ones. This fixes background content (e.g. the
     /// underlying list) bleeding through multi-level submenus, which happens
     /// when nested `anchored` popovers share the same paint order.
+    ///
+    /// The top-level menu relies on its container (e.g. `Popover`,
+    /// `ContextMenu`) to `deferred`-draw it, and each submenu is deferred once
+    /// in `render_item` with `priority + 1`. Keeping a single deferred layer
+    /// per level matters because GPUI caps nested deferred depth (see
+    /// `prepaint_deferred_draws`).
     priority: usize,
 
     _subscriptions: Vec<Subscription>,
@@ -1327,7 +1333,7 @@ impl Render for PopupMenu {
             radius: cx.theme().radius.min(px(8.)),
         };
 
-        let menu = v_flex()
+        v_flex()
             .id("popup-menu")
             .role(Role::Menu)
             .key_context(CONTEXT)
@@ -1369,9 +1375,7 @@ impl Render for PopupMenu {
             .when(self.scrollable, |this| {
                 // TODO: When the menu is limited by `overflow_y_scroll`, the sub-menu will cannot be displayed.
                 this.vertical_scrollbar(&self.scroll_handle)
-            });
-
-        deferred(menu).with_priority(self.priority)
+            })
     }
 }
 


### PR DESCRIPTION
## Description

Nested submenus were drawn as plain `anchored()` elements that shared the same paint order, so shallow-level content (e.g. the underlying list behind the menu) could show through deeper submenu panels.

This change gives each `PopupMenu` a `priority: usize` field (top-level = 1) that increments by one for every nested level, and wraps both the menu body and its submenu panels in `deferred().with_priority(priority)`:

- `PopupMenu::render()` now returns `deferred(menu).with_priority(self.priority)` so the top-level menu is itself a deferred layer.
- Each submenu panel is rendered with `.with_priority(self.priority + 1)`.
- `submenu_with_icon` propagates `priority = parent_priority + 1` down the tree.

The result is a strict paint order: top-level (1) < submenu (2) < sub-submenu (3) < ..., so deeper menus always paint on top of shallower ones.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [<img width="500" height="163" alt="before" src="https://github.com/user-attachments/assets/0da6b4c2-b26c-4cb8-9e19-ef77e362bcd0" />] | [<img width="500" height="163" alt="after" src="https://github.com/user-attachments/assets/55f3dd49-f51d-4fb8-8d23-7b658f08bf43" />] |

## How to Test

1. To reproduce the multi-level paint-order bug, a menu with **at least two    nested submenu levels** is required (e.g. a right-click tree where each item opens a submenu that itself contains another submenu). Expand several levels so deeper panels overlap shallower ones.
2. **Before:** shallow-level text was visible through deeper submenu panels (see the *Before* screenshot).
3. **After:** deeper submenus always paint on top, so background text no longer bleeds through (see the *After* screenshot).

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
