### PR TITLE
popover: Tie the deferred interaction context to a token's lifetime

### DIFF
--- a/crates/base/src/global_state.rs
+++ b/crates/base/src/global_state.rs
@@ -1,11 +1,18 @@
-use std::collections::HashSet;
+use std::rc::{Rc, Weak};
 
-use gpui::{App, ElementId, FocusHandle, Global, OwnedMenu};
+use gpui::{App, Global, OwnedMenu};
+
+/// Holds the deferred interaction context open for as long as it is alive.
+///
+/// Handed out by [`GlobalState::register_deferred_popover`]; drop it to close
+/// the context again. The registry only ever weighs the token's liveness, so
+/// there is nothing inside to read.
+pub struct DeferredPopover(#[allow(dead_code)] Rc<()>);
 
 /// Application-wide state shared by Base behaviors.
 pub struct GlobalState {
     app_menus: Vec<OwnedMenu>,
-    deferred_popovers: HashSet<ElementId>,
+    deferred_popovers: Vec<Weak<()>>,
     suppress_text_selection: bool,
 }
 
@@ -15,7 +22,7 @@ impl GlobalState {
     fn new() -> Self {
         Self {
             app_menus: Vec::new(),
-            deferred_popovers: HashSet::new(),
+            deferred_popovers: Vec::new(),
             suppress_text_selection: false,
         }
     }
@@ -69,20 +76,31 @@ impl GlobalState {
     /// Returns whether any deferred popup currently owns an open interaction
     /// context.
     pub fn is_in_deferred_context(cx: &App) -> bool {
-        !Self::global(cx).deferred_popovers.is_empty()
-    }
-
-    /// Registers an open deferred popup by its focus identity.
-    pub fn register_deferred_popover(focus_handle: &FocusHandle, cx: &mut App) {
-        Self::global_mut(cx)
+        Self::global(cx)
             .deferred_popovers
-            .insert(format!("{focus_handle:?}").into());
+            .iter()
+            .any(|popover| popover.strong_count() > 0)
     }
 
-    /// Removes a deferred popup from the open interaction context.
-    pub fn unregister_deferred_popover(focus_handle: &FocusHandle, cx: &mut App) {
-        let id: ElementId = format!("{focus_handle:?}").into();
-        Self::global_mut(cx).deferred_popovers.remove(&id);
+    /// Registers an open deferred popup, which stays registered for as long as
+    /// the returned token is held.
+    ///
+    /// A token rather than an identifier, because popup state is routinely
+    /// dropped without ever being closed: state that stops being rendered — a
+    /// popover scrolled out of a virtual list, a panel closed while its menu is
+    /// open — is collected at the end of the frame, with no chance to
+    /// deregister. A registration that outlived its popup would leave the
+    /// application believing a popup is open forever, and everything that
+    /// steps aside for open popups (the native context menu of a text input,
+    /// say) would stay disabled for the rest of the session.
+    pub fn register_deferred_popover(cx: &mut App) -> DeferredPopover {
+        let token = Rc::new(());
+        let state = Self::global_mut(cx);
+        state
+            .deferred_popovers
+            .retain(|popover| popover.strong_count() > 0);
+        state.deferred_popovers.push(Rc::downgrade(&token));
+        DeferredPopover(token)
     }
 }
 
@@ -101,11 +119,36 @@ mod tests {
             GlobalState::reset_text_selection_suppression(cx);
             assert!(!GlobalState::is_text_selection_suppressed(cx));
 
-            let focus_handle = cx.focus_handle();
             assert!(!GlobalState::is_in_deferred_context(cx));
-            GlobalState::register_deferred_popover(&focus_handle, cx);
+            let popover = GlobalState::register_deferred_popover(cx);
             assert!(GlobalState::is_in_deferred_context(cx));
-            GlobalState::unregister_deferred_popover(&focus_handle, cx);
+            drop(popover);
+            assert!(!GlobalState::is_in_deferred_context(cx));
+        });
+    }
+
+    /// Popup state is routinely dropped without being closed first, and a
+    /// registration that survived it would disable everything that steps aside
+    /// for an open popup, permanently.
+    #[gpui::test]
+    fn a_dropped_registration_closes_the_deferred_context(cx: &mut gpui::TestAppContext) {
+        cx.update(|cx| {
+            GlobalState::init(cx);
+
+            let outer = GlobalState::register_deferred_popover(cx);
+            {
+                let _inner = GlobalState::register_deferred_popover(cx);
+                assert!(GlobalState::is_in_deferred_context(cx));
+            }
+            assert!(GlobalState::is_in_deferred_context(cx));
+
+            drop(outer);
+            assert!(!GlobalState::is_in_deferred_context(cx));
+
+            // Registering again must not resurrect the collected ones.
+            let popover = GlobalState::register_deferred_popover(cx);
+            assert_eq!(GlobalState::global(cx).deferred_popovers.len(), 1);
+            drop(popover);
             assert!(!GlobalState::is_in_deferred_context(cx));
         });
     }

--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -97,7 +97,7 @@ pub use focus_trap::FocusTrapElement;
 #[doc(hidden)]
 pub use focus_trap::active_focus_trap;
 pub use geometry::*;
-pub use global_state::GlobalState;
+pub use global_state::{DeferredPopover, GlobalState};
 pub use history::{History, HistoryItem};
 pub use hover_card::{HoverCard, HoverCardState};
 pub use index_path::IndexPath;

--- a/crates/base/src/popover.rs
+++ b/crates/base/src/popover.rs
@@ -7,7 +7,7 @@ use gpui::{
     prelude::FluentBuilder as _,
 };
 
-use crate::{GlobalState, Popup, Selectable, actions::Cancel};
+use crate::{DeferredPopover, GlobalState, Popup, Selectable, actions::Cancel};
 
 const CONTEXT: &str = "Popover";
 
@@ -29,6 +29,9 @@ pub struct PopoverState {
     open: bool,
     on_open_change: Option<OpenChangeHandler>,
     dismiss_subscription: Option<Subscription>,
+    /// Held while open, so that a state collected without being closed — this
+    /// lives in element state — takes its registration with it.
+    deferred_context: Option<DeferredPopover>,
 }
 
 impl PopoverState {
@@ -40,6 +43,7 @@ impl PopoverState {
             open: default_open,
             on_open_change: None,
             dismiss_subscription: None,
+            deferred_context: None,
         }
     }
 
@@ -62,11 +66,7 @@ impl PopoverState {
     #[doc(hidden)]
     pub fn set_open(&mut self, open: bool, cx: &mut Context<Self>) {
         self.open = open;
-        if open {
-            GlobalState::register_deferred_popover(&self.focus_handle, cx);
-        } else {
-            GlobalState::unregister_deferred_popover(&self.focus_handle, cx);
-        }
+        self.deferred_context = open.then(|| GlobalState::register_deferred_popover(cx));
     }
 
     #[doc(hidden)]
@@ -310,6 +310,24 @@ mod tests {
     use super::*;
     use gpui::{AppContext as _, Context, Render, Styled as _, point, px};
     use std::{cell::RefCell, rc::Rc};
+
+    /// Popover state lives in element state, which is collected as soon as it
+    /// stops being rendered — a trigger scrolled out of a virtual list, a panel
+    /// closed with its menu open. A registration that outlived it would leave
+    /// the application believing a popup is open for the rest of the session.
+    #[gpui::test]
+    fn a_state_dropped_while_open_closes_the_deferred_context(cx: &mut gpui::TestAppContext) {
+        let state = cx.update(|cx| {
+            GlobalState::init(cx);
+            let state = cx.new(|cx| PopoverState::new(false, cx));
+            state.update(cx, |state, cx| state.set_open(true, cx));
+            assert!(GlobalState::is_in_deferred_context(cx));
+            state
+        });
+
+        cx.update(|_| drop(state));
+        cx.update(|cx| assert!(!GlobalState::is_in_deferred_context(cx)));
+    }
 
     #[gpui::test]
     fn open_state_registers_and_unregisters_deferred_context(cx: &mut gpui::TestAppContext) {

--- a/crates/ui/src/combobox.rs
+++ b/crates/ui/src/combobox.rs
@@ -527,12 +527,7 @@ where
 
     fn set_open(&mut self, open: bool, cx: &mut Context<Self>) {
         self.state.open = open;
-
-        if self.state.open {
-            GlobalState::register_deferred_popover(&self.state.focus_handle, cx)
-        } else {
-            GlobalState::unregister_deferred_popover(&self.state.focus_handle, cx)
-        }
+        self.state.deferred_context = open.then(|| GlobalState::register_deferred_popover(cx));
 
         cx.notify();
     }

--- a/crates/ui/src/searchable_list/state.rs
+++ b/crates/ui/src/searchable_list/state.rs
@@ -3,6 +3,8 @@ use gpui::{
     Pixels, StyleRefinement, Subscription, Window,
 };
 
+use gpui_base::DeferredPopover;
+
 use crate::{IndexPath, Size, list::ListState, searchable_list::adapter::SearchableListAdapter};
 
 use super::delegate::{SearchableListDelegate, SearchableListItem};
@@ -20,6 +22,9 @@ where
     pub(crate) list: Entity<ListState<SearchableListAdapter<D>>>,
     pub(crate) selection: Vec<(IndexPath, D::Item)>,
     pub(crate) open: bool,
+    /// Held while the popup is open, so that a component dropped without
+    /// closing it first takes its registration with it.
+    pub(crate) deferred_context: Option<DeferredPopover>,
     pub(crate) bounds: Bounds<Pixels>,
 
     // Shared options
@@ -108,6 +113,7 @@ where
             list,
             selection,
             open: false,
+            deferred_context: None,
             bounds: Bounds::default(),
             size: Size::default(),
             style: StyleRefinement::default(),

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -393,12 +393,7 @@ where
 
     fn set_open(&mut self, open: bool, cx: &mut Context<Self>) {
         self.state.open = open;
-
-        if self.state.open {
-            GlobalState::register_deferred_popover(&self.state.focus_handle, cx)
-        } else {
-            GlobalState::unregister_deferred_popover(&self.state.focus_handle, cx)
-        }
+        self.state.deferred_context = open.then(|| GlobalState::register_deferred_popover(cx));
 
         cx.notify();
     }


### PR DESCRIPTION
## Summary

- `GlobalState`'s registry of open deferred popups was keyed by a focus handle's debug string, added in `set_open(true)` and removed in `set_open(false)`. Popup state lives in element state, so it is collected as soon as it stops being rendered — a trigger scrolled out of a virtual list, a panel closed with its menu open — and a state collected while still open never runs the removal.
- The entry then stays forever: `FocusId` is a slotmap key, so a later popover never reproduces the same string and cannot clear it by accident. From that point `is_in_deferred_context` is permanently true, and the only thing that reads it — the native right-click menu of every text input (`input/base/state.rs`) — silently stops working for the rest of the session. Probed on `main`: dropping an open `PopoverState` leaves `is_in_deferred_context` at `true`.
- `register_deferred_popover` now returns a `DeferredPopover` token and the registry holds `Weak<()>`s, so a registration cannot outlive the state that owns it. `PopoverState` and the shared searchable-list state behind Select and Combobox hold the token; `unregister_deferred_popover` is gone.

Behaviour is unchanged on every path that already paired its calls correctly — this only closes the context on paths that never got to close it at all.

**Breaking:** `GlobalState::register_deferred_popover` no longer takes a `&FocusHandle` and returns a token that must be held; `GlobalState::unregister_deferred_popover` is removed. All three call sites in this repository are updated.

## Test plan

- [x] `cargo test -p gpui-base` — 375 passed, including two new tests: a dropped registration closes the context, and a `PopoverState` dropped while open closes it too. Both fail if the token is leaked with `mem::forget`.
- [x] `cargo test -p gpui-component` — 423 + 30 + 5 + 4 + 1 passed
- [x] `cargo clippy -p gpui-base -p gpui-component --all-targets` clean, `cargo +nightly fmt --all`
- [ ] Open a Select / Combobox, close it, then right-click a text input: the native menu appears
- [ ] Open a popover inside a scrolling list, scroll it far out of the rendered range, then right-click a text input: the native menu still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)