### PR TITLE
fps: Add per-process GPU usage to the HUD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,10 @@ version = "0.1.0"
 dependencies = [
  "gpui",
  "instant",
+ "objc2-core-foundation",
+ "objc2-io-kit",
  "sysinfo 0.37.2",
+ "windows 0.58.0",
 ]
 
 [[package]]

--- a/crates/fps/Cargo.toml
+++ b/crates/fps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpui-fps"
-description = "Realtime FPS, frame time, CPU and memory HUD for GPUI applications."
+description = "Realtime FPS, frame time, CPU, GPU and memory HUD for GPUI applications."
 keywords = ["fps", "gpui", "hud", "performance", "profiling"]
 license = "Apache-2.0"
 documentation = "https://docs.rs/gpui-fps"
@@ -20,6 +20,26 @@ instant.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 sysinfo = "0.37"
+
+# This process' GPU usage is read straight from the platform, since `sysinfo`
+# does not report it. Each backend is the counter the platform's own activity
+# monitor attributes per process with, so no vendor SDK or elevated privilege
+# is involved.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-core-foundation = { version = "0.3", default-features = false, features = [
+    "std",
+    "CFArray",
+    "CFDictionary",
+    "CFNumber",
+    "CFString",
+] }
+objc2-io-kit = { version = "0.3", default-features = false, features = [
+    "std",
+    "libc",
+] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { workspace = true, features = ["Win32_System_Performance"] }
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/fps/README.md
+++ b/crates/fps/README.md
@@ -1,21 +1,24 @@
 # gpui-fps
 
 A realtime performance HUD for [GPUI](https://gpui.rs) applications: frames per
-second, frame time, dropped frame rate, and this process' CPU and memory usage.
+second, frame time, dropped frame rate, and this process' GPU, CPU and memory
+usage.
 
 ```
 ┌──────────────────────────┐
 │  ﹋﹏  118 FPS  ﹋︿﹏﹋   │  ← the trace runs behind the headline
 │ FRAME             8.4 ms │
 │ DROP                0.0% │
+│ GPU                31.0% │
 │ CPU 12.4%      MEM 84 MB │
 └──────────────────────────┘
 ```
 
 Frame data comes from GPUI's own frame trace (`gpui::FrameTimingCollector`), so
 the numbers are what the framework actually spent in `Window::draw` rather than
-an estimate measured from the outside. The trace is colored against the frame
-budget — green within budget, amber up to twice the budget, red beyond.
+an estimate measured from the outside. Both the trace and the `FRAME` reading
+are colored against the frame budget — green within budget, amber up to twice
+the budget, red beyond.
 
 It does not depend on `gpui-component`, so it works in any GPUI application.
 
@@ -107,7 +110,7 @@ let monitor = cx.new(|cx| {
         .capacity(240)                                  // frames kept in the trace (default 120)
         .frame_budget(Duration::from_micros(6_944))     // 144Hz (default is 60Hz)
         .continuous(true)                               // default true, see below
-        .show_resources(true)                           // CPU / memory row (default true)
+        .show_resources(true)                           // GPU, CPU and memory (default true)
         .resource_interval(Duration::from_millis(500))  // default 500ms
 });
 
@@ -153,9 +156,32 @@ window redraws for its own reasons, and reads zero while the window is idle.
 - Frame tracing is a global switch that clears its buffer when disabled, so
   monitors reference count it and never turn it off while another monitor — or
   the host application's own profiling — still needs it.
+- The headline is graded on the frame *rate* and `FRAME` on the frame *time*,
+  which is why they can disagree. A window that is idle draws a handful of
+  frames a second, so the headline goes red while every one of those frames was
+  in fact drawn well inside the budget — `FRAME` staying green is what says the
+  application is fine and simply has nothing to redraw.
 - CPU and memory are sampled with `sysinfo` on a background thread; the values
   are for this process, and CPU is normalized so 100 means every logical core is
   saturated. Resource sampling is unavailable on the web.
+- `GPU` is this process' own share, like the CPU beside it and unlike a
+  device-wide reading, which would move for work the application cannot act on.
+  Each platform is read where it attributes GPU time per process, and none of
+  them needs a vendor SDK or elevated privileges:
+  - **macOS** — `accumulatedGPUTime` on the accelerator clients this process
+    owns in the IO registry, which is what Activity Monitor's GPU column shows.
+  - **Windows** — the `GPU Engine` PDH counters, filtered to this process' own
+    instances, which is what Task Manager's GPU column shows.
+  - **Linux** — `drm-engine-*` in `/proc/self/fdinfo`, which is what `nvtop` and
+    `intel_gpu_top` read.
+
+  Where several engines can run at once — Windows and Linux — the reading is the
+  busiest engine type rather than their sum, so it stays inside 100% while the
+  GPU still has headroom.
+- **The GPU row is left out entirely where no per-process counter is reachable**,
+  rather than reading a flat zero: the web, an Intel Mac, whose accelerator
+  clients do not publish `AppUsage`, and a Linux driver such as nvidia's
+  proprietary one, which keeps its accounting in NVML instead of `fdinfo`.
 
 ## Example
 

--- a/crates/fps/src/gpu.rs
+++ b/crates/fps/src/gpu.rs
@@ -1,0 +1,67 @@
+//! How much of the GPU this process is using, on the platforms that attribute
+//! it per process without a vendor SDK or elevated privileges.
+//!
+//! It is this process' share and not the device's, to match the CPU and memory
+//! beside it: a HUD that counted the compositor and every other window would
+//! move for reasons the application cannot act on. Each platform reaches it
+//! differently, and where none of them can, the reading is simply absent.
+
+#[cfg_attr(target_os = "macos", path = "gpu/macos.rs")]
+#[cfg_attr(target_os = "windows", path = "gpu/windows.rs")]
+#[cfg_attr(target_os = "linux", path = "gpu/linux.rs")]
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "windows", target_os = "linux")),
+    path = "gpu/unsupported.rs"
+)]
+mod platform;
+
+/// Samples GPU utilization.
+///
+/// Every backend answers the same two questions, and both can say no. [`new`]
+/// returns `None` when this platform has no counter to read at all, or when the
+/// machine does not publish one — a driver on Linux that omits it, a GPU with
+/// no statistics — and the HUD then leaves the row out entirely rather than
+/// showing an empty slot. [`sample`] returns `None` for a reading that is only
+/// momentarily unavailable, leaving the last one on screen.
+///
+/// [`new`]: GpuProbe::new
+/// [`sample`]: GpuProbe::sample
+pub(crate) struct GpuProbe(platform::Probe);
+
+impl GpuProbe {
+    pub(crate) fn new() -> Option<Self> {
+        platform::Probe::new().map(Self)
+    }
+
+    /// The share of the wall clock the GPU spent on this process since the
+    /// previous call, in `0..=100`.
+    ///
+    /// The clamp matters: several engines can run at once, so the raw sum of
+    /// their busy time can pass the wall clock it is divided by.
+    pub(crate) fn sample(&mut self) -> Option<f32> {
+        self.0.sample().map(|percent| percent.clamp(0., 100.))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Whether a probe exists at all is the platform's answer, and a headless
+    /// CI machine may well have no accelerator to report; what must hold is
+    /// that a probe which does exist reports a percentage rather than a raw
+    /// counter or a fraction.
+    #[test]
+    fn a_reading_is_a_percentage() {
+        let Some(mut probe) = GpuProbe::new() else {
+            return;
+        };
+
+        if let Some(percent) = probe.sample() {
+            assert!(
+                (0. ..=100.).contains(&percent),
+                "{percent} is not a percentage"
+            );
+        }
+    }
+}

--- a/crates/fps/src/gpu/linux.rs
+++ b/crates/fps/src/gpu/linux.rs
@@ -1,0 +1,149 @@
+//! Reads this process' DRM `fdinfo` counters, the per-client GPU accounting the
+//! kernel publishes and tools like `nvtop` and `intel_gpu_top` read. amdgpu,
+//! i915, xe and panfrost fill it in; a driver that does not — nvidia's
+//! proprietary one, which keeps its accounting in NVML — leaves the HUD without
+//! a GPU reading rather than showing a flat zero.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+};
+
+use instant::Instant;
+
+/// One file per open file descriptor of this process, a few of which are the
+/// DRM devices it renders through.
+const FDINFO: &str = "/proc/self/fdinfo";
+
+/// Identifies the DRM client a descriptor belongs to. Several descriptors can
+/// share one, each reporting the same running totals, so the counters are
+/// gathered per client and not per descriptor.
+const CLIENT_ID: &str = "drm-client-id:";
+
+/// Prefixes the busy time of one engine, as in `drm-engine-render: 12345 ns`.
+/// `drm-engine-capacity-*` shares the prefix but counts engines rather than
+/// nanoseconds, which is what the unit is checked for.
+const ENGINE: &str = "drm-engine-";
+const NANOSECONDS: &str = "ns";
+
+pub(super) struct Probe {
+    /// The previous totals per engine and when they were taken, once a first
+    /// reading has landed. Engine time only accumulates, so a percentage is
+    /// the time gained between two readings over the wall clock between them.
+    last: Option<(HashMap<String, u64>, Instant)>,
+}
+
+impl Probe {
+    pub(super) fn new() -> Option<Self> {
+        // Only a check that the counters are reachable at all. Whether this
+        // process' driver publishes them is settled by the first sample, since
+        // at startup it may not yet have opened the device.
+        fs::metadata(FDINFO).ok()?;
+        Some(Self { last: None })
+    }
+
+    /// The busiest engine, not the sum over all of them: render, copy and video
+    /// decode run concurrently, so adding them up can pass 100% while the GPU
+    /// still has headroom.
+    pub(super) fn sample(&mut self) -> Option<f32> {
+        let busy = engine_nanoseconds()?;
+        let now = Instant::now();
+        let (previous, at) = self.last.replace((busy.clone(), now))?;
+
+        let elapsed = now.duration_since(at).as_nanos();
+        if elapsed == 0 {
+            return None;
+        }
+
+        busy.iter()
+            .map(|(engine, used)| {
+                // Saturating because an engine the process stops using can be
+                // dropped and re-reported from zero.
+                let gained = used.saturating_sub(previous.get(engine).copied().unwrap_or(0));
+                gained as f64 / elapsed as f64 * 100.
+            })
+            .reduce(f64::max)
+            .map(|busy| busy as f32)
+    }
+}
+
+/// Nanoseconds each engine has spent on this process, or `None` when its driver
+/// reports no engine at all.
+fn engine_nanoseconds() -> Option<HashMap<String, u64>> {
+    let mut totals: HashMap<String, u64> = HashMap::new();
+    // Descriptors of one client repeat that client's totals, so only the first
+    // of them is counted.
+    let mut counted = HashSet::new();
+    let mut found = false;
+
+    for entry in fs::read_dir(FDINFO).ok()?.flatten() {
+        // A descriptor can close between listing the directory and reading it,
+        // and most of them are not DRM devices to begin with.
+        let Ok(fdinfo) = fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        let Some(client) = client_id(&fdinfo) else {
+            continue;
+        };
+        if !counted.insert(client) {
+            continue;
+        }
+
+        for (engine, used) in engines(&fdinfo) {
+            found = true;
+            *totals.entry(engine).or_default() += used;
+        }
+    }
+
+    found.then_some(totals)
+}
+
+fn client_id(fdinfo: &str) -> Option<u64> {
+    fdinfo
+        .lines()
+        .find_map(|line| line.strip_prefix(CLIENT_ID))
+        .and_then(|id| id.trim().parse().ok())
+}
+
+fn engines(fdinfo: &str) -> impl Iterator<Item = (String, u64)> {
+    fdinfo.lines().filter_map(|line| {
+        let (engine, busy) = line.strip_prefix(ENGINE)?.split_once(':')?;
+        let nanoseconds = busy.trim().strip_suffix(NANOSECONDS)?;
+        Some((engine.to_owned(), nanoseconds.trim().parse().ok()?))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FDINFO_SAMPLE: &str = "\
+pos:	0
+drm-driver:	amdgpu
+drm-client-id:	42
+drm-engine-gfx:	1200000 ns
+drm-engine-compute:	0 ns
+drm-engine-capacity-gfx:	2
+drm-memory-vram:	131072 KiB
+";
+
+    #[test]
+    fn reads_engine_times_and_skips_the_capacity_counters() {
+        assert_eq!(client_id(FDINFO_SAMPLE), Some(42));
+
+        let mut engines: Vec<_> = engines(FDINFO_SAMPLE).collect();
+        engines.sort();
+        assert_eq!(
+            engines,
+            vec![("compute".to_owned(), 0), ("gfx".to_owned(), 1_200_000)],
+            "`drm-engine-capacity-gfx` counts engines, not nanoseconds"
+        );
+    }
+
+    #[test]
+    fn a_descriptor_without_drm_counters_reports_nothing() {
+        let fdinfo = "pos:\t0\nflags:\t02\nmnt_id:\t24\n";
+        assert_eq!(client_id(fdinfo), None);
+        assert_eq!(engines(fdinfo).count(), 0);
+    }
+}

--- a/crates/fps/src/gpu/macos.rs
+++ b/crates/fps/src/gpu/macos.rs
@@ -1,0 +1,225 @@
+//! Sums the `accumulatedGPUTime` this process' accelerator clients report in
+//! the IO registry, and turns the time gained between two readings into a share
+//! of the wall clock that passed. This is the counter behind Activity Monitor's
+//! per-process GPU column, and reading it needs no privileges — unlike
+//! `powermetrics`.
+//!
+//! The accelerator's own `PerformanceStatistics` would be easier to read but is
+//! device wide, so it would report the compositor and every other application
+//! as this one's load. `task_info`'s `task_gpu_utilisation` is per process but
+//! is left at zero on Apple silicon, so it is no use either.
+
+use std::{ffi::c_char, ptr::NonNull};
+
+use instant::Instant;
+use objc2_core_foundation::{CFArray, CFDictionary, CFNumber, CFNumberType, CFRetained, CFString};
+use objc2_io_kit::{
+    IOIteratorNext, IOObjectRelease, IORegistryEntryCreateCFProperties,
+    IORegistryEntryGetChildIterator, IOServiceGetMatchingServices, IOServiceMatching,
+    io_iterator_t, io_registry_entry_t, kIOMainPortDefault, kIOReturnSuccess,
+};
+
+/// The registry plane the accelerator's clients hang off, as the fixed size
+/// buffer the call takes.
+fn service_plane() -> [c_char; 128] {
+    let mut plane = [0; 128];
+    for (slot, byte) in plane.iter_mut().zip(b"IOService") {
+        *slot = *byte as c_char;
+    }
+    plane
+}
+
+pub(super) struct Probe {
+    /// How the registry tags the clients this process opened, as in
+    /// `pid 4242, my_app`. Only the pid is matched — the name is truncated to
+    /// 16 characters, so it is not reliable to compare against.
+    creator: String,
+    /// The previous total and when it was taken, once a first reading has
+    /// landed. GPU time only accumulates, so a percentage is the time gained
+    /// between two readings over the wall clock between them.
+    last: Option<(u64, Instant)>,
+}
+
+impl Probe {
+    pub(super) fn new() -> Option<Self> {
+        // Doubles as the support check: no accelerator, no readings, and the
+        // HUD leaves the row out rather than showing a flat zero.
+        let accelerators = accelerators();
+        if accelerators.is_empty() {
+            return None;
+        }
+        release(accelerators);
+
+        Some(Self {
+            creator: format!("pid {},", std::process::id()),
+            last: None,
+        })
+    }
+
+    pub(super) fn sample(&mut self) -> Option<f32> {
+        // `None` while this process has yet to open an accelerator client,
+        // which is true for the moment between startup and the first frame.
+        let used = accumulated_nanoseconds(&self.creator)?;
+        let now = Instant::now();
+        let (previous, at) = self.last.replace((used, now))?;
+
+        let elapsed = now.duration_since(at).as_nanos();
+        if elapsed == 0 {
+            return None;
+        }
+        // Saturating because a client that goes away takes its share of the
+        // total with it, which can walk the sum backwards.
+        let busy = used.saturating_sub(previous);
+        Some((busy as f64 / elapsed as f64 * 100.) as f32)
+    }
+}
+
+/// Nanoseconds every accelerator has spent on this process, or `None` when it
+/// owns no client that reports them.
+fn accumulated_nanoseconds(creator: &str) -> Option<u64> {
+    // Passed by mutable pointer because the call's parameter type says so, not
+    // because it writes to the name.
+    let mut plane = service_plane();
+    let mut total = None;
+
+    for accelerator in accelerators() {
+        let mut clients: io_iterator_t = 0;
+        // SAFETY: the accelerator is live until it is released below, and both
+        // the plane name and the iterator are valid out parameters.
+        let result =
+            unsafe { IORegistryEntryGetChildIterator(accelerator, &mut plane, &mut clients) };
+        IOObjectRelease(accelerator);
+        if result != kIOReturnSuccess || clients == 0 {
+            continue;
+        }
+
+        loop {
+            let client = IOIteratorNext(clients);
+            if client == 0 {
+                break;
+            }
+            if let Some(used) = client_nanoseconds(client, creator) {
+                *total.get_or_insert(0) += used;
+            }
+            IOObjectRelease(client);
+        }
+        IOObjectRelease(clients);
+    }
+
+    total
+}
+
+/// What one client has accumulated, or `None` if it belongs to another process
+/// or reports no usage at all — the latter being how an Intel Mac, which does
+/// not publish `AppUsage`, ends up with no GPU row.
+fn client_nanoseconds(client: io_registry_entry_t, creator: &str) -> Option<u64> {
+    let properties = properties(client)?;
+
+    // SAFETY: the registry publishes the creator as a string and the usage as
+    // an array of dictionaries, and every borrow below is taken out of
+    // `properties` while it is alive.
+    unsafe {
+        let owner: NonNull<CFString> = value(&properties, "IOUserClientCreator")?;
+        if !owner.as_ref().to_string().starts_with(creator) {
+            return None;
+        }
+
+        let usage: NonNull<CFArray> = value(&properties, "AppUsage")?;
+        let usage = usage.as_ref();
+        let total = (0..usage.count())
+            .filter_map(|index| {
+                let queue = NonNull::new(usage.value_at_index(index).cast_mut())?;
+                let queue: NonNull<CFDictionary> = queue.cast();
+                let time: NonNull<CFNumber> = value(queue.as_ref(), "accumulatedGPUTime")?;
+                integer(time.as_ref())
+            })
+            .sum();
+        Some(total)
+    }
+}
+
+/// Every registered accelerator. The caller owns what is returned and must
+/// release it.
+fn accelerators() -> Vec<io_registry_entry_t> {
+    let mut accelerators = Vec::new();
+
+    // SAFETY: the class name is a valid C string, and the dictionary it returns
+    // is handed straight to the lookup below, which takes over its reference.
+    let Some(matching) = (unsafe { IOServiceMatching(c"IOAccelerator".as_ptr()) }) else {
+        return accelerators;
+    };
+
+    let mut iterator: io_iterator_t = 0;
+    // SAFETY: the matching dictionary is a plain `CFDictionary` under its
+    // mutable type, and the iterator is a live out parameter.
+    let result = unsafe {
+        IOServiceGetMatchingServices(
+            kIOMainPortDefault,
+            Some(CFRetained::cast_unchecked::<CFDictionary>(matching)),
+            &mut iterator,
+        )
+    };
+    if result != kIOReturnSuccess || iterator == 0 {
+        return accelerators;
+    }
+
+    loop {
+        let accelerator = IOIteratorNext(iterator);
+        if accelerator == 0 {
+            break;
+        }
+        accelerators.push(accelerator);
+    }
+
+    IOObjectRelease(iterator);
+    accelerators
+}
+
+fn release(entries: Vec<io_registry_entry_t>) {
+    for entry in entries {
+        IOObjectRelease(entry);
+    }
+}
+
+/// A snapshot of one registry entry's properties.
+fn properties(entry: io_registry_entry_t) -> Option<CFRetained<CFDictionary>> {
+    let mut properties = std::ptr::null_mut();
+    // SAFETY: the entry is live for the length of the call, and `properties` is
+    // a valid out parameter.
+    let result = unsafe { IORegistryEntryCreateCFProperties(entry, &mut properties, None, 0) };
+    if result != kIOReturnSuccess {
+        return None;
+    }
+
+    // SAFETY: on success the call returns a snapshot owned by this task, which
+    // the `CFRetained` releases when it is dropped.
+    let properties = unsafe { CFRetained::from_raw(NonNull::new(properties)?) };
+    // SAFETY: a mutable dictionary is a dictionary; nothing here mutates it.
+    Some(unsafe { CFRetained::cast_unchecked::<CFDictionary>(properties) })
+}
+
+/// Borrows `key` out of `dictionary`.
+///
+/// # Safety
+///
+/// The value stored under `key` must be a `T`, and the borrow must not outlive
+/// `dictionary`.
+unsafe fn value<T>(dictionary: &CFDictionary, key: &str) -> Option<NonNull<T>> {
+    let key = CFString::from_str(key);
+    // SAFETY: the key is alive for the length of the lookup, and the value is
+    // borrowed from the dictionary rather than owned.
+    let value = unsafe { dictionary.value(std::ptr::from_ref(&*key).cast()) };
+    NonNull::new(value.cast_mut().cast::<T>())
+}
+
+fn integer(number: &CFNumber) -> Option<u64> {
+    let mut value: i64 = 0;
+    // SAFETY: the destination matches the type asked for.
+    let read = unsafe {
+        number.value(
+            CFNumberType::SInt64Type,
+            std::ptr::from_mut(&mut value).cast(),
+        )
+    };
+    read.then(|| value.max(0) as u64)
+}

--- a/crates/fps/src/gpu/unsupported.rs
+++ b/crates/fps/src/gpu/unsupported.rs
@@ -1,0 +1,14 @@
+//! Platforms with no GPU counter reachable from an ordinary process.
+//! Construction always fails, so the HUD leaves the reading out.
+
+pub(super) struct Probe;
+
+impl Probe {
+    pub(super) fn new() -> Option<Self> {
+        None
+    }
+
+    pub(super) fn sample(&mut self) -> Option<f32> {
+        None
+    }
+}

--- a/crates/fps/src/gpu/windows.rs
+++ b/crates/fps/src/gpu/windows.rs
@@ -36,7 +36,9 @@ pub(super) struct Probe {
     /// Reused across samples so a reading twice a second does not reallocate.
     /// PDH writes the instance name strings into the tail of the same buffer,
     /// past the array it fills, so this is sized in bytes rather than items.
-    buffer: Vec<PDH_FMT_COUNTERVALUE_ITEM_W>,
+    /// 64-bit words provide the array's required alignment without retaining
+    /// the non-`Send` pointers in `PDH_FMT_COUNTERVALUE_ITEM_W` between calls.
+    buffer: Vec<u64>,
 }
 
 impl Probe {
@@ -112,9 +114,15 @@ impl Probe {
             return None;
         }
 
-        let items = (bytes as usize).div_ceil(size_of::<PDH_FMT_COUNTERVALUE_ITEM_W>());
+        const {
+            assert!(
+                align_of::<u64>() >= align_of::<PDH_FMT_COUNTERVALUE_ITEM_W>(),
+                "PDH buffer word must satisfy the counter item alignment"
+            );
+        }
+        let words = (bytes as usize).div_ceil(size_of::<u64>());
         self.buffer.clear();
-        self.buffer.resize_with(items, Default::default);
+        self.buffer.resize(words, 0);
 
         // SAFETY: the buffer holds at least the `bytes` PDH asked for, so it
         // can write both the array and the names that follow it.
@@ -124,14 +132,22 @@ impl Probe {
                 PDH_FMT_DOUBLE,
                 &mut bytes,
                 &mut count,
-                Some(self.buffer.as_mut_ptr()),
+                Some(self.buffer.as_mut_ptr().cast()),
             )
         };
         if read != PDH_SUCCESS {
             return None;
         }
 
-        let readings = self.buffer[..count as usize]
+        // SAFETY: PDH filled `count` items at the start of this suitably
+        // aligned buffer, and `read` above succeeded.
+        let items = unsafe {
+            std::slice::from_raw_parts(
+                self.buffer.as_ptr().cast::<PDH_FMT_COUNTERVALUE_ITEM_W>(),
+                count as usize,
+            )
+        };
+        let readings = items
             .iter()
             .filter_map(|item| {
                 // SAFETY: PDH filled `count` items, each naming its instance in

--- a/crates/fps/src/gpu/windows.rs
+++ b/crates/fps/src/gpu/windows.rs
@@ -1,0 +1,154 @@
+//! Reads the `GPU Engine` performance counters through PDH, the same source
+//! Task Manager's GPU column uses. Each instance is named after the process
+//! that owns it, so this process' share falls out of the instance names. No
+//! driver SDK is involved, so it works the same on any vendor's adapter.
+
+use std::collections::HashMap;
+
+use windows::{
+    Win32::System::Performance::{
+        PDH_FMT_COUNTERVALUE_ITEM_W, PDH_FMT_DOUBLE, PDH_MORE_DATA, PdhAddEnglishCounterW,
+        PdhCloseQuery, PdhCollectQueryData, PdhGetFormattedCounterArrayW, PdhOpenQueryW,
+    },
+    core::w,
+};
+
+/// Every engine of every adapter, for every process; this process' instances
+/// are picked out of the result. PDH has no way to ask for one process' engines
+/// up front, since the instance name is not known until it is enumerated. The
+/// counter is registered under its English name so it resolves on a localized
+/// Windows too.
+const COUNTER_PATH: windows::core::PCWSTR = w!("\\GPU Engine(*)\\Utilization Percentage");
+
+/// PDH's own success code, which is `ERROR_SUCCESS` rather than a PDH status.
+const PDH_SUCCESS: u32 = 0;
+
+/// Marks the end of an instance name's engine type, as in
+/// `pid_4242_luid_0x00000000_0x0000BEEF_phys_0_eng_1_engtype_3D`. The same name
+/// opens with the owning process, which is what [`Probe::owner`] matches.
+const ENGINE_TYPE: &str = "engtype_";
+
+pub(super) struct Probe {
+    query: isize,
+    counter: isize,
+    /// How every instance name this process owns opens, as in `pid_4242_`.
+    owner: String,
+    /// Reused across samples so a reading twice a second does not reallocate.
+    /// PDH writes the instance name strings into the tail of the same buffer,
+    /// past the array it fills, so this is sized in bytes rather than items.
+    buffer: Vec<PDH_FMT_COUNTERVALUE_ITEM_W>,
+}
+
+impl Probe {
+    pub(super) fn new() -> Option<Self> {
+        let mut query = 0;
+        // SAFETY: both handles are live out parameters, and the counter path is
+        // a static wide string.
+        let opened = unsafe { PdhOpenQueryW(None, 0, &mut query) };
+        if opened != PDH_SUCCESS {
+            return None;
+        }
+
+        let mut probe = Self {
+            query,
+            counter: 0,
+            owner: format!("pid_{}_", std::process::id()),
+            buffer: Vec::new(),
+        };
+        // SAFETY: the query was just opened, and is closed by `Drop` either way.
+        let added =
+            unsafe { PdhAddEnglishCounterW(probe.query, COUNTER_PATH, 0, &mut probe.counter) };
+        if added != PDH_SUCCESS {
+            return None;
+        }
+
+        // Utilization is a rate, so it is the difference between two
+        // collections. This one is the baseline the first sample subtracts
+        // from; without it that sample would read zero.
+        //
+        // SAFETY: the query is live.
+        unsafe { PdhCollectQueryData(probe.query) };
+        Some(probe)
+    }
+
+    /// The busiest engine *type* this process is using, not the sum over all of
+    /// them: 3D, Copy and Video Decode run concurrently, so adding them up can
+    /// pass 100% while the adapter still has headroom. Within one type this
+    /// process' engines are summed, since it can be on several at once.
+    pub(super) fn sample(&mut self) -> Option<f32> {
+        // SAFETY: the query is live until `Drop`.
+        if unsafe { PdhCollectQueryData(self.query) } != PDH_SUCCESS {
+            return None;
+        }
+
+        let mut busy: HashMap<String, f64> = HashMap::new();
+        for (instance, utilization) in self.collect()? {
+            if !instance.starts_with(&self.owner) {
+                continue;
+            }
+            let Some((_, engine)) = instance.rsplit_once(ENGINE_TYPE) else {
+                continue;
+            };
+            *busy.entry(engine.to_owned()).or_default() += utilization;
+        }
+
+        // Zero rather than nothing once the process has engines at all: it is
+        // idle, not unmeasurable. Nothing means the adapter reported none.
+        busy.into_values().reduce(f64::max).map(|busy| busy as f32)
+    }
+
+    /// Reads the formatted counter array, growing the buffer to whatever PDH
+    /// asks for. The first call reports the size it needs, which changes as
+    /// processes come and go.
+    fn collect(&mut self) -> Option<Vec<(String, f64)>> {
+        let mut bytes = 0;
+        let mut count = 0;
+        // SAFETY: passing no buffer asks for the required size, which PDH
+        // reports through `PDH_MORE_DATA`.
+        let sized = unsafe {
+            PdhGetFormattedCounterArrayW(self.counter, PDH_FMT_DOUBLE, &mut bytes, &mut count, None)
+        };
+        if sized != PDH_MORE_DATA || bytes == 0 {
+            return None;
+        }
+
+        let items = (bytes as usize).div_ceil(size_of::<PDH_FMT_COUNTERVALUE_ITEM_W>());
+        self.buffer.clear();
+        self.buffer.resize_with(items, Default::default);
+
+        // SAFETY: the buffer holds at least the `bytes` PDH asked for, so it
+        // can write both the array and the names that follow it.
+        let read = unsafe {
+            PdhGetFormattedCounterArrayW(
+                self.counter,
+                PDH_FMT_DOUBLE,
+                &mut bytes,
+                &mut count,
+                Some(self.buffer.as_mut_ptr()),
+            )
+        };
+        if read != PDH_SUCCESS {
+            return None;
+        }
+
+        let readings = self.buffer[..count as usize]
+            .iter()
+            .filter_map(|item| {
+                // SAFETY: PDH filled `count` items, each naming its instance in
+                // the buffer's tail, and the value is the `f64` the double
+                // format asked for.
+                let instance = unsafe { item.szName.to_string() }.ok()?;
+                Some((instance, unsafe { item.FmtValue.Anonymous.doubleValue }))
+            })
+            .collect();
+        Some(readings)
+    }
+}
+
+impl Drop for Probe {
+    fn drop(&mut self) {
+        // SAFETY: the query was opened in `new` and is closed exactly once.
+        // Closing it also releases the counter added to it.
+        unsafe { PdhCloseQuery(self.query) };
+    }
+}

--- a/crates/fps/src/lib.rs
+++ b/crates/fps/src/lib.rs
@@ -1,5 +1,5 @@
 //! A realtime performance HUD for GPUI applications: frames per second, a
-//! rolling frame time chart, and this process' CPU and memory usage.
+//! rolling frame time chart, and this process' GPU, CPU and memory usage.
 //!
 //! Frame data comes from GPUI's own frame trace
 //! ([`gpui::FrameTimingCollector`]), so the numbers are what the framework
@@ -30,6 +30,8 @@
 //! This crate depends only on `gpui`, so it can be used from any GPUI
 //! application.
 
+#[cfg(not(target_family = "wasm"))]
+mod gpu;
 mod monitor;
 mod overlay;
 mod sampler;

--- a/crates/fps/src/monitor.rs
+++ b/crates/fps/src/monitor.rs
@@ -76,7 +76,7 @@ const DEFAULT_FONT: &str = "Consolas";
 const DEFAULT_FONT: &str = "monospace";
 
 /// A realtime performance HUD: frames per second, a rolling frame time chart,
-/// and this process' CPU and memory usage.
+/// and this process' GPU, CPU and memory usage.
 ///
 /// This is a view rather than a stateless component on purpose. Driving
 /// continuous redraws goes through [`Window::request_animation_frame`], which
@@ -165,14 +165,17 @@ impl FpsMonitor {
         self
     }
 
-    /// Whether to sample and show this process' CPU and memory usage.
-    /// Defaults to `true`, and is always off on the web.
+    /// Whether to sample and show CPU, memory and GPU usage. Defaults to
+    /// `true`, and is always off on the web.
+    ///
+    /// The GPU reading is left out on its own where the platform publishes no
+    /// counter for it, so turning this on does not guarantee three readings.
     pub fn show_resources(mut self, show_resources: bool) -> Self {
         self.show_resources = show_resources;
         self
     }
 
-    /// How often CPU and memory are resampled. Defaults to 500ms, and is
+    /// How often CPU, memory and GPU are resampled. Defaults to 500ms, and is
     /// clamped up to the shortest interval that yields a meaningful CPU delta.
     pub fn resource_interval(mut self, interval: Duration) -> Self {
         self.resource_interval = interval;
@@ -437,7 +440,12 @@ impl Render for FpsMonitor {
                         .child(reading(
                             "FRAME",
                             format!("{frame_millis:.1} ms"),
-                            style.foreground,
+                            // Graded against the budget, not against the frame
+                            // rate. An idle window draws a handful of frames a
+                            // second, so the headline goes red while every one
+                            // of those frames was in fact drawn well inside the
+                            // budget; this row is what says so.
+                            style.level_color(frame_millis / 1000., budget.as_secs_f32()),
                             style,
                         ))
                         .child(reading(
@@ -446,6 +454,17 @@ impl Render for FpsMonitor {
                             style.level_color(if dropped > 0. { 1. } else { 0. }, 0.5),
                             style,
                         ))
+                        .when_some(
+                            resources.and_then(|resources| resources.gpu_percent),
+                            |this, gpu| {
+                                this.child(reading(
+                                    "GPU",
+                                    format!("{gpu:.1}%"),
+                                    style.foreground,
+                                    style,
+                                ))
+                            },
+                        )
                         .when_some(resources, |this, resources| {
                             this.child(
                                 // CPU and memory share a row: both are coarse

--- a/crates/fps/src/sampler.rs
+++ b/crates/fps/src/sampler.rs
@@ -153,7 +153,7 @@ impl FrameSampler {
     }
 }
 
-/// A sample of this process' resource usage.
+/// A sample of the resource usage shown beside the frame numbers.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub(crate) struct ResourceSample {
     /// CPU used by this process, normalized so that 100 means every logical
@@ -162,9 +162,12 @@ pub(crate) struct ResourceSample {
     pub cpu_percent: f32,
     /// Resident memory of this process, in bytes.
     pub memory_bytes: u64,
+    /// The share of the GPU this process is using, and `None` on a platform
+    /// that does not attribute GPU time per process. See [`crate::gpu`].
+    pub gpu_percent: Option<f32>,
 }
 
-/// Samples this process' CPU and memory usage.
+/// Samples this process' CPU, memory and GPU usage.
 ///
 /// Refreshing is a blocking syscall walk, so this must be driven from a
 /// background thread rather than from the render loop.
@@ -173,6 +176,9 @@ pub(crate) struct ResourceProbe {
     system: sysinfo::System,
     pid: sysinfo::Pid,
     cores: f32,
+    /// `None` when this platform publishes no per-process GPU counter, which
+    /// the HUD shows by leaving the reading out rather than at a flat zero.
+    gpu: Option<crate::gpu::GpuProbe>,
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -189,6 +195,7 @@ impl ResourceProbe {
             system: sysinfo::System::new(),
             pid,
             cores,
+            gpu: crate::gpu::GpuProbe::new(),
         };
         // The first refresh only establishes the baseline; `cpu_usage` is a
         // delta against the previous refresh and reads zero until then.
@@ -198,10 +205,15 @@ impl ResourceProbe {
 
     pub(crate) fn sample(&mut self) -> Option<ResourceSample> {
         self.refresh();
+        // Sampled before the process is borrowed out of `self.system`, so the
+        // two borrows of `self` do not overlap.
+        let gpu_percent = self.gpu.as_mut().and_then(crate::gpu::GpuProbe::sample);
+
         let process = self.system.process(self.pid)?;
         Some(ResourceSample {
             cpu_percent: (process.cpu_usage() / self.cores).min(100.),
             memory_bytes: process.memory(),
+            gpu_percent,
         })
     }
 


### PR DESCRIPTION
## Summary

The HUD reported CPU and memory but nothing about the GPU, which for a renderer is the half that usually explains a slow frame. This adds a `GPU` reading for **this process' own share**, and colors the `FRAME` value against the frame budget.

```
┌──────────────────────────┐
│  ﹋﹏  118 FPS  ﹋︿﹏﹋   │
│ FRAME             8.4 ms │  ← now colored against the budget
│ DROP                0.0% │
│ GPU                31.0% │  ← new
│ CPU 12.4%      MEM 84 MB │
└──────────────────────────┘
```

### Why per-process, not device-wide

A device-wide number moves for the compositor and every other window, none of which the application can act on. It also would not sit sensibly next to the per-process CPU beside it.

Each platform is read where it already attributes GPU time per process. No vendor SDK, no elevated privilege:

| Platform | Source | Same counter as |
|---|---|---|
| macOS | `accumulatedGPUTime` on this process' accelerator clients in the IO registry | Activity Monitor's GPU column |
| Windows | `\GPU Engine(*)\Utilization Percentage`, filtered to `pid_<self>_` instances | Task Manager's GPU column |
| Linux | `drm-engine-*` in `/proc/self/fdinfo` | `nvtop`, `intel_gpu_top` |

Two dead ends are recorded in `gpu/macos.rs` so they are not retried: the accelerator's own `PerformanceStatistics` is easier to read but device wide, and `task_info`'s `task_gpu_utilisation` is per process but sits at zero on Apple silicon.

Where several engines run at once (Windows, Linux) the reading is the busiest engine *type* rather than their sum, which would pass 100% while the GPU still had headroom.

**The row is left out entirely where no per-process counter is reachable**, rather than reading a flat zero — the web, an Intel Mac (accelerator clients publish no `AppUsage`), and a Linux driver such as nvidia's, which keeps its accounting in NVML.

### `FRAME` color

The headline is graded on the frame *rate*, so an idle window drawing a handful of frames a second turns it red even though every one of those frames landed well inside the budget. `FRAME` is graded on the frame *time* with the same scale as the trace, so it staying green is what tells you the application is fine and simply has nothing to redraw.

## Test plan

- Verified on macOS against a real load: the reading tracked the window from 0% in the background, to 13% in the foreground, to 33% with the example's curve count dialed up, cross-checked against `ioreg`'s accumulated total for the same pid.
- `cargo clippy -p gpui-fps --all-targets -- -D warnings` clean; 12 tests pass; `rustfmt`, `typos` and `cargo machete` clean.
- The Windows and Linux backends cannot link the full `gpui` from macOS, so both were extracted into an isolated crate and run through `cargo clippy -D warnings` for `x86_64-pc-windows-msvc` and `x86_64-unknown-linux-gnu`. The Linux `fdinfo` parser's tests (including that `drm-engine-capacity-*` counts engines, not nanoseconds) pass on the host. **Runtime behavior on those two platforms still needs confirmation from CI or a reviewer on that hardware.**
- `wasm32-unknown-unknown` and the whole workspace compile.

No public API change: the new reading rides on the existing `show_resources` and `resource_interval` builders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
