### PR TITLE
color_picker: add ColorPickerState::set_open and is_open

### DIFF
--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -249,6 +249,23 @@ impl ColorPickerState {
         self.value
     }
 
+    /// Open or close the picker popover.
+    ///
+    /// Lets a caller drive the picker from something other than its own
+    /// trigger, e.g. selecting a color by clicking the element it paints.
+    pub fn set_open(&mut self, open: bool, cx: &mut Context<Self>) {
+        if self.open == open {
+            return;
+        }
+        self.open = open;
+        cx.notify();
+    }
+
+    /// Whether the picker popover is open.
+    pub fn is_open(&self) -> bool {
+        self.open
+    }
+
     fn on_confirm(&mut self, _: &Confirm, _: &mut Window, cx: &mut Context<Self>) {
         self.open = !self.open;
         cx.notify();


### PR DESCRIPTION
## Summary

`ColorPickerState.open` is private with no setter, so a picker can only be opened by clicking its own trigger button. Callers that want to drive it from elsewhere have no supported way to do so.

My use case: a terminal theme editor that renders a preview of coloured output and lets you click any run of text to edit the colour that painted it. The click knows which palette slot it needs, but cannot open that slot's picker. The workaround is to select the slot and make the user click the swatch a second time.

## Changes

Adds `set_open`/`is_open` to `ColorPickerState`, alongside the existing `set_value`/`value` pair:

```rust
picker.update(cx, |state, cx| state.set_open(true, cx));
```

`set_open` returns early when the state is unchanged, so it will not spuriously notify.

17 lines added, no existing behaviour changed, no public API removed or altered.

## Testing

Typechecked against a real consumer rather than in isolation: pinned my application to this branch and built it, exercising both `set_open(true)` and `set_open(false)` from mouse handlers.

I could not get `cargo check` to run on this repo standalone — `pathfinder_simd` fails with `cannot find function simd_fmin` on my toolchain (Rust nightly 1.97, macOS aarch64), which reproduces on an unmodified checkout and so looks unrelated to this change.

## AI disclosure

Per CLAUDE.md's request to mark AI-generated portions: this patch was written with Claude Code. The diff is small and I have reviewed it.