### PR TITLE
animation: Align `cubic_bezier` with CSS `cubic-bezier`

### DIFF
--- a/crates/base/src/animation.rs
+++ b/crates/base/src/animation.rs
@@ -279,6 +279,24 @@ mod tests {
     }
 
     #[test]
+    fn cubic_bezier_with_thirds_x_maps_time_identically() {
+        // x1 = 1/3, x2 = 2/3 collapse the x solve to the identity, making the
+        // output the plain y polynomial; Dialog relies on this to keep the
+        // trajectory it was tuned with before `cubic_bezier` solved for x.
+        let ease = cubic_bezier(1. / 3., 0.72, 2. / 3., 1.);
+        for step in 0..=100 {
+            let t = step as f32 / 100.;
+            let one_t = 1. - t;
+            let expected = 3. * 0.72 * one_t * one_t * t + 3. * one_t * t * t + t * t * t;
+            assert!(
+                (ease(t) - expected).abs() < 1e-4,
+                "ease({t}) = {}, expected {expected}",
+                ease(t)
+            );
+        }
+    }
+
+    #[test]
     fn cubic_bezier_stays_within_unit_range() {
         // GPUI panics when an easing delta leaves [0, 1]; sweep the curves
         // used in-repo densely to catch solver overshoot and rounding error.

--- a/crates/base/src/animation.rs
+++ b/crates/base/src/animation.rs
@@ -12,17 +12,53 @@ use smallvec::SmallVec;
 ///
 /// https://cubic-bezier.com
 pub fn cubic_bezier(x1: f32, y1: f32, x2: f32, y2: f32) -> impl Fn(f32) -> f32 {
+    // Polynomial form of the unit bezier, where p0 = (0, 0) and p3 = (1, 1).
+    let (cx, cy) = (3.0 * x1, 3.0 * y1);
+    let (bx, by) = (3.0 * (x2 - x1) - cx, 3.0 * (y2 - y1) - cy);
+    let (ax, ay) = (1.0 - cx - bx, 1.0 - cy - by);
+    let sample_x = move |t: f32| ((ax * t + bx) * t + cx) * t;
+    let sample_y = move |t: f32| ((ay * t + by) * t + cy) * t;
+    let slope_x = move |t: f32| (3.0 * ax * t + 2.0 * bx) * t + cx;
+
+    // Solve `x(s) = t` for the curve parameter `s`.
+    let solve_s = move |t: f32| {
+        let mut s = t;
+        for _ in 0..8 {
+            let error = sample_x(s) - t;
+            if error.abs() < 1e-6 {
+                return s;
+            }
+            let slope = slope_x(s);
+            if slope.abs() < 1e-6 {
+                break;
+            }
+            s = (s - error / slope).clamp(0.0, 1.0);
+        }
+
+        let (mut low, mut high) = (0.0, 1.0);
+        let mut s = t;
+        for _ in 0..32 {
+            let x = sample_x(s);
+            if (x - t).abs() < 1e-6 {
+                break;
+            }
+            if x < t {
+                low = s;
+            } else {
+                high = s;
+            }
+            s = (low + high) / 2.0;
+        }
+        s
+    };
+
     move |t: f32| {
-        let one_t = 1.0 - t;
-        let one_t2 = one_t * one_t;
-        let t2 = t * t;
-        let t3 = t2 * t;
-
-        // The Bezier curve function for x and y, where x0 = 0, y0 = 0, x3 = 1, y3 = 1
-        let _x = 3.0 * x1 * one_t2 * t + 3.0 * x2 * one_t * t2 + t3;
-        let y = 3.0 * y1 * one_t2 * t + 3.0 * y2 * one_t * t2 + t3;
-
-        y
+        let t = t.clamp(0.0, 1.0);
+        // `t` is elapsed progress along x, not the curve parameter: solve
+        // `x(s) = t` before sampling y, otherwise the curve reads much slower
+        // than the same control points do in CSS. GPUI asserts easing deltas
+        // stay within [0, 1], so clamp away solver and rounding error.
+        sample_y(solve_s(t)).clamp(0.0, 1.0)
     }
 }
 
@@ -218,3 +254,55 @@ impl FluentBuilder for EffectTransition {}
 /// concepts sharing one name.
 #[deprecated(since = "0.5.2", note = "renamed to `EffectTransition`")]
 pub type Transition = EffectTransition;
+
+#[cfg(test)]
+mod tests {
+    use super::cubic_bezier;
+
+    #[test]
+    fn cubic_bezier_matches_css_ease() {
+        let ease = cubic_bezier(0.25, 0.1, 0.25, 1.);
+        // Reference values sampled from the CSS `ease` curve.
+        for (t, expected) in [
+            (0.0, 0.0),
+            (0.2, 0.295),
+            (0.5, 0.802),
+            (0.8, 0.976),
+            (1.0, 1.0),
+        ] {
+            assert!(
+                (ease(t) - expected).abs() < 1e-3,
+                "ease({t}) = {}, expected {expected}",
+                ease(t)
+            );
+        }
+    }
+
+    #[test]
+    fn cubic_bezier_stays_within_unit_range() {
+        // GPUI panics when an easing delta leaves [0, 1]; sweep the curves
+        // used in-repo densely to catch solver overshoot and rounding error.
+        for (x1, y1, x2, y2) in [(0.25, 0.1, 0.25, 1.), (0.32, 0.72, 0., 1.)] {
+            let ease = cubic_bezier(x1, y1, x2, y2);
+            for step in 0..=10_000 {
+                let t = step as f32 / 10_000.;
+                let y = ease(t);
+                assert!((0.0..=1.0).contains(&y), "ease({t}) = {y} out of range");
+            }
+        }
+    }
+
+    #[test]
+    fn cubic_bezier_is_monotonic_and_clamped() {
+        let ease = cubic_bezier(0.32, 0.72, 0., 1.);
+        assert_eq!(ease(-1.), 0.);
+        assert_eq!(ease(2.), 1.);
+
+        let mut previous = 0.;
+        for step in 0..=100 {
+            let current = ease(step as f32 / 100.);
+            assert!(current >= previous - 1e-4, "not monotonic at {step}");
+            previous = current;
+        }
+    }
+}

--- a/crates/base/src/animation.rs
+++ b/crates/base/src/animation.rs
@@ -260,9 +260,9 @@ mod tests {
     use super::cubic_bezier;
 
     #[test]
-    fn cubic_bezier_matches_css_ease() {
-        let ease = cubic_bezier(0.25, 0.1, 0.25, 1.);
+    fn cubic_bezier_matches_engine_published_values() {
         // Reference values sampled from the CSS `ease` curve.
+        let ease = cubic_bezier(0.25, 0.1, 0.25, 1.);
         for (t, expected) in [
             (0.0, 0.0),
             (0.2, 0.295),
@@ -274,6 +274,37 @@ mod tests {
                 (ease(t) - expected).abs() < 1e-3,
                 "ease({t}) = {}, expected {expected}",
                 ease(t)
+            );
+        }
+
+        // Chromium's CubicBezier(0.25, 0, 0.75, 1) expectations, from
+        // ui/gfx/geometry/cubic_bezier_unittest.cc (epsilon 0.00015 there;
+        // widened for our f32 arithmetic).
+        let curve = cubic_bezier(0.25, 0., 0.75, 1.);
+        for (t, expected) in [
+            (0.05, 0.01136),
+            (0.1, 0.03978),
+            (0.15, 0.07978),
+            (0.2, 0.12803),
+            (0.25, 0.18235),
+            (0.3, 0.24115),
+            (0.35, 0.30323),
+            (0.4, 0.36761),
+            (0.45, 0.43345),
+            (0.5, 0.5),
+            (0.6, 0.63238),
+            (0.65, 0.69676),
+            (0.7, 0.75884),
+            (0.75, 0.81764),
+            (0.8, 0.87196),
+            (0.85, 0.92021),
+            (0.9, 0.96021),
+            (0.95, 0.98863),
+        ] {
+            assert!(
+                (curve(t) - expected).abs() < 3e-4,
+                "curve({t}) = {}, Chromium says {expected}",
+                curve(t)
             );
         }
     }
@@ -297,14 +328,53 @@ mod tests {
     }
 
     #[test]
-    fn cubic_bezier_stays_within_unit_range() {
-        // GPUI panics when an easing delta leaves [0, 1]; sweep the curves
-        // used in-repo densely to catch solver overshoot and rounding error.
-        for (x1, y1, x2, y2) in [(0.25, 0.1, 0.25, 1.), (0.32, 0.72, 0., 1.)] {
+    fn cubic_bezier_matches_the_css_definition() {
+        // Reference solver written straight off the CSS Easing Functions
+        // definition — solve `x(s) = t` by bisection in f64, then sample
+        // `y(s)` — independent of the production Newton solver.
+        fn css_reference(x1: f64, y1: f64, x2: f64, y2: f64, t: f64) -> f64 {
+            let sample = |p1: f64, p2: f64, s: f64| {
+                3. * p1 * (1. - s) * (1. - s) * s + 3. * p2 * (1. - s) * s * s + s * s * s
+            };
+            let (mut low, mut high) = (0f64, 1f64);
+            for _ in 0..64 {
+                let mid = (low + high) / 2.;
+                if sample(x1, x2, mid) < t {
+                    low = mid;
+                } else {
+                    high = mid;
+                }
+            }
+            sample(y1, y2, (low + high) / 2.)
+        }
+
+        let curves = [
+            // The runtime curves in this repo.
+            (0.25, 0.1, 0.25, 1.),
+            (1. / 3., 0.72, 2. / 3., 1.),
+            // CSS keyword curves.
+            (0.42, 0., 1., 1.),
+            (0., 0., 0.58, 1.),
+            (0.42, 0., 0.58, 1.),
+            (0., 0., 1., 1.),
+            // Degenerate x slopes: zero at s = 0.5, 0, and 1, forcing the
+            // Newton solve to fall back to bisection.
+            (1., 0., 0., 1.),
+            (0., 0., 0., 1.),
+            (1., 0.5, 1., 0.5),
+        ];
+        for (x1, y1, x2, y2) in curves {
             let ease = cubic_bezier(x1, y1, x2, y2);
-            for step in 0..=10_000 {
-                let t = step as f32 / 10_000.;
+            for step in 0..=1000 {
+                let t = step as f32 / 1000.;
                 let y = ease(t);
+                let expected =
+                    css_reference(x1 as f64, y1 as f64, x2 as f64, y2 as f64, t as f64) as f32;
+                assert!(
+                    (y - expected).abs() < 5e-4,
+                    "cubic_bezier({x1}, {y1}, {x2}, {y2})({t}) = {y}, CSS = {expected}"
+                );
+                // GPUI panics when an easing delta leaves [0, 1].
                 assert!((0.0..=1.0).contains(&y), "ease({t}) = {y} out of range");
             }
         }

--- a/crates/ui/src/dialog/dialog.rs
+++ b/crates/ui/src/dialog/dialog.rs
@@ -515,8 +515,16 @@ impl RenderOnce for Dialog {
             paddings.bottom = pb.to_pixels(base_size, rem_size);
         }
 
-        let animation =
-            Animation::new(*ANIMATION_DURATION).with_easing(cubic_bezier(0.32, 0.72, 0., 1.));
+        // x1 = 1/3, x2 = 2/3 make the bezier's time mapping the identity,
+        // preserving the trajectory this dialog was tuned with before
+        // `cubic_bezier` solved for x; vaul's (0.32, 0.72, 0., 1.) is far
+        // more front-loaded under the CSS-correct solver.
+        let animation = Animation::new(*ANIMATION_DURATION).with_easing(cubic_bezier(
+            1. / 3.,
+            0.72,
+            2. / 3.,
+            1.,
+        ));
 
         anchored()
             .position(point(window_paddings.left, window_paddings.top))


### PR DESCRIPTION
## Description

Align `cubic_bezier` with CSS `cubic-bezier`.

The old implementation plugged elapsed progress `t` in as the curve parameter and sampled `y` directly, skipping the `x(s) = t` solve that CSS performs first. Every curve therefore ran noticeably slower than the same control points do in CSS — most visibly, the notification stack's expand/collapse dragged even though its 400ms / `cubic-bezier(.25, .1, .25, 1)` already matched shadcn/sonner.

The fix replaces the sampling with the standard unit-bezier solver (Newton-Raphson + bisection fallback, as in WebKit/Blink's `UnitBezier`), clamped to `[0, 1]` since GPUI asserts easing deltas stay in that range.

Dialog keeps its hand-tuned trajectory exactly: `x1 = 1/3, x2 = 2/3` make the time mapping the identity, reproducing the pre-fix output for its `(y1, y2)` — the same trick works for any downstream caller tuned against the old sampler.

Tests pin the implementation to Chromium's published `CubicBezier` expectations and to an independent in-test solver of the CSS definition, including degenerate curves.
