### PR TITLE
popover: Match shadcn's popup surface and animate dropdowns open

### DIFF
--- a/crates/ui/src/combobox.rs
+++ b/crates/ui/src/combobox.rs
@@ -692,6 +692,7 @@ where
                 .when(self.state.open, |this| {
                     this.child(
                         deferred(render_popup_shell(
+                            ("combobox-popup", cx.entity_id()),
                             &self.state.list,
                             self.state.menu_width,
                             self.state.search_placeholder.clone(),
@@ -1018,6 +1019,7 @@ fn render_trigger_container(
 /// Renders the deferred anchored popup shell containing the searchable list and optional footer.
 #[allow(clippy::too_many_arguments)]
 fn render_popup_shell<D: SearchableListDelegate + 'static>(
+    id: impl Into<ElementId>,
     list: &Entity<ListState<SearchableListAdapter<D>>>,
     menu_width: Length,
     search_placeholder: Option<SharedString>,
@@ -1029,46 +1031,39 @@ fn render_popup_shell<D: SearchableListDelegate + 'static>(
     cx: &mut App,
 ) -> AnyElement {
     let has_footer = footer_el.is_some();
-    let popup_radius = cx.theme().radius.min(px(8.));
 
-    crate::popover::dropdown_positioner(bounds)
-        .child(
-            div()
-                .occlude()
-                .map(|this| match menu_width {
-                    Length::Auto => this.w(bounds.size.width + px(2.)),
-                    Length::Definite(w) => this.w(w),
-                })
-                .child(
-                    v_flex()
-                        .occlude()
-                        .bg(cx.theme().tokens.popover)
-                        .border_1()
+    crate::popover::dropdown_popup(
+        id,
+        bounds,
+        v_flex()
+            .occlude()
+            .map(|this| match menu_width {
+                Length::Auto => this.w(bounds.size.width + px(2.)),
+                Length::Definite(w) => this.w(w),
+            })
+            .popover_style(cx)
+            .child(
+                List::new(list)
+                    .when_some(search_placeholder, |this, placeholder| {
+                        this.search_placeholder(placeholder)
+                    })
+                    .with_size(size)
+                    .max_h(menu_max_h)
+                    .paddings(Edges::all(px(4.))),
+            )
+            .when(has_footer, |this| {
+                this.child(
+                    div()
+                        .border_t_1()
                         .border_color(cx.theme().border)
-                        .rounded(popup_radius)
-                        .shadow_md()
-                        .child(
-                            List::new(list)
-                                .when_some(search_placeholder, |this, placeholder| {
-                                    this.search_placeholder(placeholder)
-                                })
-                                .with_size(size)
-                                .max_h(menu_max_h)
-                                .paddings(Edges::all(px(4.))),
-                        )
-                        .when(has_footer, |this| {
-                            this.child(
-                                div()
-                                    .border_t_1()
-                                    .border_color(cx.theme().border)
-                                    .p_1()
-                                    .when_some(footer_el, |this, el| this.child(el)),
-                            )
-                        }),
+                        .p_1()
+                        .when_some(footer_el, |this, el| this.child(el)),
                 )
-                .on_mouse_down_out(dismiss_handler),
-        )
-        .into_any_element()
+            })
+            .on_mouse_down_out(dismiss_handler),
+        cx,
+    )
+    .into_any_element()
 }
 
 // MARK: Tests

--- a/crates/ui/src/notification.rs
+++ b/crates/ui/src/notification.rs
@@ -15,6 +15,7 @@ use crate::{
     ActiveTheme as _, Edges, Icon, IconName, Sizable as _, StyledExt, TITLE_BAR_HEIGHT,
     animation::cubic_bezier,
     button::{Button, ButtonVariants as _},
+    styled::toast_shadow,
     v_flex,
 };
 
@@ -338,7 +339,7 @@ impl Render for Notification {
             .border_color(cx.theme().border)
             .bg(cx.theme().tokens.popover)
             .rounded(cx.theme().radius_lg)
-            .shadow_md()
+            .shadow(toast_shadow(1.))
             .py_3p5()
             .px_4()
             .gap_3()
@@ -400,7 +401,7 @@ impl Render for Notification {
                 move |this, delta| {
                     if closing {
                         let opacity = 1. - delta;
-                        let that = this.opacity(opacity);
+                        let that = this.opacity(opacity).shadow(toast_shadow(opacity.powi(3)));
                         let y_offset = match placement {
                             Anchor::TopLeft | Anchor::TopRight | Anchor::TopCenter => {
                                 -delta * NOTIFICATION_TRANSITION_OFFSET
@@ -424,9 +425,16 @@ impl Render for Notification {
                             _ => px(0.),
                         };
                         let opacity = delta;
+                        // GPUI paints a drop shadow *under* the card and has no
+                        // group compositing, so a card that is still translucent
+                        // does not hide its own shadow and it shows through as a
+                        // dark slab. Ramping the ink by the cube of the fade
+                        // keeps it out of sight until the card can cover it —
+                        // where this used to drop the shadow outright past a
+                        // threshold, which popped.
                         this.top(px(0.) + y_offset)
                             .opacity(opacity)
-                            .when(opacity < 0.85, |this| this.shadow_none())
+                            .shadow(toast_shadow(opacity.powi(3)))
                     }
                 },
             )

--- a/crates/ui/src/popover.rs
+++ b/crates/ui/src/popover.rs
@@ -1,23 +1,104 @@
 use gpui::{
-    Anchor, AnyElement, App, Bounds, Context, Div, ElementId, FocusHandle, InteractiveElement as _,
-    IntoElement, MouseButton, ParentElement, Pixels, RenderOnce, Stateful, StyleRefinement, Styled,
-    Window, prelude::FluentBuilder as _, px,
+    Anchor, Animation, AnimationExt as _, AnyElement, App, Bounds, Context, Div, ElementId,
+    FocusHandle, InteractiveElement as _, IntoElement, MouseButton, ParentElement, Pixels,
+    RenderOnce, Stateful, StyleRefinement, Styled, Window, prelude::FluentBuilder as _, px,
 };
-use std::rc::Rc;
+use std::{rc::Rc, time::Duration};
 
 use crate::ThemeStyled as _;
-use crate::{Selectable, StyledExt as _, v_flex};
+use crate::{
+    Selectable, StyledExt as _,
+    animation::ease_out_cubic,
+    styled::{popover_ring, popover_shadow},
+    v_flex,
+};
 use gpui_base::Popover as BasePopover;
 pub use gpui_base::PopoverState;
 
 pub(crate) fn init(_: &mut App) {}
 
-pub(crate) fn dropdown_positioner(bounds: Bounds<Pixels>) -> gpui_base::Positioner {
+/// How long a dropdown takes to settle into place after it opens.
+///
+/// This is shadcn/ui's figure: its popup surfaces carry `animate-in`, whose
+/// duration is 150ms.
+const DROPDOWN_ENTER_DURATION: Duration = Duration::from_millis(150);
+
+/// Where a dropdown starts out, relative to where it comes to rest.
+///
+/// Negative is above, so the surface slides *down* out of the trigger's edge —
+/// what shadcn/ui expresses as `data-[side=bottom]:slide-in-from-top-2`. Its
+/// `2` is `0.5rem`, which is 8px at the default root size.
+const DROPDOWN_ENTER_OFFSET: Pixels = px(-8.);
+
+fn dropdown_positioner(bounds: Bounds<Pixels>) -> gpui_base::Positioner {
     gpui_base::Positioner::side(bounds)
         .placement(gpui_base::Placement::Bottom)
         .align(gpui_base::Align::Start)
         .offset(px(6.))
         .margin(px(8.))
+}
+
+/// Positions a dropdown surface under its trigger and animates it in.
+///
+/// This is the shared open motion for Select, Combobox and DatePicker, modelled
+/// on shadcn/ui: over 150ms the surface fades up from nothing while sliding the
+/// last 8px out of the trigger's edge, on an ease-out curve so it decelerates
+/// into place.
+///
+/// `surface` must be the panel itself — the element carrying
+/// [`ThemeStyled::popover_style`] — and not a wrapper around it. GPUI takes a
+/// shadow's shape from the element it is set on, so a wrapper of a different
+/// size would throw the shadow out of register with the panel.
+///
+/// # Why the shadow is animated too
+///
+/// GPUI has no group compositing: `opacity` multiplies into each primitive's
+/// alpha separately rather than fading a composited subtree. A drop shadow is
+/// painted as a full blurred rect *under* the element — the shader only cuts the
+/// element out of `inset` shadows — so a translucent panel does not hide its own
+/// shadow, and mid-fade the shadow shows straight through the panel as a dark
+/// slab. Ramping the ink by the cube of the fade keeps it out of sight until the
+/// panel is opaque enough to cover it, and still lands on the resting shadow
+/// [`popover_shadow`] gives every other popup.
+///
+/// # Departures from shadcn
+///
+/// - shadcn also scales the surface up from 95% (`zoom-in-95`). GPUI has no
+///   element transform — only images and SVGs take a `TransformationMatrix` —
+///   so there is nothing to scale a subtree with, and the fade and slide carry
+///   the motion on their own.
+/// - There is no exit motion. A closing dropdown stops being rendered in the
+///   same frame its state flips, so playing one would mean keeping the surface
+///   mounted past the close, which is a change to how each of these components
+///   tracks `open`.
+/// - The slide always comes from above. [`gpui_base::Positioner`] resolves the
+///   side the surface actually lands on during layout and does not report it
+///   back, so a dropdown that flips above its trigger for want of room below
+///   slides the opposite way — 8px over 150ms, in the rare case where it
+///   happens.
+///
+/// Reduced motion needs no handling here: GPUI's animation element adopts the
+/// final value on the first frame when the system asks for it.
+pub(crate) fn dropdown_popup(
+    id: impl Into<ElementId>,
+    bounds: Bounds<Pixels>,
+    surface: impl IntoElement + Styled + 'static,
+    cx: &App,
+) -> gpui_base::Positioner {
+    let travel: f32 = DROPDOWN_ENTER_OFFSET.into();
+    // Read out here: the animation runs long after `cx` is gone.
+    let ring = popover_ring(cx);
+
+    dropdown_positioner(bounds).child(surface.with_animation(
+        id,
+        Animation::new(DROPDOWN_ENTER_DURATION).with_easing(ease_out_cubic),
+        move |surface, delta| {
+            surface
+                .top(px(travel * (1. - delta)))
+                .opacity(delta)
+                .shadow(popover_shadow(ring, delta * delta * delta))
+        },
+    ))
 }
 
 /// A popover element that can be triggered by a button or any other element.
@@ -246,7 +327,7 @@ impl RenderOnce for Popover {
 mod tests {
     use super::*;
     use crate::{button::Button, theme::Theme};
-    use gpui::{Bounds, Context, MouseButton, Point, Render, div, point, px};
+    use gpui::{Bounds, Context, MouseButton, Point, Render, div, point, px, size};
     use gpui_base::Popup as BasePopup;
     use std::{cell::RefCell, rc::Rc};
 
@@ -377,5 +458,64 @@ mod tests {
         cx.update(|window, cx| window.draw(cx).clear(cx));
         cx.update(|window, cx| window.draw(cx).clear(cx));
         assert!(cx.debug_bounds("default-open-content").is_some());
+    }
+
+    struct Harness {
+        open: bool,
+    }
+
+    impl Render for Harness {
+        fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().when(self.open, |this| {
+                this.child(dropdown_popup(
+                    "dropdown",
+                    Bounds::new(point(px(0.), px(100.)), size(px(120.), px(30.))),
+                    div().debug_selector(|| "surface".into()).size(px(50.)),
+                    cx,
+                ))
+            })
+        }
+    }
+
+    /// A dropdown that reused one animation key across opens would play its
+    /// enter motion the first time and then appear already settled on every
+    /// open after that. That is invisible in any single frame and easy to
+    /// reintroduce by giving the animation a constant id, so it is pinned here.
+    #[gpui::test]
+    fn the_enter_motion_starts_over_every_time_the_dropdown_opens(cx: &mut gpui::TestAppContext) {
+        cx.update(crate::init);
+        let (view, window) = cx.add_window_view(|_, _| Harness { open: true });
+
+        window.update(|window, cx| window.draw(cx).clear(cx));
+        let opening = window.debug_bounds("surface").unwrap().origin;
+
+        // The animation runs off the wall clock, so settling is waited out
+        // rather than stepped. Several times the duration leaves room for a
+        // loaded machine.
+        std::thread::sleep(DROPDOWN_ENTER_DURATION * 4);
+        window.update(|window, cx| window.draw(cx).clear(cx));
+        let settled = window.debug_bounds("surface").unwrap().origin;
+
+        assert!(
+            opening.y < settled.y,
+            "the surface should slide down into place, from {opening:?} to {settled:?}",
+        );
+
+        for open in [false, true] {
+            window.update(|window, cx| {
+                view.update(cx, |this, cx| {
+                    this.open = open;
+                    cx.notify();
+                });
+                window.draw(cx).clear(cx);
+            });
+        }
+
+        let reopening = window.debug_bounds("surface").unwrap().origin;
+        assert!(
+            reopening.y < settled.y,
+            "reopening should start the motion over at {opening:?} rather than showing a \
+             settled surface, but the first frame was already at {reopening:?}",
+        );
     }
 }

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -461,7 +461,6 @@ where
         let bounds = self.state.bounds;
         let allow_open = !(self.state.open || self.state.disabled);
         let outline_visible = self.state.open || (is_focused && !self.state.disabled);
-        let popup_radius = cx.theme().radius.min(px(8.));
 
         let (bg, fg) = input_style(self.state.disabled, cx);
 
@@ -549,40 +548,33 @@ where
                 )
                 .when(self.state.open, |this| {
                     this.child(
-                        deferred(
-                            crate::popover::dropdown_positioner(bounds).child(
-                                div()
-                                    .occlude()
-                                    .map(|this| match self.state.menu_width {
-                                        Length::Auto => this.w(bounds.size.width + px(2.)),
-                                        Length::Definite(w) => this.w(w),
-                                    })
-                                    .child(
-                                        v_flex()
-                                            .occlude()
-                                            .bg(cx.theme().tokens.popover)
-                                            .border_1()
-                                            .border_color(cx.theme().border)
-                                            .rounded(popup_radius)
-                                            .shadow_md()
-                                            .child(
-                                                List::new(&self.state.list)
-                                                    .when_some(
-                                                        self.state.search_placeholder.clone(),
-                                                        |this, placeholder| {
-                                                            this.search_placeholder(placeholder)
-                                                        },
-                                                    )
-                                                    .with_size(self.state.size)
-                                                    .max_h(self.state.menu_max_h)
-                                                    .paddings(Edges::all(px(4.))),
-                                            ),
-                                    )
-                                    .on_mouse_down_out(cx.listener(|this, _, window, cx| {
-                                        this.escape(&Cancel, window, cx);
-                                    })),
-                            ),
-                        )
+                        deferred(crate::popover::dropdown_popup(
+                            ("select-popup", cx.entity_id()),
+                            bounds,
+                            v_flex()
+                                .occlude()
+                                .map(|this| match self.state.menu_width {
+                                    Length::Auto => this.w(bounds.size.width + px(2.)),
+                                    Length::Definite(w) => this.w(w),
+                                })
+                                .popover_style(cx)
+                                .child(
+                                    List::new(&self.state.list)
+                                        .when_some(
+                                            self.state.search_placeholder.clone(),
+                                            |this, placeholder| {
+                                                this.search_placeholder(placeholder)
+                                            },
+                                        )
+                                        .with_size(self.state.size)
+                                        .max_h(self.state.menu_max_h)
+                                        .paddings(Edges::all(px(4.))),
+                                )
+                                .on_mouse_down_out(cx.listener(|this, _, window, cx| {
+                                    this.escape(&Cancel, window, cx);
+                                })),
+                            cx,
+                        ))
                         .with_priority(gpui_base::POPUP_PRIORITY),
                     )
                 }),

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -1,12 +1,72 @@
 pub use crate::component_traits::{Collapsible, Disableable, Selectable};
 pub use crate::sizing::{Sizable, Size, StyleSized};
-use gpui::{App, Corners, Edges, ParentElement, Pixels, StyleRefinement, Styled, Window, div, px};
+use gpui::{
+    App, BoxShadow, Corners, Edges, ParentElement, Pixels, StyleRefinement, Styled, Window, div,
+    hsla, px,
+};
 pub use gpui_base::{FocusableExt, RoleOverride, StyledExt, box_shadow, h_flex, v_flex};
 
 use crate::ActiveTheme as _;
 
 const FOCUS_RING_WIDTH: Pixels = px(3.);
 const FOCUS_RING_OPACITY: f32 = 0.5;
+
+/// Ink of a popover's shadow — the alpha shadcn/ui's `shadow-md` layers carry,
+/// `rgb(0 0 0 / 0.1)`.
+const POPOVER_SHADOW_INK: f32 = 0.1;
+
+/// Ink of the hairline ring standing in for a popover's border.
+///
+/// shadcn/ui draws no border on a popup surface at all: its edge is a 1px
+/// `rgb(0 0 0 / 0.1)` ring spent as a shadow layer. Because the ring is
+/// translucent the shadow shows *through* it, which is what makes the edge read
+/// as part of one grounded surface rather than as an outline with a separate
+/// shadow below it. An opaque border cannot reproduce that — a border composites
+/// over the element's own background, not over the shadow.
+const POPOVER_RING_INK: f32 = 0.1;
+
+/// The colour of a popup surface's hairline ring in this theme.
+///
+/// shadcn spends black on it in light mode and white in dark
+/// (`oklch(1 0 0 / 10%)`), so it follows the foreground rather than the border
+/// token: a fixed black ring would all but vanish on a dark surface.
+pub(crate) fn popover_ring(cx: &App) -> gpui::Hsla {
+    cx.theme().foreground.alpha(POPOVER_RING_INK)
+}
+
+/// shadcn/ui's popup surface shadow — a hairline `ring` plus `shadow-md` — at
+/// `strength` of its full ink.
+///
+/// Callers animating a surface in pass a rising `strength`; a resting surface
+/// passes `1.0`.
+///
+/// The two blurred layers use Tailwind's radii **halved**, which is the
+/// conversion CSS requires and not a taste adjustment. CSS defines a box
+/// shadow's blur radius as twice the gaussian's standard deviation, while GPUI's
+/// shader takes the field as the deviation itself (`gaussian(y, sigma)`).
+/// Copying Tailwind's `6px` and `4px` across therefore spreads the shadow over
+/// twice the distance, which is why [`Styled::shadow_md`] reads as a wide grey
+/// haze next to a browser's compact one.
+///
+/// Measured against shadcn's own render, this lands within a luminance step of
+/// it the whole way down the falloff.
+pub(crate) fn popover_shadow(ring: gpui::Hsla, strength: f32) -> Vec<BoxShadow> {
+    let strength = strength.clamp(0., 1.);
+    let ink = hsla(0., 0., 0., POPOVER_SHADOW_INK * strength);
+    vec![
+        // The ring, sitting in the 1px band outside the surface. No blur, so it
+        // takes the shader's crisp path rather than the gaussian one.
+        BoxShadow::new(px(0.), px(0.), ring.alpha(ring.a * strength))
+            .blur_radius(px(0.))
+            .spread_radius(px(1.)),
+        BoxShadow::new(px(0.), px(4.), ink)
+            .blur_radius(px(3.))
+            .spread_radius(px(-1.)),
+        BoxShadow::new(px(0.), px(2.), ink)
+            .blur_radius(px(2.))
+            .spread_radius(px(-2.)),
+    ]
+}
 
 /// Finished styles that read the theme.
 ///
@@ -32,7 +92,11 @@ pub trait ThemeStyled: Styled + Sized {
     where
         Self: ParentElement;
 
-    /// Give this element the surface, border, shadow and radius of a popover.
+    /// Give this element the surface, edge, shadow and radius of a popover.
+    ///
+    /// This is the one surface every popup shares — Popover, PopupMenu, Select,
+    /// Combobox, DatePicker and the editor's hover popovers — so they cannot
+    /// drift apart. See [`popover_shadow`] for what the shadow is modelled on.
     fn popover_style(self, cx: &App) -> Self;
 }
 
@@ -127,11 +191,11 @@ impl<T: Styled + Sized> ThemeStyled for T {
 
     fn popover_style(self, cx: &App) -> Self {
         let theme = cx.theme();
+        // No border: the edge is the ring inside `popover_shadow`, which is how
+        // shadcn draws it and the only way the shadow can show through it.
         self.bg(theme.popover)
             .text_color(theme.popover_foreground)
-            .border_1()
-            .border_color(theme.border)
-            .shadow_lg()
+            .shadow(popover_shadow(popover_ring(cx), 1.))
             .rounded(theme.radius)
     }
 }

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -1,8 +1,8 @@
 pub use crate::component_traits::{Collapsible, Disableable, Selectable};
 pub use crate::sizing::{Sizable, Size, StyleSized};
 use gpui::{
-    App, BoxShadow, Corners, Edges, ParentElement, Pixels, StyleRefinement, Styled, Window, div,
-    hsla, px,
+    App, BoxShadow, Corners, Edges, Hsla, ParentElement, Pixels, StyleRefinement, Styled, Window,
+    div, hsla, px,
 };
 pub use gpui_base::{FocusableExt, RoleOverride, StyledExt, box_shadow, h_flex, v_flex};
 
@@ -11,9 +11,9 @@ use crate::ActiveTheme as _;
 const FOCUS_RING_WIDTH: Pixels = px(3.);
 const FOCUS_RING_OPACITY: f32 = 0.5;
 
-/// Ink of a popover's shadow — the alpha shadcn/ui's `shadow-md` layers carry,
-/// `rgb(0 0 0 / 0.1)`.
-const POPOVER_SHADOW_INK: f32 = 0.1;
+/// Ink every layer of a surface's shadow carries — the `rgb(0 0 0 / 0.1)`
+/// shadcn/ui spends at each elevation.
+const SURFACE_SHADOW_INK: f32 = 0.1;
 
 /// Ink of the hairline ring standing in for a popover's border.
 ///
@@ -30,7 +30,8 @@ const POPOVER_RING_INK: f32 = 0.1;
 /// shadcn spends black on it in light mode and white in dark
 /// (`oklch(1 0 0 / 10%)`), so it follows the foreground rather than the border
 /// token: a fixed black ring would all but vanish on a dark surface.
-pub(crate) fn popover_ring(cx: &App) -> gpui::Hsla {
+///
+pub(crate) fn popover_ring(cx: &App) -> Hsla {
     cx.theme().foreground.alpha(POPOVER_RING_INK)
 }
 
@@ -50,9 +51,12 @@ pub(crate) fn popover_ring(cx: &App) -> gpui::Hsla {
 ///
 /// Measured against shadcn's own render, this lands within a luminance step of
 /// it the whole way down the falloff.
-pub(crate) fn popover_shadow(ring: gpui::Hsla, strength: f32) -> Vec<BoxShadow> {
+///
+/// The ring is taken as a colour rather than read from the theme here so that an
+/// animation can hold it across frames, where no `App` is in hand.
+pub(crate) fn popover_shadow(ring: Hsla, strength: f32) -> Vec<BoxShadow> {
     let strength = strength.clamp(0., 1.);
-    let ink = hsla(0., 0., 0., POPOVER_SHADOW_INK * strength);
+    let ink = hsla(0., 0., 0., SURFACE_SHADOW_INK * strength);
     vec![
         // The ring, sitting in the 1px band outside the surface. No blur, so it
         // takes the shader's crisp path rather than the gaussian one.
@@ -65,6 +69,26 @@ pub(crate) fn popover_shadow(ring: gpui::Hsla, strength: f32) -> Vec<BoxShadow> 
         BoxShadow::new(px(0.), px(2.), ink)
             .blur_radius(px(2.))
             .spread_radius(px(-2.)),
+    ]
+}
+
+/// shadcn/ui's `shadow-lg`, the elevation it lifts a toast to, at `strength` of
+/// its full ink.
+///
+/// A toast sits higher than a popover and is built differently: shadcn gives it
+/// a real 1px border rather than the translucent ring it puts on a popup, so
+/// there is no ring layer here. Its corner radius is left to the caller.
+///
+/// The radii are Tailwind's halved, for the reason [`popover_shadow`] explains.
+pub(crate) fn toast_shadow(strength: f32) -> Vec<BoxShadow> {
+    let ink = hsla(0., 0., 0., SURFACE_SHADOW_INK * strength.clamp(0., 1.));
+    vec![
+        BoxShadow::new(px(0.), px(10.), ink)
+            .blur_radius(px(7.5))
+            .spread_radius(px(-3.)),
+        BoxShadow::new(px(0.), px(4.), ink)
+            .blur_radius(px(3.))
+            .spread_radius(px(-4.)),
     ]
 }
 

--- a/crates/ui/src/time/date_picker.rs
+++ b/crates/ui/src/time/date_picker.rs
@@ -488,68 +488,58 @@ impl RenderOnce for DatePicker {
             )
             .when(state.open, |this| {
                 this.child(
-                    deferred(
-                        crate::popover::dropdown_positioner(state.bounds).child(
-                            div()
-                                .occlude()
-                                .p_3()
-                                .border_1()
-                                .border_color(cx.theme().border)
-                                .shadow_lg()
-                                .rounded((cx.theme().radius * 2.).min(px(8.)))
-                                .bg(cx.theme().tokens.popover)
-                                .text_color(cx.theme().popover_foreground)
-                                .on_mouse_up_out(
-                                    MouseButton::Left,
-                                    window.listener_for(&self.state, |view, _, window, cx| {
-                                        view.on_escape(&Cancel, window, cx);
-                                    }),
-                                )
-                                .child(
-                                    h_flex()
-                                        .gap_3()
-                                        .h_full()
-                                        .items_start()
-                                        .when_some(self.presets.clone(), |this, presets| {
-                                            this.child(
-                                                v_flex().my_1().gap_2().justify_end().children(
-                                                    presets.into_iter().enumerate().map(
-                                                        |(i, preset)| {
-                                                            Button::new(("preset", i))
-                                                                .small()
-                                                                .ghost()
-                                                                .tab_stop(false)
-                                                                .label(preset.label.clone())
-                                                                .on_click(window.listener_for(
-                                                                    &self.state,
-                                                                    move |this, _, window, cx| {
-                                                                        this.select_preset(
-                                                                            &preset, window, cx,
-                                                                        );
-                                                                    },
-                                                                ))
+                    deferred(crate::popover::dropdown_popup(
+                        ("date-picker-popup", self.state.entity_id()),
+                        state.bounds,
+                        div()
+                            .occlude()
+                            .p_3()
+                            .popover_style(cx)
+                            .on_mouse_up_out(
+                                MouseButton::Left,
+                                window.listener_for(&self.state, |view, _, window, cx| {
+                                    view.on_escape(&Cancel, window, cx);
+                                }),
+                            )
+                            .child(
+                                h_flex()
+                                    .gap_3()
+                                    .h_full()
+                                    .items_start()
+                                    .when_some(self.presets.clone(), |this, presets| {
+                                        this.child(v_flex().my_1().gap_2().justify_end().children(
+                                            presets.into_iter().enumerate().map(|(i, preset)| {
+                                                Button::new(("preset", i))
+                                                    .small()
+                                                    .ghost()
+                                                    .tab_stop(false)
+                                                    .label(preset.label.clone())
+                                                    .on_click(window.listener_for(
+                                                        &self.state,
+                                                        move |this, _, window, cx| {
+                                                            this.select_preset(&preset, window, cx);
                                                         },
-                                                    ),
-                                                ),
-                                            )
-                                        })
-                                        .child(
-                                            Calendar::new(&state.calendar)
-                                                .number_of_months(self.number_of_months)
-                                                .first_day_of_week(state.first_day_of_week)
-                                                .border_0()
-                                                .rounded_none()
-                                                .p_0()
-                                                .map(|this| match self.size {
-                                                    Size::Small => this.w(px(196.) * month_count),
-                                                    Size::Large => this.w(px(280.) * month_count),
-                                                    _ => this.w(px(224.) * month_count),
-                                                })
-                                                .with_size(self.size),
-                                        ),
-                                ),
-                        ),
-                    )
+                                                    ))
+                                            }),
+                                        ))
+                                    })
+                                    .child(
+                                        Calendar::new(&state.calendar)
+                                            .number_of_months(self.number_of_months)
+                                            .first_day_of_week(state.first_day_of_week)
+                                            .border_0()
+                                            .rounded_none()
+                                            .p_0()
+                                            .map(|this| match self.size {
+                                                Size::Small => this.w(px(196.) * month_count),
+                                                Size::Large => this.w(px(280.) * month_count),
+                                                _ => this.w(px(224.) * month_count),
+                                            })
+                                            .with_size(self.size),
+                                    ),
+                            ),
+                        cx,
+                    ))
                     .with_priority(gpui_base::POPUP_PRIORITY),
                 )
             })


### PR DESCRIPTION
## Summary

Two things: **one shared popup surface** matching shadcn/ui, and an **open animation** for the dropdowns.

Every popup surface previously rolled its own background, border, radius and shadow, so they had already drifted — two used `shadow_md`, one `shadow_lg`, three different radii. `popover_style` now owns the whole surface and all eight popups route through it: Popover, PopupMenu, Select, Combobox, DatePicker, the editor's hover + LSP popovers, and the plot tooltip.

<img width="364" height="317" alt="image" src="https://github.com/user-attachments/assets/f5f11156-9dc5-4d99-89d7-72f29b7f03ee" />

<img width="335" height="317" alt="image" src="https://github.com/user-attachments/assets/7ab32f95-07df-4855-b420-e61f2525e57f" />

<img width="358" height="322" alt="image" src="https://github.com/user-attachments/assets/c843ee6c-3fd9-4923-9d7b-4423fce06486" />

## The surface

Read off shadcn's *computed* style rather than inferred. shadcn draws **no border** on a popup — its edge is a 1px translucent ring spent as a shadow layer:

```
oklab(0 0 0 / 0.1)  0 0 0 1px       ← hairline ring, no blur
rgba(0,0,0,0.1)     0 4px 6px -1px  ← shadow-md
rgba(0,0,0,0.1)     0 2px 4px -2px
```

Because the ring is translucent the shadow shows *through* it, which is what makes the edge read as one grounded surface rather than an outline with a detached shadow under it. An opaque border cannot reproduce this: a border composites over the element's own background, never over the shadow. The ring follows the foreground token, since shadcn spends black on it in light mode and `oklch(1 0 0 / 10%)` in dark.

## Two GPUI details this depended on

**Shadow blur is σ, not CSS blur.** The shader passes `blur_radius` straight into `gaussian(y, sigma)`, but CSS defines a box shadow's blur radius as *twice* the standard deviation. `shadow_md` copies Tailwind's numbers verbatim, so it spreads a shadow over twice the distance and reads as a wide grey haze. Halving the radii is the conversion, not taste. **Every other `shadow_*` preset has the same problem** — this PR only corrects the popup surfaces; fixing it globally is a much larger visual change.

**No group compositing.** `opacity` multiplies into each primitive's alpha separately, and a drop shadow paints as a full blurred rect *under* the element (the shader only cuts the element out when `inset != 0`). So a fading surface does not hide its own shadow, and it shows through as a dark slab mid-fade. The motion ramps the shadow's ink by the **cube** of the fade, keeping it invisible until the surface is opaque enough to cover it and still landing on the resting shadow.

## The motion

150ms, ease-out, opacity 0→1 plus an 8px slide out of the trigger's edge — shadcn's `fade-in-0` + `slide-in-from-top-2`. Three deliberate departures, documented at `dropdown_popup`:

- **No `zoom-in-95`.** GPUI has no element transform; only images and SVGs take a `TransformationMatrix`. I did not fake it with a size animation, which would clip rather than scale.
- **No exit motion.** A closing dropdown stops rendering in the same frame `open` flips, so playing one means keeping the surface mounted past the close — a change to each component's open state machine.
- **Slide direction is fixed to "from above".** `Positioner` resolves the final side during layout and does not report it back, so a dropdown that flips above its trigger slides the opposite way. 8px over 150ms, in the rare case it happens.

Reduced motion needs no handling — GPUI's animation element adopts the final value on the first frame when the system asks.

## Behaviour change

`popover_style` no longer draws a border, so popup content is 1px less inset on each side. This is faithful to shadcn (its box has no border either, and the ring sits outside), but it affects every popup:

```diff
  fn popover_style(self, cx: &App) -> Self {
      self.bg(theme.popover)
          .text_color(theme.popover_foreground)
-         .border_1()
-         .border_color(theme.border)
-         .shadow_lg()
+         .shadow(popover_shadow(popover_ring(cx), 1.))
          .rounded(theme.radius)
  }
```

Radii are also unified on `theme.radius` — DatePicker was `(radius * 2).min(8)`, Select and Combobox `radius.min(8)`. Select and Combobox additionally lose a wrapper div, since GPUI takes a shadow's shape from the element it is set on and a wrapper of a different size throws it out of register.

## Test plan

Verified by **pixel measurement**, not by eye — earlier eyeballed attempts converged on the wrong answer twice.

- Decoded the rendered PNGs and compared luminance falloff below the surface edge against shadcn's own render. The shipped `popover_style` tracks it **within ±1 step at every one of 20 rows** (fit error 7, from 1442 for the previous border construction; the edge alone was off by 28 steps).
- Confirmed the ring keeps a visible edge on the **dark** theme, since removing the border was the real risk of this change.
- `cargo clippy -p gpui-component --all-targets -- -D warnings` clean; 455 tests pass; `rustfmt` and `typos` clean.
- Added `the_enter_motion_starts_over_every_time_the_dropdown_opens`, which pins that reopening replays the animation. A constant animation id would make it play once and then show a settled surface on every later open — invisible in any single frame and easy to reintroduce. The test asserts only that each open's first frame sits above the resting position, so it does not assert presentation dimensions.

**Not yet verified visually: the animation itself.** The shadow work is measured, but I have not watched the fade run in the app — please confirm the dark slab is gone on open.

## Notification

A toast turned out **not** to be the popup surface. Read off shadcn's live computed style, it keeps a real 1px border rather than the translucent ring, and sits a whole elevation higher:

```
border-width: 1px, color: --border            ← real border, not a ring
box-shadow: 0 10px 15px -3px, 0 4px 6px -4px  ← shadow-lg
```

So this adds a separate `toast_shadow` instead of forcing notifications through `popover_style`. Measured at the card's bottom edge against shadcn's render:

| | border | +2 | +6 | +10 | +14 | +19 | total |
|---|---|---|---|---|---|---|---|
| shadcn | 26, 26 | 32 | 24 | 18 | 14 | **10** | 392 |
| ours, before | 26, 26 | 28 | 21 | 14 | 8 | **4** | 313 |

The border already matched; `shadow_md` was simply a whole elevation too low, dying at +19 where shadcn's is still clearly visible. **The border and radius are unchanged.**

The notification also already had a workaround for the same shadow bleed the dropdowns hit — `.when(opacity < 0.85, shadow_none())`, which drops the shadow outright and pops it back in mid-fade. That is now the same cube ramp, and it is applied to the **exit** fade too, which had no workaround at all and showed the slab on dismiss.

⚠️ Unlike the popover work, **the toast elevation is not pixel-measured** — the machine's screen locked before I could capture it. It applies the identical σ conversion that measured within ±1 step for the popover, and the arithmetic predicts ~37 at the edge against shadcn's 32, but that is reasoning rather than measurement. Worth an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

