### PR TITLE
text: Add `table_actions` hook for Markdown tables

### DIFF
--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -19,11 +19,12 @@ use gpui_component::{
         DocumentRangeSemanticTokensProvider, Editor, EditorState, InputEvent, Rope, RopeExt,
         TabSize,
     },
+    menu::{DropdownMenu as _, PopupMenuItem},
     resizable::{h_resizable, resizable_panel},
     status_bar::StatusBar,
     text::{
-        MarkdownNode, MarkdownParseContext, MarkdownPlugin, SelectionFormat, TextViewStyle,
-        markdown, markdown_ast,
+        MarkdownNode, MarkdownParseContext, MarkdownPlugin, SelectionFormat, TableData,
+        TextViewStyle, markdown, markdown_ast,
     },
     v_flex,
 };
@@ -1029,6 +1030,46 @@ fn svg_color(color: Hsla) -> (String, f32) {
     )
 }
 
+/// Serialize a [`TableData`] to CSV: `,` separated, quoting only cells that
+/// contain `"`, `,` or a newline, with `"` doubled inside quotes.
+fn table_to_csv(table: &TableData) -> String {
+    let field = |cell: &str| {
+        if cell.contains(['"', ',', '\n']) {
+            format!("\"{}\"", cell.replace('"', "\"\""))
+        } else {
+            cell.to_string()
+        }
+    };
+    let line = |cells: &[String]| cells.iter().map(|c| field(c)).collect::<Vec<_>>().join(",");
+
+    std::iter::once(line(&table.headers))
+        .chain(table.rows.iter().map(|row| line(row)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Serialize a [`TableData`] to TSV: tab separated, never quoted; tabs and
+/// newlines inside a cell become literal `\t` / `\n` so rows stay intact.
+fn table_to_tsv(table: &TableData) -> String {
+    let field = |cell: &str| {
+        cell.replace('\t', "\\t")
+            .replace('\n', "\\n")
+            .replace('\r', "\\r")
+    };
+    let line = |cells: &[String]| {
+        cells
+            .iter()
+            .map(|c| field(c))
+            .collect::<Vec<_>>()
+            .join("\t")
+    };
+
+    std::iter::once(line(&table.headers))
+        .chain(table.rows.iter().map(|row| line(row)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Example [`DocumentRangeSemanticTokensProvider`]: tags `TODO` / `FIXME` /
 /// `XXX` / `HACK` / `NOTE` markers anywhere in the document, each with its
 /// own semantic token type so they render in distinct theme colors.
@@ -1266,6 +1307,78 @@ impl Render for Example {
                                                             this
                                                         }
                                                     })
+                                            })
+                                            .table_actions(|table, _window, cx| {
+                                                // The hook hands over the table as plain data:
+                                                // header cells, body rows, and the table
+                                                // re-serialized to GFM Markdown.
+                                                let markdown = table.markdown.clone();
+                                                let csv = table_to_csv(table);
+                                                let tsv = table_to_tsv(table);
+                                                // `span.start` is stable while streaming (only
+                                                // `end` grows), so it is a safe element id seed
+                                                // when a document holds several tables.
+                                                let seed =
+                                                    table.span.as_ref().map_or(0, |s| s.start);
+                                                let shape = format!(
+                                                    "{} × {}",
+                                                    table.rows.len(),
+                                                    table.headers.len()
+                                                );
+
+                                                h_flex()
+                                                    .w_full()
+                                                    .justify_end()
+                                                    .items_center()
+                                                    .gap_1()
+                                                    .child(
+                                                        div()
+                                                            .text_xs()
+                                                            .text_color(cx.theme().muted_foreground)
+                                                            .child(shape),
+                                                    )
+                                                    .child(
+                                                        Clipboard::new(("copy-table", seed))
+                                                            .value(markdown.clone())
+                                                            .tooltip("Copy as Markdown"),
+                                                    )
+                                                    .child(
+                                                        Button::new(("export-table", seed))
+                                                            .icon(IconName::Ellipsis)
+                                                            .ghost()
+                                                            .xsmall()
+                                                            .dropdown_menu_with_anchor(
+                                                                Anchor::TopRight,
+                                                                move |menu, _window, _cx| {
+                                                                    // The builder is a `Fn`, so
+                                                                    // captured values are cloned
+                                                                    // on every rebuild.
+                                                                    let csv = csv.clone();
+                                                                    let tsv = tsv.clone();
+
+                                                                    menu.item(
+                                                                        PopupMenuItem::new(
+                                                                            "Copy as CSV",
+                                                                        )
+                                                                        .on_click(
+                                                                            move |_, _, cx| {
+                                                                                cx.write_to_clipboard(ClipboardItem::new_string(csv.clone()));
+                                                                            },
+                                                                        ),
+                                                                    )
+                                                                    .item(
+                                                                        PopupMenuItem::new(
+                                                                            "Copy as TSV",
+                                                                        )
+                                                                        .on_click(
+                                                                            move |_, _, cx| {
+                                                                                cx.write_to_clipboard(ClipboardItem::new_string(tsv.clone()));
+                                                                            },
+                                                                        ),
+                                                                    )
+                                                                },
+                                                            ),
+                                                    )
                                             })
                                             .plugin(TickerPlugin::new(
                                                 TickerQuote {

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -23,8 +23,8 @@ use gpui_component::{
     resizable::{h_resizable, resizable_panel},
     status_bar::StatusBar,
     text::{
-        MarkdownNode, MarkdownParseContext, MarkdownPlugin, SelectionFormat, TableData,
-        TextViewStyle, markdown, markdown_ast,
+        MarkdownNode, MarkdownParseContext, MarkdownPlugin, SelectionFormat, TextViewStyle,
+        markdown, markdown_ast,
     },
     v_flex,
 };
@@ -1030,9 +1030,9 @@ fn svg_color(color: Hsla) -> (String, f32) {
     )
 }
 
-/// Serialize a [`TableData`] to CSV: `,` separated, quoting only cells that
-/// contain `"`, `,` or a newline, with `"` doubled inside quotes.
-fn table_to_csv(table: &TableData) -> String {
+/// Serialize a table to CSV: `,` separated, quoting only cells that contain
+/// `"`, `,` or a newline, with `"` doubled inside quotes.
+fn table_to_csv(headers: &[String], rows: &[Vec<String>]) -> String {
     let field = |cell: &str| {
         if cell.contains(['"', ',', '\n']) {
             format!("\"{}\"", cell.replace('"', "\"\""))
@@ -1042,15 +1042,15 @@ fn table_to_csv(table: &TableData) -> String {
     };
     let line = |cells: &[String]| cells.iter().map(|c| field(c)).collect::<Vec<_>>().join(",");
 
-    std::iter::once(line(&table.headers))
-        .chain(table.rows.iter().map(|row| line(row)))
+    std::iter::once(line(headers))
+        .chain(rows.iter().map(|row| line(row)))
         .collect::<Vec<_>>()
         .join("\n")
 }
 
-/// Serialize a [`TableData`] to TSV: tab separated, never quoted; tabs and
-/// newlines inside a cell become literal `\t` / `\n` so rows stay intact.
-fn table_to_tsv(table: &TableData) -> String {
+/// Serialize a table to TSV: tab separated, never quoted; tabs and newlines
+/// inside a cell become literal `\t` / `\n` so rows stay intact.
+fn table_to_tsv(headers: &[String], rows: &[Vec<String>]) -> String {
     let field = |cell: &str| {
         cell.replace('\t', "\\t")
             .replace('\n', "\\n")
@@ -1064,8 +1064,8 @@ fn table_to_tsv(table: &TableData) -> String {
             .join("\t")
     };
 
-    std::iter::once(line(&table.headers))
-        .chain(table.rows.iter().map(|row| line(row)))
+    std::iter::once(line(headers))
+        .chain(rows.iter().map(|row| line(row)))
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -1312,9 +1312,13 @@ impl Render for Example {
                                                 // The hook hands over the table as plain data:
                                                 // header cells, body rows, and the table
                                                 // re-serialized to GFM Markdown.
+                                                //
+                                                // This runs on every render, so only cheap
+                                                // clones belong here — CSV / TSV are built
+                                                // inside the click handlers instead.
                                                 let markdown = table.markdown.clone();
-                                                let csv = table_to_csv(table);
-                                                let tsv = table_to_tsv(table);
+                                                let headers = table.headers.clone();
+                                                let rows = table.rows.clone();
                                                 // `span.start` is stable while streaming (only
                                                 // `end` grows), so it is a safe element id seed
                                                 // when a document holds several tables.
@@ -1353,8 +1357,10 @@ impl Render for Example {
                                                                     // The builder is a `Fn`, so
                                                                     // captured values are cloned
                                                                     // on every rebuild.
-                                                                    let csv = csv.clone();
-                                                                    let tsv = tsv.clone();
+                                                                    let (csv_headers, csv_rows) =
+                                                                        (headers.clone(), rows.clone());
+                                                                    let (tsv_headers, tsv_rows) =
+                                                                        (headers.clone(), rows.clone());
 
                                                                     menu.item(
                                                                         PopupMenuItem::new(
@@ -1362,7 +1368,8 @@ impl Render for Example {
                                                                         )
                                                                         .on_click(
                                                                             move |_, _, cx| {
-                                                                                cx.write_to_clipboard(ClipboardItem::new_string(csv.clone()));
+                                                                                let csv = table_to_csv(&csv_headers, &csv_rows);
+                                                                                cx.write_to_clipboard(ClipboardItem::new_string(csv));
                                                                             },
                                                                         ),
                                                                     )
@@ -1372,7 +1379,8 @@ impl Render for Example {
                                                                         )
                                                                         .on_click(
                                                                             move |_, _, cx| {
-                                                                                cx.write_to_clipboard(ClipboardItem::new_string(tsv.clone()));
+                                                                                let tsv = table_to_tsv(&tsv_headers, &tsv_rows);
+                                                                                cx.write_to_clipboard(ClipboardItem::new_string(tsv));
                                                                             },
                                                                         ),
                                                                     )

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -1319,11 +1319,8 @@ impl Render for Example {
                                                 let markdown = table.markdown.clone();
                                                 let headers = table.headers.clone();
                                                 let rows = table.rows.clone();
-                                                // `span.start` is stable while streaming (only
-                                                // `end` grows), so it is a safe element id seed
-                                                // when a document holds several tables.
-                                                let seed =
-                                                    table.span.as_ref().map_or(0, |s| s.start);
+                                                // Plain ids are fine: the actions row is scoped
+                                                // per table by the component.
                                                 let shape = format!(
                                                     "{} × {}",
                                                     table.rows.len(),
@@ -1342,12 +1339,12 @@ impl Render for Example {
                                                             .child(shape),
                                                     )
                                                     .child(
-                                                        Clipboard::new(("copy-table", seed))
+                                                        Clipboard::new("copy-table")
                                                             .value(markdown.clone())
                                                             .tooltip("Copy as Markdown"),
                                                     )
                                                     .child(
-                                                        Button::new(("export-table", seed))
+                                                        Button::new("export-table")
                                                             .icon(IconName::Ellipsis)
                                                             .ghost()
                                                             .xsmall()

--- a/crates/ui/src/text/mod.rs
+++ b/crates/ui/src/text/mod.rs
@@ -15,6 +15,7 @@ mod window_selection;
 
 use gpui::{App, ElementId, IntoElement, RenderOnce, SharedString, Window};
 pub use markdown_ext::*;
+pub use node::TableData;
 pub use state::*;
 pub use style::*;
 pub use text_view::*;

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -972,9 +972,12 @@ pub struct TableData {
     pub rows: Vec<Vec<String>>,
     /// The table serialized back to GFM pipe-table Markdown, alignments kept.
     pub markdown: String,
-    /// Byte range of the table in the Markdown source. `start` is stable
-    /// across re-renders while streaming (only `end` grows), so it is safe
-    /// to use as an element id seed.
+    /// Byte range of the table in the Markdown source, for callers that need
+    /// to map the table back to the document.
+    ///
+    /// Not needed to keep element ids apart: the actions row is wrapped in its
+    /// own identified element, so plain ids like `"copy"` are already scoped
+    /// per table.
     pub span: Option<Range<usize>>,
 }
 
@@ -2193,13 +2196,16 @@ impl BlockNode {
             // Custom actions row (e.g. copy / download) rendered below the
             // table. The hook's element spans full width; alignment is up to
             // the caller (e.g. `h_flex().justify_end()`). The gap keeps hover
-            // backgrounds of the action buttons off the table border.
-            .children(
-                node_cx
-                    .table_actions
-                    .clone()
-                    .map(|f| div().mt_1().child(f(&table.table_data(), window, cx))),
-            )
+            // backgrounds of the action buttons off the table border, and the
+            // id scopes the caller's element ids per table, so plain ids like
+            // `"copy"` don't collide across tables (same as code blocks).
+            .children(node_cx.table_actions.clone().map(|f| {
+                div().id(("table-actions", options.ix)).mt_1().child(f(
+                    &table.table_data(),
+                    window,
+                    cx,
+                ))
+            }))
             .into_any_element()
     }
 
@@ -2276,13 +2282,16 @@ impl BlockNode {
             // Custom actions row (e.g. copy / download) rendered below the
             // table. The hook's element spans full width; alignment is up to
             // the caller (e.g. `h_flex().justify_end()`). The gap keeps hover
-            // backgrounds of the action buttons off the table border.
-            .children(
-                node_cx
-                    .table_actions
-                    .clone()
-                    .map(|f| div().mt_1().child(f(&table.table_data(), window, cx))),
-            )
+            // backgrounds of the action buttons off the table border, and the
+            // id scopes the caller's element ids per table, so plain ids like
+            // `"copy"` don't collide across tables (same as code blocks).
+            .children(node_cx.table_actions.clone().map(|f| {
+                div().id(("table-actions", options.ix)).mt_1().child(f(
+                    &table.table_data(),
+                    window,
+                    cx,
+                ))
+            }))
             .into_any_element()
     }
 

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -20,7 +20,7 @@ use crate::{
     input::{InputEdit, Point, RopeExt as _},
     scroll::horizontal_scroll_area,
     text::{
-        CodeBlockActionsFn, LinkClickHandlerFn, MarkdownExtensions, MarkdownNode,
+        CodeBlockActionsFn, LinkClickHandlerFn, MarkdownExtensions, MarkdownNode, TableActionsFn,
         document::NodeRenderOptions,
         inline::{Inline, InlineState},
         inline_flow::{InlineFlow, InlineFlowItem},
@@ -961,9 +961,87 @@ pub(crate) struct Table {
     pub(crate) span: Option<Span>,
 }
 
+/// Plain snapshot of a rendered Markdown table, passed to the
+/// [`crate::text::TextView::table_actions`] hook.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TableData {
+    /// First table row (header cells) as plain text.
+    pub headers: Vec<String>,
+    /// Rows after the header as plain text cells. May be ragged while
+    /// a table is still streaming in.
+    pub rows: Vec<Vec<String>>,
+    /// The table serialized back to GFM pipe-table Markdown, alignments kept.
+    pub markdown: String,
+    /// Byte range of the table in the Markdown source. `start` is stable
+    /// across re-renders while streaming (only `end` grows), so it is safe
+    /// to use as an element id seed.
+    pub span: Option<Range<usize>>,
+}
+
 impl Table {
     pub(crate) fn column_align(&self, index: usize) -> ColumnumnAlign {
         self.column_aligns.get(index).copied().unwrap_or_default()
+    }
+
+    /// Serialize the table back to GFM pipe-table Markdown (`| a | b |`),
+    /// preserving column alignments. Cell newlines collapse to spaces and
+    /// `|` is escaped so rows stay intact.
+    ///
+    /// Mirrors [`table_selected_source`], which does the same for the selected
+    /// cells only.
+    pub(crate) fn to_markdown(&self) -> String {
+        let mut lines: Vec<String> = Vec::with_capacity(self.children.len() + 1);
+
+        for (row_ix, row) in self.children.iter().enumerate() {
+            let cells: Vec<String> = row
+                .children
+                .iter()
+                .map(|cell| {
+                    cell.children
+                        .to_markdown()
+                        .trim()
+                        .replace('\n', " ")
+                        .replace('|', "\\|")
+                })
+                .collect();
+            lines.push(format!("| {} |", cells.join(" | ")));
+
+            // The Markdown delimiter row carries the column alignments and must
+            // follow the header row.
+            if row_ix == 0 {
+                let aligns: Vec<String> = (0..row.children.len())
+                    .map(|ix| {
+                        match self.column_align(ix) {
+                            ColumnumnAlign::Left => ":--",
+                            ColumnumnAlign::Center => ":-:",
+                            ColumnumnAlign::Right => "--:",
+                        }
+                        .to_string()
+                    })
+                    .collect();
+                lines.push(format!("| {} |", aligns.join(" | ")));
+            }
+        }
+
+        lines.join("\n")
+    }
+
+    /// Snapshot of this table for the [`crate::text::TextView::table_actions`]
+    /// hook.
+    pub(crate) fn table_data(&self) -> TableData {
+        let row_text = |row: &TableRow| {
+            row.children
+                .iter()
+                .map(|cell| cell.children.text().trim().to_string())
+                .collect::<Vec<_>>()
+        };
+
+        TableData {
+            headers: self.children.first().map(row_text).unwrap_or_default(),
+            rows: self.children.iter().skip(1).map(row_text).collect(),
+            markdown: self.to_markdown(),
+            span: self.span.map(|span| span.start..span.end),
+        }
     }
 }
 
@@ -1279,6 +1357,7 @@ pub(crate) struct NodeContext {
     pub(crate) link_refs: HashMap<SharedString, LinkMark>,
     pub(crate) style: TextViewStyle,
     pub(crate) code_block_actions: Option<Arc<CodeBlockActionsFn>>,
+    pub(crate) table_actions: Option<Arc<TableActionsFn>>,
     pub(crate) link_click_handler: Option<Arc<LinkClickHandlerFn>>,
     pub(crate) markdown_extensions: Arc<MarkdownExtensions>,
 }
@@ -1292,8 +1371,8 @@ impl NodeContext {
 impl PartialEq for NodeContext {
     fn eq(&self, other: &Self) -> bool {
         self.link_refs == other.link_refs && self.style == other.style
-        // Note: code_block_actions and markdown_extensions are intentionally
-        // not compared (closures can't be compared)
+        // Note: code_block_actions, table_actions and markdown_extensions are
+        // intentionally not compared (closures can't be compared)
     }
 }
 
@@ -1697,46 +1776,7 @@ impl BlockNode {
                     code_block.code()
                 )
             }
-            BlockNode::Table(table) => {
-                let header = table
-                    .children
-                    .first()
-                    .map(|row| {
-                        row.children
-                            .iter()
-                            .map(|cell| cell.children.to_markdown())
-                            .collect::<Vec<_>>()
-                            .join(" | ")
-                    })
-                    .unwrap_or_default();
-                let alignments = table
-                    .column_aligns
-                    .iter()
-                    .map(|align| {
-                        match align {
-                            ColumnumnAlign::Left => ":--",
-                            ColumnumnAlign::Center => ":-:",
-                            ColumnumnAlign::Right => "--:",
-                        }
-                        .to_string()
-                    })
-                    .collect::<Vec<_>>()
-                    .join(" | ");
-                let rows = table
-                    .children
-                    .iter()
-                    .skip(1)
-                    .map(|row| {
-                        row.children
-                            .iter()
-                            .map(|cell| cell.children.to_markdown())
-                            .collect::<Vec<_>>()
-                            .join(" | ")
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                format!("{}\n{}\n{}", header, alignments, rows)
-            }
+            BlockNode::Table(table) => table.to_markdown(),
             BlockNode::Break { html, .. } => {
                 if *html {
                     "<br>".to_string()
@@ -2150,6 +2190,16 @@ impl BlockNode {
                         .children(rows),
                 ),
             )
+            // Custom actions row (e.g. copy / download) rendered below the
+            // table. The hook's element spans full width; alignment is up to
+            // the caller (e.g. `h_flex().justify_end()`). The gap keeps hover
+            // backgrounds of the action buttons off the table border.
+            .children(
+                node_cx
+                    .table_actions
+                    .clone()
+                    .map(|f| div().mt_1().child(f(&table.table_data(), window, cx))),
+            )
             .into_any_element()
     }
 
@@ -2222,6 +2272,16 @@ impl BlockNode {
                     .overflow_hidden()
                     .children(rows)
                     .refine_style(&style.table),
+            )
+            // Custom actions row (e.g. copy / download) rendered below the
+            // table. The hook's element spans full width; alignment is up to
+            // the caller (e.g. `h_flex().justify_end()`). The gap keeps hover
+            // backgrounds of the action buttons off the table border.
+            .children(
+                node_cx
+                    .table_actions
+                    .clone()
+                    .map(|f| div().mt_1().child(f(&table.table_data(), window, cx))),
             )
             .into_any_element()
     }
@@ -2646,6 +2706,117 @@ mod tests {
             block.selected_text(SelectionFormat::Source),
             "| Name | Age |\n| :-- | --: |\n| Alice | 30 |\n"
         );
+    }
+
+    /// A cell holding plain text, as `Table::to_markdown` and
+    /// `Table::table_data` see it (neither needs a selection).
+    fn plain_cell(text: &str) -> TableCell {
+        TableCell {
+            children: Paragraph::new(text.to_string()),
+            width: None,
+        }
+    }
+
+    fn table_of(rows: Vec<Vec<TableCell>>, column_aligns: Vec<ColumnumnAlign>) -> Table {
+        Table {
+            children: rows
+                .into_iter()
+                .map(|children| TableRow { children })
+                .collect(),
+            column_aligns,
+            span: None,
+        }
+    }
+
+    #[test]
+    fn table_to_markdown_pipes_cells_with_alignment_row() {
+        let table = table_of(
+            vec![
+                vec![plain_cell("Name"), plain_cell("Age"), plain_cell("Score")],
+                vec![plain_cell("Alice"), plain_cell("30"), plain_cell("9.5")],
+            ],
+            vec![
+                ColumnumnAlign::Left,
+                ColumnumnAlign::Center,
+                ColumnumnAlign::Right,
+            ],
+        );
+
+        assert_eq!(
+            table.to_markdown(),
+            "| Name | Age | Score |\n| :-- | :-: | --: |\n| Alice | 30 | 9.5 |"
+        );
+        // The block arm delegates to it.
+        assert_eq!(
+            BlockNode::Table(table.clone()).to_markdown(),
+            table.to_markdown()
+        );
+    }
+
+    #[test]
+    fn table_to_markdown_keeps_outer_pipes_for_a_single_column() {
+        let table = table_of(
+            vec![vec![plain_cell("Symbol")], vec![plain_cell("TSLA.US")]],
+            vec![ColumnumnAlign::Left],
+        );
+
+        assert_eq!(table.to_markdown(), "| Symbol |\n| :-- |\n| TSLA.US |");
+    }
+
+    #[test]
+    fn table_to_markdown_escapes_pipes_and_keeps_inline_marks() {
+        let bold = TableCell {
+            children: paragraph_with_children(vec![
+                InlineNode::new("bold").marks(vec![(0..4, TextMark::default().bold())]),
+            ]),
+            width: None,
+        };
+        let table = table_of(
+            vec![
+                vec![plain_cell("a | b"), plain_cell("plain")],
+                vec![plain_cell("c"), bold],
+            ],
+            vec![ColumnumnAlign::Left, ColumnumnAlign::Left],
+        );
+
+        assert_eq!(
+            table.to_markdown(),
+            "| a \\| b | plain |\n| :-- | :-- |\n| c | **bold** |"
+        );
+    }
+
+    #[test]
+    fn table_data_snapshots_plain_cells_and_markdown() {
+        let mut table = table_of(
+            vec![
+                vec![plain_cell("  Name  "), plain_cell("Age")],
+                vec![plain_cell("Alice"), plain_cell("30")],
+            ],
+            vec![ColumnumnAlign::Left, ColumnumnAlign::Right],
+        );
+        table.span = Some(Span { start: 4, end: 42 });
+
+        let data = table.table_data();
+        assert_eq!(data.headers, vec!["Name", "Age"]);
+        assert_eq!(data.rows, vec![vec!["Alice", "30"]]);
+        assert_eq!(data.markdown, table.to_markdown());
+        assert_eq!(data.span, Some(4..42));
+    }
+
+    #[test]
+    fn table_data_handles_tables_without_rows() {
+        // Header only: still a valid table, with no data rows.
+        let header_only = table_of(
+            vec![vec![plain_cell("Name"), plain_cell("Age")]],
+            vec![ColumnumnAlign::Left, ColumnumnAlign::Left],
+        );
+        let data = header_only.table_data();
+        assert_eq!(data.headers, vec!["Name", "Age"]);
+        assert!(data.rows.is_empty());
+        assert_eq!(data.markdown, "| Name | Age |\n| :-- | :-- |");
+
+        // No rows at all (a table still streaming in): an empty snapshot.
+        assert_eq!(Table::default().table_data(), TableData::default());
     }
 
     fn image_paragraph(alt: &str, url: &str) -> Paragraph {

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -13,7 +13,7 @@ use crate::{
     input::{self, SelectAll},
     scroll::AutoScroll,
     text::{
-        CodeBlockActionsFn, LinkClickHandlerFn, MarkdownExtensions, TextViewStyle,
+        CodeBlockActionsFn, LinkClickHandlerFn, MarkdownExtensions, TableActionsFn, TextViewStyle,
         document::ParsedDocument,
         format,
         node::{self, NodeContext},
@@ -77,6 +77,7 @@ pub struct TextViewState {
     pub(super) scrollable: bool,
     pub(super) text_view_style: TextViewStyle,
     pub(super) code_block_actions: Option<std::sync::Arc<CodeBlockActionsFn>>,
+    pub(super) table_actions: Option<std::sync::Arc<TableActionsFn>>,
     pub(super) link_click_handler: Option<std::sync::Arc<LinkClickHandlerFn>>,
     pub(super) markdown_extensions: Arc<MarkdownExtensions>,
 
@@ -171,6 +172,7 @@ impl TextViewState {
             list_state: ListState::new(0, gpui::ListAlignment::Top, px(1000.)).measure_all(),
             text_view_style: TextViewStyle::default(),
             code_block_actions: None,
+            table_actions: None,
             link_click_handler: None,
             markdown_extensions: Arc::default(),
             is_selecting: false,
@@ -557,6 +559,7 @@ impl Render for TextViewState {
         let mut node_cx = self.parsed_content.node_cx.clone();
 
         node_cx.code_block_actions = self.code_block_actions.clone();
+        node_cx.table_actions = self.table_actions.clone();
         node_cx.link_click_handler = self.link_click_handler.clone();
         node_cx.markdown_extensions = self.markdown_extensions.clone();
         node_cx.style = self.text_view_style.clone();

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -11,13 +11,17 @@ use crate::StyledExt;
 use crate::scroll::ScrollableElement;
 use crate::text::TextViewFormat;
 use crate::text::markdown_ext::{MarkdownExtensions, MarkdownNode, MarkdownPlugin};
-use crate::text::node::CodeBlock;
+use crate::text::node::{CodeBlock, TableData};
 use crate::text::state::{SelectionFormat, TextViewState};
 use crate::{global_state::UiGlobalState, text::TextViewStyle};
 
 /// Type for code block actions generator function.
 pub(crate) type CodeBlockActionsFn =
     dyn Fn(&CodeBlock, &mut Window, &mut App) -> AnyElement + Send + Sync;
+
+/// Type for the table actions generator function.
+pub(crate) type TableActionsFn =
+    dyn Fn(&TableData, &mut Window, &mut App) -> AnyElement + Send + Sync;
 
 pub(crate) type LinkClickHandlerFn =
     dyn Fn(&SharedString, &ClickEvent, &mut Window, &mut App) + Send + Sync;
@@ -70,6 +74,7 @@ pub struct TextView {
     selection_format: SelectionFormat,
     scrollable: bool,
     code_block_actions: Option<Arc<CodeBlockActionsFn>>,
+    table_actions: Option<Arc<TableActionsFn>>,
     link_click_handler: Option<Arc<LinkClickHandlerFn>>,
     markdown_extensions: Arc<MarkdownExtensions>,
 }
@@ -111,6 +116,7 @@ impl TextView {
             selection_format: SelectionFormat::default(),
             scrollable: false,
             code_block_actions: None,
+            table_actions: None,
             link_click_handler: None,
             markdown_extensions: Arc::default(),
         }
@@ -129,6 +135,7 @@ impl TextView {
             selection_format: SelectionFormat::default(),
             scrollable: false,
             code_block_actions: None,
+            table_actions: None,
             link_click_handler: None,
             markdown_extensions: Arc::default(),
         }
@@ -147,6 +154,7 @@ impl TextView {
             selection_format: SelectionFormat::default(),
             scrollable: false,
             code_block_actions: None,
+            table_actions: None,
             link_click_handler: None,
             markdown_extensions: Arc::default(),
         }
@@ -201,6 +209,21 @@ impl TextView {
     {
         self.code_block_actions = Some(Arc::new(move |code_block, window, cx| {
             f(&code_block, window, cx).into_any_element()
+        }));
+        self
+    }
+
+    /// Set custom actions to be rendered below each Markdown table.
+    ///
+    /// The closure receives the [`TableData`],
+    /// and returns an element to display.
+    pub fn table_actions<F, E>(mut self, f: F) -> Self
+    where
+        F: Fn(&TableData, &mut Window, &mut App) -> E + Send + Sync + 'static,
+        E: IntoElement,
+    {
+        self.table_actions = Some(Arc::new(move |table, window, cx| {
+            f(table, window, cx).into_any_element()
         }));
         self
     }
@@ -330,6 +353,7 @@ impl Element for TextView {
 
         state.update(cx, |state, cx| {
             state.code_block_actions = self.code_block_actions.clone();
+            state.table_actions = self.table_actions.clone();
             state.link_click_handler = self.link_click_handler.clone();
             state.set_markdown_extensions(self.markdown_extensions.clone(), cx);
             state.selectable = self.selectable;
@@ -432,11 +456,12 @@ impl Element for TextView {
 #[cfg(test)]
 mod tests {
     use super::{TextView, TextViewPlugin};
-    use crate::text::TextViewState;
+    use crate::text::{TableData, TextViewState, TextViewStyle};
     use gpui::{
-        AppContext as _, ClickEvent, Context, Entity, InteractiveElement as _, IntoElement,
-        Modifiers, MouseButton, MouseDownEvent, MouseUpEvent, ParentElement as _, Render,
-        SharedString, Styled as _, TestAppContext, VisualTestContext, Window, div, point, px,
+        AppContext as _, Bounds, ClickEvent, Context, Entity, InteractiveElement as _, IntoElement,
+        Modifiers, MouseButton, MouseDownEvent, MouseUpEvent, Overflow, ParentElement as _, Pixels,
+        Render, SharedString, StyleRefinement, Styled as _, TestAppContext, VisualTestContext,
+        Window, div, point, px,
     };
 
     struct TextViewTestRoot {
@@ -606,6 +631,95 @@ mod tests {
             top_level_action.right() - nested_action.right() < px(32.),
             "nested code block should fill the list item's available width"
         );
+    }
+
+    /// Draw a Markdown table with a `table_actions` hook installed, and return
+    /// the painted bounds of the actions element plus the data it received.
+    /// `scroll` opts into the horizontally scrollable table layout.
+    fn draw_table_with_actions(
+        cx: &mut TestAppContext,
+        scroll: bool,
+    ) -> (Bounds<Pixels>, TableData) {
+        use std::sync::{Arc, Mutex};
+
+        struct TableRoot {
+            scroll: bool,
+            captured: Arc<Mutex<Vec<TableData>>>,
+        }
+
+        impl Render for TableRoot {
+            fn render(
+                &mut self,
+                _window: &mut Window,
+                _cx: &mut Context<Self>,
+            ) -> impl IntoElement {
+                let captured = self.captured.clone();
+                let mut table_style = StyleRefinement::default();
+                if self.scroll {
+                    table_style.overflow.x = Some(Overflow::Scroll);
+                }
+
+                div().w(px(320.)).child(
+                    TextView::markdown(
+                        "table-actions",
+                        "| Name | Age |\n|:--|--:|\n| Alice | 30 |\n| Bob | 41 |",
+                    )
+                    .style(TextViewStyle::default().table(table_style))
+                    .table_actions(move |table, _, _| {
+                        if let Ok(mut captured) = captured.lock() {
+                            captured.push(table.clone());
+                        }
+                        div().debug_selector(|| "table-action".into()).child("Copy")
+                    }),
+                )
+            }
+        }
+
+        cx.update(crate::init);
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let (_, cx) = cx.add_window_view({
+            let captured = captured.clone();
+            move |_, _| TableRoot { scroll, captured }
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let bounds = cx
+            .debug_bounds("table-action")
+            .expect("table actions should be painted");
+        let data = captured
+            .lock()
+            .expect("captured table data")
+            .last()
+            .cloned()
+            .expect("table actions hook should receive the table");
+
+        (bounds, data)
+    }
+
+    #[gpui::test]
+    fn table_actions_render_below_the_table(cx: &mut TestAppContext) {
+        for scroll in [false, true] {
+            let (bounds, data) = draw_table_with_actions(cx, scroll);
+
+            // Header plus two data rows are painted above the actions row.
+            assert!(
+                bounds.top() > px(40.),
+                "actions should sit below the table (scroll: {scroll}), got {:?}",
+                bounds.top()
+            );
+            assert_eq!(data.headers, vec!["Name", "Age"]);
+            assert_eq!(data.rows, vec![vec!["Alice", "30"], vec!["Bob", "41"]]);
+            assert_eq!(
+                data.markdown,
+                "| Name | Age |\n| :-- | --: |\n| Alice | 30 |\n| Bob | 41 |"
+            );
+            assert_eq!(data.span, Some(0..52));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a `TextView::table_actions` hook, mirroring the existing `code_block_actions`: apps can render their own element (copy / download buttons, …) directly below every Markdown table.
- The hook receives a plain `TableData` snapshot — header cells, body rows, the table re-serialized to GFM Markdown, and the source byte range — so callers never need access to the internal node types. `TableData` is re-exported from `text`, unlike `CodeBlock`.
- `TableData.span.start` stays stable while a table streams in (only `end` grows), making it a safe element id seed for documents holding several tables.
- Both table layouts (scrolling and wrapping) render the actions row, with a small gap so the buttons' hover backgrounds stay clear of the table border. Alignment is left to the caller.
- Fix `BlockNode::to_markdown` for tables along the way: it joined cells straight from `Paragraph::to_markdown`, which trails `"\n\n"`, and emitted no outer pipes — so single-column tables were not valid GFM. Table serialization now lives in `Table::to_markdown`, mirroring `table_selected_source`.
- The Markdown example demonstrates the hook with a row showing the table shape plus copy-as-Markdown / CSV / TSV actions.

## Test plan

- [x] `cargo test -p gpui-component text` — 129 passed (123 before; 5 new unit tests for `to_markdown` / `table_data`, 1 new render test)
- [x] `table_actions_render_below_the_table` draws a real frame and asserts the painted bounds sit below the table, covering **both** the scrolling and wrapping layouts; verified it is not vacuous by temporarily removing the render hook (test fails as expected)
- [x] `cargo build -p gpui-component`, `cargo clippy -p gpui-component --all-targets`, `cargo check --no-default-features` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo run --example markdown -p gpui-component-story` — actions row renders below tables (including tables nested in list items), reports the correct row × column counts, and copy actions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)