### PR TITLE
text_view: Parse large full replacements off the UI thread

### DIFF
--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -25,6 +25,9 @@ use crate::{
 const CONTEXT: &'static str = "TextView";
 // Keep coalescing bounded so sustained streams still render intermediate updates.
 const MAX_COALESCED_UPDATES_PER_PARSE: usize = 64;
+// Preserve exact first-layout height for small documents while bounding the
+// amount of source parsed synchronously on the UI thread.
+const MAX_SYNC_FULL_REPLACE_BYTES: usize = 4 * 1024;
 
 pub(crate) fn init(cx: &mut App) {
     cx.bind_keys(vec![
@@ -88,8 +91,8 @@ pub struct TextViewState {
     pub(super) selection_adapter: TextViewSelectionAdapter,
 
     pub(super) parsed_content: ParsedContent,
-    /// Content format (markdown / html), used to parse synchronously on the
-    /// main thread for full-replace updates.
+    /// Content format (markdown / html), used for bounded synchronous parsing
+    /// of small full-replace updates.
     format: TextViewFormat,
     text: String,
     revision: usize,
@@ -332,28 +335,25 @@ impl TextViewState {
         if !append {
             self.selection_revision = self.selection_revision.wrapping_add(1);
         }
+        let parse_synchronously = !append && text.len() <= MAX_SYNC_FULL_REPLACE_BYTES;
         let update_options = UpdateOptions {
             revision: self.revision,
             append,
             mode: if append {
                 ParseMode::Compatible
-            } else {
+            } else if parse_synchronously {
                 ParseMode::BaselineAck
+            } else {
+                ParseMode::Replace
             },
             pending_text: text.to_string(),
             markdown_extensions: self.markdown_extensions.clone(),
         };
 
-        // Full-replace updates (initial content / `set_text`) parse
-        // synchronously on the main thread so the first layout already has the
-        // correct height. Otherwise parsing finishes later on a background task
-        // and the first layout sees an empty `parsed_content` (~0 height); when
-        // this `TextView` is an item inside an outer `list` with `measure_all`,
-        // off-screen items get measured at that empty height and the total
-        // content height keeps growing as items scroll into view; the scrollbar
-        // thumb jitters. Streaming appends stay async to avoid re-parsing the
-        // whole document on every chunk.
-        if !append {
+        // Keep small full replacements synchronous so their first layout has
+        // the exact content height. Larger replacements use the existing
+        // background parser, bounding synchronous parser input on the UI thread.
+        if parse_synchronously {
             match parse_content(self.format, ParsedContent::default(), &update_options) {
                 Ok(content) => {
                     self.parsed_content = content;
@@ -692,7 +692,9 @@ impl UpdateOptions {
         if next.append {
             self.pending_text.push_str(&next.pending_text);
             self.revision = next.revision;
-            self.mode = ParseMode::Compatible;
+            if self.mode != ParseMode::Replace {
+                self.mode = ParseMode::Compatible;
+            }
         } else {
             *self = next;
         }
@@ -710,6 +712,7 @@ struct ParsedUpdate {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ParseMode {
     BaselineAck,
+    Replace,
     Compatible,
 }
 
@@ -773,6 +776,78 @@ mod tests {
     use super::*;
     use crate::text::MarkdownNode;
     use gpui::TestAppContext;
+
+    #[gpui::test]
+    fn small_full_replace_parses_before_background_executor_runs(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let markdown = "# ready";
+        let state = cx.update(|cx| cx.new(|cx| TextViewState::markdown(markdown, cx)));
+
+        state.read_with(cx, |state, _| {
+            assert_eq!(state.source().as_str(), markdown);
+            assert_eq!(state.parsed_content.document.blocks.len(), 1);
+        });
+    }
+
+    #[gpui::test]
+    fn large_markdown_and_html_full_replacements_wait_for_background_executor(
+        cx: &mut TestAppContext,
+    ) {
+        cx.update(crate::init);
+        let markdown = "# x\n\n".repeat(MAX_SYNC_FULL_REPLACE_BYTES / 5 + 1);
+        let html = format!("<p>{}</p>", "x".repeat(MAX_SYNC_FULL_REPLACE_BYTES + 1));
+        assert!(markdown.len() > MAX_SYNC_FULL_REPLACE_BYTES);
+        assert!(html.len() > MAX_SYNC_FULL_REPLACE_BYTES);
+
+        let (markdown_state, html_state) = cx.update(|cx| {
+            (
+                cx.new(|cx| TextViewState::markdown(&markdown, cx)),
+                cx.new(|cx| TextViewState::html(&html, cx)),
+            )
+        });
+
+        markdown_state.read_with(cx, |state, _| {
+            assert_eq!(state.text.as_str(), markdown.as_str());
+            assert!(state.source().as_str().is_empty());
+            assert!(state.parsed_content.document.blocks.is_empty());
+        });
+        html_state.read_with(cx, |state, _| {
+            assert_eq!(state.text.as_str(), html.as_str());
+            assert!(state.source().as_str().is_empty());
+            assert!(state.parsed_content.document.blocks.is_empty());
+        });
+
+        cx.run_until_parked();
+
+        markdown_state.read_with(cx, |state, _| {
+            assert_eq!(state.source().as_str(), markdown.as_str());
+            assert!(!state.parsed_content.document.blocks.is_empty());
+        });
+        html_state.read_with(cx, |state, _| {
+            assert_eq!(state.source().as_str(), html.as_str());
+            assert!(!state.parsed_content.document.blocks.is_empty());
+        });
+    }
+
+    #[gpui::test]
+    fn async_full_replace_then_push_str_preserves_complete_source(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let state = cx.update(|cx| cx.new(|cx| TextViewState::markdown("old", cx)));
+        cx.run_until_parked();
+
+        let replacement = "x".repeat(MAX_SYNC_FULL_REPLACE_BYTES + 1);
+        let expected = format!("{replacement} tail");
+        state.update(cx, |state, cx| {
+            state.set_text(&replacement, cx);
+            state.push_str(" tail", cx);
+        });
+        cx.run_until_parked();
+
+        state.read_with(cx, |state, _| {
+            assert_eq!(state.text.as_str(), expected.as_str());
+            assert_eq!(state.source().as_str(), expected.as_str());
+        });
+    }
 
     #[gpui::test]
     fn set_text_then_push_str_appends_to_replaced_content(cx: &mut TestAppContext) {
@@ -850,6 +925,30 @@ mod tests {
         assert_eq!(options.revision, 3);
         assert_eq!(options.pending_text, "new text");
         assert!(!options.append);
+    }
+
+    #[test]
+    fn append_merged_into_async_replace_remains_a_replacement() {
+        let mut options = UpdateOptions {
+            revision: 1,
+            pending_text: "new".to_string(),
+            append: false,
+            mode: ParseMode::Replace,
+            markdown_extensions: Arc::default(),
+        };
+
+        options.merge(UpdateOptions {
+            revision: 2,
+            pending_text: " text".to_string(),
+            append: true,
+            mode: ParseMode::Compatible,
+            markdown_extensions: Arc::default(),
+        });
+
+        assert_eq!(options.revision, 2);
+        assert_eq!(options.pending_text, "new text");
+        assert!(!options.append);
+        assert_eq!(options.mode, ParseMode::Replace);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Full-replacement `TextView` updates currently parse their entire Markdown or
HTML source synchronously so the first layout has an exact content height. That
preserves the scrollbar fix from #2470 for ordinary content, but it also lets a
large document block the UI thread before construction or layout can return.

This change keeps the synchronous path for full replacements at or below a
private 4 KiB byte budget. Larger replacements are sent through the existing
background parser and applied through its existing revision checks. Documents
are still parsed and displayed in full; this is a scheduling boundary, not a
document-length limit.

The 4 KiB value is an intentionally conservative private scheduling budget. It
preserves the exact first-layout path for short TextViews and can be adjusted
later without changing the public API.

The background mode distinguishes an unapplied `Replace` from `BaselineAck` and
append-compatible work. If an append is coalesced into an async replacement,
the merged update remains a replacement so selection and layout state are reset
when the result is applied.

This is intentionally limited to `crates/ui/src/text/state.rs`. It does not
change LSP popovers, `render_markdown`, parser behavior, public APIs,
coalescing limits, or task cancellation.

Closes #2740

## Before and after

The same 250 KB Markdown document (`"# x\n\n"` repeated 50,000 times) was
tested on `main` at `da4f93696dc2` and on this branch. The durations are
machine-specific and are reported as reproduction evidence, not test
thresholds.

| Metric | Before | After |
| --- | --- | --- |
| UI-thread construction latency | `3410ms`, including the full parse | `<1ms` (reported as `0ms`); no large parser work before returning |
| State when construction returns | `source_len=250000`, `blocks=50000` | `source_len=0`, `blocks=0`, with the complete input already stored in `text` |
| First parse completion | During construction | `3573ms` later on the background executor, then `source_len=250000`, `blocks=50000` |
| Observed test runtime | `7.13s` | `3.61s` |

The `3410ms` and `3573ms` samples are individual debug-build parser runs, not
evidence of a parser throughput regression. Their 163ms difference is normal
run-to-run variation. Before this change, a large full replacement is parsed
once synchronously and then queued as `BaselineAck`, causing the background
worker to parse the same document again to establish its baseline. The old
test's `7.13s` total is consistent with those two parses. After this change, the
large replacement is parsed once by the background worker and the test finishes
in `3.61s`; most importantly, construction returns without waiting for the full
parse.

For documents at or below 4 KiB, behavior is unchanged: parsing completes
synchronously so the first layout retains its exact height. For larger
documents, the previous or empty parsed document may be shown initially,
followed by a relayout when the current background result is applied.

## Security impact

This bounds the amount of attacker-controlled Markdown or HTML parsed
synchronously on the UI thread. In particular, large LSP hover, completion, or
diagnostic contents can no longer make `TextView` synchronously parse the whole
document during popover construction.

This change does not attempt to bound total background CPU use from a sustained
stream of large documents; that is separate from the synchronous UI-thread
availability issue addressed here.

## Tests added

- Small full replacements are parsed before the background executor runs.
- Over-budget Markdown and HTML wait for the background executor and are then
  applied in full.
- An async full replacement immediately followed by `push_str` preserves the
  complete source.
- `Replace` followed by a coalesced append remains `ParseMode::Replace`.

The existing `outer_list_content_total_stable_while_scrolling` regression test
is unchanged and continues to pass.

## Breaking changes

None. The byte budget and `ParseMode` are private implementation details.

## How to test

Passed locally on Arch Linux x86_64 with Rust 1.96.1:

```shell
cargo fmt --all -- --check
cargo test --locked -p gpui-component text::state::tests -- --nocapture
cargo test --locked -p gpui-component \
  text::text_view::tests::outer_list_content_total_stable_while_scrolling \
  -- --nocapture
cargo test --locked -p gpui-component
cargo check --locked -p gpui-component --no-default-features
cargo clippy --locked -p gpui-component --no-deps -- --deny warnings
cargo test --locked --all
```

The repository-wide CI Clippy command currently stops on two pre-existing
`clippy::nonminimal_bool` diagnostics in `crates/base/src/calendar.rs:131` with
Rust 1.96.1. This PR does not modify that file; Clippy for the changed
`gpui-component` crate passes with warnings denied.

## AI assistance

AI assisted with root-cause analysis, patch drafting, test design, and PR
wording. I reviewed the final diff and ran all commands listed above locally.

## Checklist

- [x] I have read the `CONTRIBUTING.md` document and followed the guidelines.
- [x] Reviewed the AI-assisted changes and confirmed the described behavior.
- [x] Added deterministic tests for the changed scheduling and merge semantics.
- [x] Kept the change to one problem and one production source file.
- [ ] Ran the Story app manually; not run because this change is covered by
  state and layout regression tests.
- [ ] Tested macOS and Windows; Linux validation passed and the platform matrix
  remains for GitHub Actions.
