### PR TITLE
theme: Follow the global radius setting everywhere

### DIFF
--- a/crates/story/src/gallery.rs
+++ b/crates/story/src/gallery.rs
@@ -1,6 +1,6 @@
 use gpui::{prelude::*, *};
 use gpui_component::{
-    Icon, IconName,
+    Icon, IconName, ThemeStyled as _,
     button::{Button, ButtonVariants as _},
     h_flex,
     input::{Input, InputEvent, InputState},
@@ -268,11 +268,8 @@ impl Render for Gallery {
                                     .child(
                                         div()
                                             .bg(cx.theme().sidebar_accent)
-                                            .rounded_full()
+                                            .rounded_full_style(cx)
                                             .px_1()
-                                            .when(cx.theme().radius.is_zero(), |this| {
-                                                this.rounded(px(0.))
-                                            })
                                             .flex_1()
                                             .mx_1()
                                             .child(

--- a/crates/story/src/stories/accordion_story.rs
+++ b/crates/story/src/stories/accordion_story.rs
@@ -1,6 +1,6 @@
 use gpui::{
     Action, App, AppContext, Context, Entity, FocusHandle, Focusable, Hsla, InteractiveElement,
-    IntoElement, ParentElement as _, Render, StyleRefinement, Styled as _, Window, div,
+    IntoElement, ParentElement as _, Pixels, Render, StyleRefinement, Styled as _, Window, div,
     prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
@@ -26,6 +26,15 @@ enum ToggleOption {
     Bordered,
 }
 
+/// The theme-derived values a settings row draws with, read once so the row
+/// builder itself needs no app context.
+#[derive(Clone, Copy)]
+struct SettingsItemStyle {
+    icon_bg: Hsla,
+    muted: Hsla,
+    icon_radius: Pixels,
+}
+
 /// A settings row: the icon sits in a rounded square, and the content lines up
 /// with the title rather than with the icon.
 fn settings_item(
@@ -34,9 +43,14 @@ fn settings_item(
     title: &'static str,
     tag: Option<Tag>,
     body: &'static str,
-    icon_bg: Hsla,
-    muted: Hsla,
+    style: SettingsItemStyle,
 ) -> AccordionItem {
+    let SettingsItemStyle {
+        icon_bg,
+        muted,
+        icon_radius,
+    } = style;
+
     item.title(
         h_flex()
             .gap_2()
@@ -47,7 +61,7 @@ fn settings_item(
                     .size(px(32.))
                     .items_center()
                     .justify_center()
-                    .rounded(px(8.))
+                    .rounded(icon_radius)
                     .bg(icon_bg)
                     .child(Icon::new(icon).small().text_color(muted)),
             )
@@ -129,8 +143,11 @@ impl Focusable for AccordionStory {
 
 impl Render for AccordionStory {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let icon_bg = cx.theme().secondary.opacity(0.5);
-        let muted_fg = cx.theme().muted_foreground;
+        let settings_item_style = SettingsItemStyle {
+            icon_bg: cx.theme().secondary.opacity(0.5),
+            muted: cx.theme().muted_foreground,
+            icon_radius: cx.theme().radius,
+        };
 
         v_flex()
             .w_full()
@@ -243,7 +260,7 @@ impl Render for AccordionStory {
                     div()
                         .w(px(480.))
                         .p(px(4.))
-                        .rounded(px(16.))
+                        .rounded(cx.theme().radius_lg * 2.)
                         .bg(cx.theme().secondary.opacity(0.5))
                         .border_1()
                         .border_color(cx.theme().border.opacity(0.5))
@@ -260,8 +277,7 @@ impl Render for AccordionStory {
                                         "Manage your account preferences, security settings, \
                                     and personal information. You can also configure \
                                     two-factor authentication here.",
-                                        icon_bg,
-                                        muted_fg,
+                                        settings_item_style,
                                     )
                                     .open(self.styled_open_ixs.contains(&0))
                                 })
@@ -273,8 +289,7 @@ impl Render for AccordionStory {
                                         None,
                                         "Control who can see your profile and how your data \
                                     is used.",
-                                        icon_bg,
-                                        muted_fg,
+                                        settings_item_style,
                                     )
                                     .open(self.styled_open_ixs.contains(&1))
                                 })
@@ -286,8 +301,7 @@ impl Render for AccordionStory {
                                         None,
                                         "Browse the documentation, or get in touch with the \
                                     support team.",
-                                        icon_bg,
-                                        muted_fg,
+                                        settings_item_style,
                                     )
                                     .open(self.styled_open_ixs.contains(&2))
                                 })

--- a/crates/story/src/stories/chart_story/chart_story.rs
+++ b/crates/story/src/stories/chart_story/chart_story.rs
@@ -380,6 +380,7 @@ impl Render for ChartStory {
                             .label({
                                 let muted_foreground = cx.theme().muted_foreground;
                                 let accent = cx.theme().chart_2;
+                                let badge_radius = cx.theme().radius_full();
 
                                 move |d: &RadarDevice| {
                                     let grade = match d.desktop {
@@ -401,7 +402,7 @@ impl Render for ChartStory {
                                             h_flex()
                                                 .justify_center()
                                                 .size_6()
-                                                .rounded_full()
+                                                .rounded(badge_radius)
                                                 .bg(accent.opacity(0.1))
                                                 .text_sm()
                                                 .font_weight(FontWeight::SEMIBOLD)

--- a/crates/story/src/stories/collapsible_story.rs
+++ b/crates/story/src/stories/collapsible_story.rs
@@ -350,7 +350,7 @@ impl CollapsibleStory {
                                 Button::new("toggle-usage")
                                     .outline()
                                     .xsmall()
-                                    .rounded_full()
+                                    .rounded(cx.theme().radius_full())
                                     .bg(cx.theme().background)
                                     .icon(if open {
                                         IconName::ChevronUp

--- a/crates/story/src/stories/combobox_story.rs
+++ b/crates/story/src/stories/combobox_story.rs
@@ -1,6 +1,6 @@
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{
-    ActiveTheme, Icon, IconName, IndexPath, Sizable as _,
+    ActiveTheme, Icon, IconName, IndexPath, Sizable as _, ThemeStyled as _,
     button::Button,
     button::ButtonVariants as _,
     combobox::*,
@@ -260,7 +260,7 @@ impl SearchableListDelegate for FeaturedDelegate {
                 })
                 .child(
                     div()
-                        .rounded_sm()
+                        .rounded(cx.theme().radius.half())
                         .bg(cx.theme().primary)
                         .text_color(cx.theme().primary_foreground)
                         .px_1()
@@ -706,7 +706,7 @@ impl Render for ComboboxStory {
                                                     div()
                                                         .bg(cx.theme().primary)
                                                         .text_color(cx.theme().primary_foreground)
-                                                        .rounded_full()
+                                                        .rounded_full_style(cx)
                                                         .px_2()
                                                         .py_0p5()
                                                         .text_xs()
@@ -767,7 +767,7 @@ impl Render for ComboboxStory {
                                                         .min_w_0()
                                                         .gap_0p5()
                                                         .items_center()
-                                                        .rounded_sm()
+                                                        .rounded(cx.theme().radius.half())
                                                         .border_1()
                                                         .border_color(cx.theme().border)
                                                         .px_1()
@@ -873,7 +873,7 @@ impl Render for ComboboxStory {
                                     .children(trigger.selection().iter().take(MAX_SHOWN).map(
                                         |(_index, item)| {
                                             div()
-                                                .rounded_sm()
+                                                .rounded(cx.theme().radius.half())
                                                 .border_1()
                                                 .border_color(cx.theme().border)
                                                 .px_1()
@@ -885,7 +885,7 @@ impl Render for ComboboxStory {
                                         let hidden = trigger.selection().len() - MAX_SHOWN;
                                         this.child(
                                             div()
-                                                .rounded_sm()
+                                                .rounded(cx.theme().radius.half())
                                                 .border_1()
                                                 .border_color(cx.theme().border)
                                                 .px_1()
@@ -933,7 +933,7 @@ impl Render for ComboboxStory {
                                             .min_w(px(16.))
                                             .h(px(16.))
                                             .px_1()
-                                            .rounded_full()
+                                            .rounded_full_style(cx)
                                             .bg(cx.theme().red)
                                             .text_color(white())
                                             .text_size(px(10.))

--- a/crates/story/src/stories/editor_preview.rs
+++ b/crates/story/src/stories/editor_preview.rs
@@ -14,7 +14,7 @@ impl ProjectOverview {
         v_flex()
             .gap_1()
             .p_4()
-            .rounded_lg()
+            .rounded(cx.theme().radius_lg)
             .border_1()
             .child(div().text_sm().child(label))
             .child(div().text_2xl().font_semibold().child(value))
@@ -50,7 +50,7 @@ impl Render for ProjectOverview {
                 v_flex()
                     .gap_3()
                     .p_4()
-                    .rounded_lg()
+                    .rounded(cx.theme().radius_lg)
                     .bg(cx.theme().muted)
                     .child(
                         h_flex()

--- a/crates/story/src/stories/list_story.rs
+++ b/crates/story/src/stories/list_story.rs
@@ -9,7 +9,7 @@ use gpui::{
 };
 
 use gpui_component::{
-    ActiveTheme, Icon, IconName, IndexPath, Selectable,
+    ActiveTheme, Icon, IconName, IndexPath, Selectable, ThemeStyled as _,
     button::Button,
     h_flex,
     label::Label,
@@ -187,7 +187,7 @@ impl RenderOnce for CompanyListItem {
                                 .left_0()
                                 .right_0()
                                 .h(px(2.))
-                                .rounded_full()
+                                .rounded_full_style(cx)
                                 .bg(cx.theme().blue);
 
                             this.child(match position {

--- a/crates/story/src/stories/native_menu_story.rs
+++ b/crates/story/src/stories/native_menu_story.rs
@@ -113,7 +113,7 @@ impl NativeMenuStory {
             .h_24()
             .border_1()
             .border_color(cx.theme().border)
-            .rounded_lg()
+            .rounded(cx.theme().radius_lg)
             .text_color(cx.theme().muted_foreground)
             .child(SharedString::from(label.to_string()))
     }

--- a/crates/story/src/stories/sidebar_story.rs
+++ b/crates/story/src/stories/sidebar_story.rs
@@ -7,7 +7,7 @@ use gpui::{
 };
 
 use gpui_component::{
-    ActiveTheme, Icon, IconName, Side, Sizable, StyledExt,
+    ActiveTheme, Icon, IconName, Side, Sizable, StyledExt, ThemeStyled as _,
     badge::Badge,
     breadcrumb::{Breadcrumb, BreadcrumbItem},
     button::Button,
@@ -232,7 +232,7 @@ impl SidebarStory {
                                         .flex()
                                         .items_center()
                                         .justify_center()
-                                        .rounded_full()
+                                        .rounded_full_style(cx)
                                         .bg(cx.theme().muted)
                                         .child(Icon::new(icon).small()),
                                 )

--- a/crates/story/src/stories/skeleton_story.rs
+++ b/crates/story/src/stories/skeleton_story.rs
@@ -2,7 +2,7 @@ use gpui::{
     App, AppContext, Context, Entity, Focusable, IntoElement, ParentElement, Render, Styled,
     Window, px,
 };
-use gpui_component::{ActiveTheme as _, skeleton::Skeleton, v_flex};
+use gpui_component::{ActiveTheme as _, ThemeStyled as _, skeleton::Skeleton, v_flex};
 
 use crate::section;
 
@@ -62,7 +62,7 @@ impl Render for SkeletonStory {
                         gpui_component::h_flex()
                             .w_full()
                             .gap_3()
-                            .child(Skeleton::new().size_12().rounded_full())
+                            .child(Skeleton::new().size_12().rounded_full_style(cx))
                             .child(
                                 v_flex()
                                     .flex_1()

--- a/crates/story/src/stories/textarea_story.rs
+++ b/crates/story/src/stories/textarea_story.rs
@@ -242,7 +242,7 @@ impl Render for TextareaStory {
                                     .id(("chat-msg", i))
                                     .px_2()
                                     .py_1()
-                                    .rounded(px(4.))
+                                    .rounded(cx.theme().radius)
                                     .bg(cx.theme().muted)
                                     .child(msg.clone())
                             }),

--- a/crates/story/src/stories/theme_story/color_theme_story.rs
+++ b/crates/story/src/stories/theme_story/color_theme_story.rs
@@ -1,6 +1,6 @@
 use gpui::{prelude::FluentBuilder, *};
 use gpui_component::{
-    ActiveTheme as _, Icon, IconName, IndexPath, StyledExt as _, ThemeColor,
+    ActiveTheme as _, Icon, IconName, IndexPath, StyledExt as _, ThemeColor, ThemeStyled as _,
     button::{Button, ButtonVariants as _},
     h_flex,
     input::{Input, InputEvent, InputState},
@@ -329,7 +329,7 @@ impl ThemeColorsStory {
                                 this.child(
                                     div()
                                         .size_1p5()
-                                        .rounded_full()
+                                        .rounded_full_style(cx)
                                         .bg(isolated_theme.foreground)
                                         .flex_shrink_0(),
                                 )
@@ -444,7 +444,7 @@ impl ThemeColorsStory {
                                                 this.child(
                                                     div()
                                                         .size_1p5()
-                                                        .rounded_full()
+                                                        .rounded_full_style(cx)
                                                         .bg(cx.theme().foreground),
                                                 )
                                             })

--- a/crates/story/src/title_bar.rs
+++ b/crates/story/src/title_bar.rs
@@ -111,6 +111,7 @@ impl FontSizeSelector {
         cx: &mut Context<Self>,
     ) {
         Theme::global_mut(cx).font_size = px(font_size.0 as f32);
+        Theme::sync_base(cx);
         window.refresh();
     }
 
@@ -126,6 +127,8 @@ impl FontSizeSelector {
         } else {
             px(0.)
         };
+        // The scrollbar paints from the Base layer's own copy of the theme.
+        Theme::sync_base(cx);
         window.refresh();
     }
 

--- a/crates/ui/src/avatar/avatar.rs
+++ b/crates/ui/src/avatar/avatar.rs
@@ -5,7 +5,7 @@ use gpui::{
 use gpui_base::{Avatar as BaseAvatar, AvatarFallback, AvatarImage};
 
 use crate::{
-    ActiveTheme, Colorize, Icon, IconName, Sizable, Size, StyledExt,
+    ActiveTheme, Colorize, Icon, IconName, Sizable, Size, StyledExt, ThemeStyled as _,
     avatar::{AvatarSized as _, avatar_size},
 };
 
@@ -97,7 +97,7 @@ impl RenderOnce for Avatar {
             .flex()
             .items_center()
             .justify_center()
-            .rounded_full()
+            .rounded_full_style(cx)
             .overflow_hidden()
             .when(self.name.is_none(), |this| {
                 this.text_size(avatar_size(self.size) * 0.6)
@@ -115,7 +115,7 @@ impl RenderOnce for Avatar {
         self.base
             .size(avatar_size(self.size))
             .flex_shrink_0()
-            .rounded_full()
+            .rounded_full_style(cx)
             .overflow_hidden()
             .bg(cx.theme().tokens.secondary)
             .text_color(cx.theme().background)
@@ -126,7 +126,7 @@ impl RenderOnce for Avatar {
                 this.image(
                     AvatarImage::new(src)
                         .size_full()
-                        .rounded_full()
+                        .rounded_full_style(cx)
                         .refine_style(&inner_style),
                 )
             })

--- a/crates/ui/src/badge.rs
+++ b/crates/ui/src/badge.rs
@@ -3,7 +3,7 @@ use gpui::{
     div, prelude::FluentBuilder, px, relative,
 };
 
-use crate::{ActiveTheme, Icon, Sizable, Size, StyledExt, h_flex, white};
+use crate::{ActiveTheme, Icon, Sizable, Size, StyledExt, ThemeStyled as _, h_flex, white};
 
 #[derive(Default, Clone)]
 enum BadgeVariant {
@@ -121,7 +121,7 @@ impl RenderOnce for Badge {
                         .absolute()
                         .justify_center()
                         .items_center()
-                        .rounded_full()
+                        .rounded_full_style(cx)
                         .bg(self.color.unwrap_or(cx.theme().red))
                         .text_color(white())
                         .text_size(text_size)

--- a/crates/ui/src/description_list.rs
+++ b/crates/ui/src/description_list.rs
@@ -283,7 +283,7 @@ impl RenderOnce for DescriptionList {
             .gap(gap)
             .overflow_hidden()
             .when(self.bordered, |this| {
-                this.rounded(padding_x)
+                this.rounded(cx.theme().radius)
                     .border_1()
                     .border_color(cx.theme().border)
             })

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -7,7 +7,7 @@ use gpui::{
     StatefulInteractiveElement as _, StyleRefinement, Styled, TextAlign, Window, div, px, relative,
 };
 
-use crate::button::{Button, ButtonVariants as _};
+use crate::button::{Button, ButtonRounded, ButtonVariants as _};
 use crate::input::clear_button;
 use crate::native_menu::NativeMenu;
 use crate::spinner::Spinner;
@@ -400,7 +400,7 @@ impl RenderOnce for Input {
                             IconName::ChevronDown
                         })
                         .xsmall()
-                        .rounded_xs()
+                        .rounded(ButtonRounded::Small)
                         .size(px(14.))
                         .selected(is_folded)
                         .into_any_element()

--- a/crates/ui/src/plot/tooltip.rs
+++ b/crates/ui/src/plot/tooltip.rs
@@ -1,5 +1,5 @@
 use gpui::{
-    AnyElement, App, Div, Hsla, IntoElement, ParentElement, Pixels, Point, RenderOnce,
+    AnyElement, App, Div, Half as _, Hsla, IntoElement, ParentElement, Pixels, Point, RenderOnce,
     SharedString, Size, StyleRefinement, Styled, Window, deferred, div, prelude::FluentBuilder, px,
 };
 
@@ -380,7 +380,12 @@ impl RenderOnce for Tooltip {
                             h_flex()
                                 .items_center()
                                 .gap_1p5()
-                                .child(div().size_2().rounded_sm().bg(row.color))
+                                .child(
+                                    div()
+                                        .size_2()
+                                        .rounded(cx.theme().radius.half())
+                                        .bg(row.color),
+                                )
                                 .child(
                                     div()
                                         .text_color(cx.theme().muted_foreground)

--- a/crates/ui/src/progress/progress.rs
+++ b/crates/ui/src/progress/progress.rs
@@ -1,7 +1,8 @@
 use crate::{ActiveTheme, Sizable, Size, StyledExt};
 use gpui::{
-    Animation, AnimationExt as _, App, Background, ElementId, Hsla, IntoElement, ParentElement,
-    RenderOnce, StyleRefinement, Styled, Window, ease_in_out, prelude::FluentBuilder, px, relative,
+    Animation, AnimationExt as _, App, Background, ElementId, Hsla, IntoElement, IsZero as _,
+    ParentElement, RenderOnce, StyleRefinement, Styled, Window, ease_in_out,
+    prelude::FluentBuilder, px, relative,
 };
 use gpui_base::{Progress as BaseProgress, ProgressIndicator, ProgressTrack};
 use instant::Duration;
@@ -82,12 +83,19 @@ impl RenderOnce for Progress {
         let mut inner_style = StyleRefinement::default();
         inner_style.corner_radii = radius;
 
-        let (height, radius) = match self.size {
+        let (height, pill_radius) = match self.size {
             Size::XSmall => (px(4.), px(2.)),
             Size::Small => (px(6.), px(3.)),
             Size::Medium => (px(8.), px(4.)),
             Size::Large => (px(10.), px(5.)),
             Size::Size(s) => (s, s / 2.),
+        };
+        // The bar reads as a pill of half its own height, and squares off with
+        // the rest of the UI when the theme has no radius.
+        let radius = if cx.theme().radius.is_zero() {
+            px(0.)
+        } else {
+            pill_radius
         };
 
         let state = window.use_keyed_state(self.id.clone(), cx, |_, _| ProgressState::new(value));

--- a/crates/ui/src/radio.rs
+++ b/crates/ui/src/radio.rs
@@ -204,7 +204,7 @@ impl RenderOnce for Radio {
                         _ => this.size_4(),
                     })
                     .flex_shrink_0()
-                    .rounded_full()
+                    .rounded_full_style(cx)
                     .border_1()
                     .border_color(border_color)
                     .map(|this| match self.checked {

--- a/crates/ui/src/slider.rs
+++ b/crates/ui/src/slider.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use crate::{ActiveTheme, AxisExt, StyledExt, animation::ease_out_cubic};
+use crate::{ActiveTheme, AxisExt, StyledExt, ThemeStyled as _, animation::ease_out_cubic};
 pub use gpui_base::slider::{SliderEvent, SliderScale, SliderState, SliderValue};
 use gpui_base::{
     Slider as BaseSlider, SliderIndicator, SliderThumb, SliderTrack, Transition, transition,
@@ -8,8 +8,8 @@ use gpui_base::{
 
 use gpui::{
     App, Axis, Background, Corners, DefiniteLength, ElementId, Entity, EntityId, Hsla,
-    InteractiveElement as _, IntoElement, IsZero, MouseButton, ParentElement as _, Pixels,
-    RenderOnce, StatefulInteractiveElement as _, StyleRefinement, Styled, Window, div,
+    InteractiveElement as _, IntoElement, MouseButton, ParentElement as _, Pixels, RenderOnce,
+    StatefulInteractiveElement as _, StyleRefinement, Styled, Window, div,
     prelude::FluentBuilder as _, px, relative,
 };
 
@@ -174,8 +174,10 @@ impl RenderOnce for Slider {
             .map(Into::into)
             .unwrap_or_else(|| cx.theme().tokens.slider_thumb.into());
         let corner_radii = self.style.corner_radii.clone();
-        let default_radius = px(999.);
-        let mut radius = Corners {
+        // The track is a pill by default, and square when the theme squares its
+        // corners. A caller's own corner radii still win.
+        let default_radius = cx.theme().radius_full();
+        let radius = Corners {
             top_left: corner_radii
                 .top_left
                 .map(|v| v.to_pixels(rem_size))
@@ -193,12 +195,6 @@ impl RenderOnce for Slider {
                 .map(|v| v.to_pixels(rem_size))
                 .unwrap_or(default_radius),
         };
-        if cx.theme().radius.is_zero() {
-            radius.top_left = px(0.);
-            radius.top_right = px(0.);
-            radius.bottom_left = px(0.);
-            radius.bottom_right = px(0.);
-        }
 
         let ring_color = cx.theme().ring;
         let entity_id = self.state.entity_id();
@@ -222,7 +218,7 @@ impl RenderOnce for Slider {
                         .items_center()
                         .justify_center()
                         .flex_shrink_0()
-                        .rounded_full()
+                        .rounded_full_style(cx)
                         .bg(bar_color.opacity(0.5))
                         .size_4()
                         .p(px(1.))
@@ -253,7 +249,7 @@ impl RenderOnce for Slider {
                                 .left(-ring.width)
                                 .right(-ring.width)
                                 .bottom(-ring.width)
-                                .rounded_full()
+                                .rounded_full_style(cx)
                                 .border(ring.width)
                                 .border_color(ring.color),
                         )
@@ -261,7 +257,7 @@ impl RenderOnce for Slider {
                             div()
                                 .flex_shrink_0()
                                 .size_full()
-                                .rounded_full()
+                                .rounded_full_style(cx)
                                 .bg(thumb_bg),
                         )
                 })
@@ -309,7 +305,7 @@ impl RenderOnce for Slider {
                                         this.w_full().bottom(bar_start).top(bar_end)
                                     })
                                     .bg(bar_color)
-                                    .when(!cx.theme().radius.is_zero(), |this| this.rounded_full()),
+                                    .rounded_full_style(cx),
                             )
                             .when_some(start_ring, |this, ring| {
                                 this.child(thumb(relative(percentage.start), true, ring))

--- a/crates/ui/src/stepper/trigger.rs
+++ b/crates/ui/src/stepper/trigger.rs
@@ -4,7 +4,7 @@ use gpui::{
     prelude::FluentBuilder as _, px,
 };
 
-use crate::{ActiveTheme as _, AxisExt, Icon, Size, StyleSized, StyledExt as _};
+use crate::{ActiveTheme as _, AxisExt, Icon, Size, StyleSized, StyledExt as _, ThemeStyled as _};
 
 /// The trigger part of a stepper item.
 #[derive(IntoElement)]
@@ -118,7 +118,7 @@ impl RenderOnce for StepperTrigger {
                     .size(self.icon_size)
                     .overflow_hidden()
                     .flex()
-                    .rounded_full()
+                    .rounded_full_style(cx)
                     .items_center()
                     .justify_center()
                     .bg(cx.theme().tokens.secondary)

--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -122,6 +122,17 @@ pub trait ThemeStyled: Styled + Sized {
     /// Combobox, DatePicker and the editor's hover popovers — so they cannot
     /// drift apart. See [`popover_shadow`] for what the shadow is modelled on.
     fn popover_style(self, cx: &App) -> Self;
+
+    /// Round this element as far as its size allows — a circle if it is square,
+    /// a pill if it is not — unless the theme squares its corners.
+    ///
+    /// Use this instead of [`gpui::Styled::rounded_full`] on anything the theme
+    /// owns. A hardcoded `rounded_full` survives [`crate::Theme::radius`] being
+    /// set to zero, which leaves avatars, badge dots and slider thumbs round in
+    /// a UI that is square everywhere else. See [`crate::Theme::radius_full`].
+    fn rounded_full_style(self, cx: &App) -> Self {
+        self.rounded(cx.theme().radius_full())
+    }
 }
 
 impl<T: Styled + Sized> ThemeStyled for T {

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -345,7 +345,7 @@ impl TabVariant {
 
     fn radius(&self, size: Size, cx: &App) -> Pixels {
         match self {
-            TabVariant::Outline | TabVariant::Pill => px(99.),
+            TabVariant::Outline | TabVariant::Pill => cx.theme().radius_full(),
             TabVariant::Segmented => match size {
                 Size::XSmall | Size::Small => cx.theme().radius,
                 Size::Large => cx.theme().radius_lg,
@@ -357,9 +357,12 @@ impl TabVariant {
 
     pub(super) fn inner_radius(&self, size: Size, cx: &App) -> Pixels {
         match self {
+            // The inset the active pill sits at, taken off the bar's own radius
+            // so the two curves stay concentric. Floored at zero: a square bar
+            // has nothing to inset from.
             TabVariant::Segmented => match size {
-                Size::Large => self.tab_bar_radius(size, cx) - px(3.),
-                _ => self.tab_bar_radius(size, cx) - px(2.),
+                Size::Large => (self.tab_bar_radius(size, cx) - px(3.)).max(px(0.)),
+                _ => (self.tab_bar_radius(size, cx) - px(2.)).max(px(0.)),
             },
             _ => px(0.),
         }

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -241,7 +241,7 @@ impl TabBar {
                     div()
                         .size_full()
                         .bg(cx.theme().tokens.primary)
-                        .rounded(px(99.)),
+                        .rounded(cx.theme().radius_full()),
                 ),
                 TabVariant::Underline => el.child(
                     div()

--- a/crates/ui/src/theme/mod.rs
+++ b/crates/ui/src/theme/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     highlighter::HighlightTheme, list::ListSettings, notification::NotificationSettings,
     scroll::ScrollbarMode, sheet::SheetSettings,
 };
-use gpui::{App, Global, Hsla, Pixels, SharedString, Window, WindowAppearance, px};
+use gpui::{App, Global, Hsla, IsZero as _, Pixels, SharedString, Window, WindowAppearance, px};
 pub use gpui_base::{
     ColorTokens, RadiusTokens, SemanticThemeTokens, ShadowTokens, SpacingTokens, TextStyleToken,
     TypographyTokens,
@@ -48,6 +48,11 @@ impl ActiveTheme for App {
 fn default_true() -> bool {
     true
 }
+
+/// The radius that rounds a shape as far as its own size allows, giving a
+/// circle or a pill. Any value past half the shorter side is clamped by the
+/// renderer, so this is simply "as round as it goes".
+const RADIUS_FULL: Pixels = px(9999.);
 
 /// How long the scrollbar stays visible after the last scroll, drag, or hover.
 const SCROLLBAR_IDLE: Duration = Duration::from_secs(2);
@@ -166,6 +171,10 @@ impl Theme {
     }
 
     /// Returns the global theme mutable reference
+    ///
+    /// Changes to fields the Base layer mirrors — the radius, the colors, the
+    /// fonts — reach the scrollbar and resize handles only once
+    /// [`Theme::sync_base`] runs.
     #[inline(always)]
     pub fn global_mut(cx: &mut App) -> &mut Theme {
         cx.global_mut::<Theme>()
@@ -237,38 +246,67 @@ impl Theme {
             theme.apply_config(&theme.light_theme.clone());
         }
 
-        let base_theme = gpui_base::Theme {
-            tokens: theme.semantic_tokens(),
-            scrollbar: gpui_base::ScrollbarTheme::new()
-                .with_mode(theme.scrollbar_mode)
-                .with_motion(scrollbar_motion(theme.scrollbar_mode))
-                .with_styles(
-                    gpui_base::ScrollbarStyles::default()
-                        .track(|style| style.bg(theme.scrollbar))
-                        .track_hover(|style| style.bg(theme.scrollbar))
-                        .track_active(|style| style.bg(theme.scrollbar).border_color(theme.border))
-                        .thumb(|style| style.bg(theme.tokens.scrollbar_thumb).radius(theme.radius))
-                        .thumb_hover(|style| {
-                            style
-                                .bg(theme.tokens.scrollbar_thumb_hover)
-                                .radius(theme.radius)
-                        })
-                        .thumb_active(|style| {
-                            style
-                                .bg(theme.tokens.scrollbar_thumb_hover)
-                                .radius(theme.radius)
-                        }),
-                ),
-            resizable: gpui_base::ResizableTheme {
-                handle: theme.border,
-                active_handle: theme.drag_border,
-            },
-        };
+        let base_theme = theme.base_theme();
         cx.set_global(base_theme);
 
         if let Some(window) = window {
             window.refresh();
         }
+    }
+
+    /// This theme projected onto the Base layer, which owns the scrollbar and
+    /// resize handles and reads the semantic tokens.
+    fn base_theme(&self) -> gpui_base::Theme {
+        gpui_base::Theme {
+            tokens: self.semantic_tokens(),
+            scrollbar: gpui_base::ScrollbarTheme::new()
+                .with_mode(self.scrollbar_mode)
+                .with_motion(scrollbar_motion(self.scrollbar_mode))
+                .with_styles(
+                    gpui_base::ScrollbarStyles::default()
+                        .track(|style| style.bg(self.scrollbar))
+                        .track_hover(|style| style.bg(self.scrollbar))
+                        .track_active(|style| style.bg(self.scrollbar).border_color(self.border))
+                        .thumb(|style| style.bg(self.tokens.scrollbar_thumb).radius(self.radius))
+                        .thumb_hover(|style| {
+                            style
+                                .bg(self.tokens.scrollbar_thumb_hover)
+                                .radius(self.radius)
+                        })
+                        .thumb_active(|style| {
+                            style
+                                .bg(self.tokens.scrollbar_thumb_hover)
+                                .radius(self.radius)
+                        }),
+                ),
+            resizable: gpui_base::ResizableTheme {
+                handle: self.border,
+                active_handle: self.drag_border,
+            },
+        }
+    }
+
+    /// Push the current theme down to the Base layer.
+    ///
+    /// The Base layer holds its own copy of the theme — the semantic tokens
+    /// plus the scrollbar and resize-handle styles — because it paints those
+    /// without going through `gpui-component`. [`Theme::change`] refreshes that
+    /// copy, but writing to the theme's public fields directly does not, so a
+    /// scrollbar keeps painting with the radius and colors it was last given.
+    ///
+    /// Call this after mutating the theme through [`Theme::global_mut`]:
+    ///
+    /// ```ignore
+    /// Theme::global_mut(cx).radius = px(0.);
+    /// Theme::sync_base(cx);
+    /// ```
+    ///
+    /// It rebuilds the Base theme from scratch, so any style written straight
+    /// onto the Base global is replaced — the same thing [`Theme::change`]
+    /// does.
+    pub fn sync_base(cx: &mut App) {
+        let base_theme = Theme::global(cx).base_theme();
+        cx.set_global(base_theme);
     }
 
     /// Get the input background color.
@@ -328,6 +366,22 @@ impl Theme {
         }
     }
 
+    /// The radius of a shape that reads as a circle or a pill — an avatar, a
+    /// slider thumb, a badge dot, a pill tab.
+    ///
+    /// A theme whose [`Theme::radius`] is zero squares these off too, so one
+    /// setting governs the whole UI instead of leaving a handful of
+    /// permanently round elements behind. Use it in place of
+    /// [`gpui::Styled::rounded_full`], or reach for
+    /// [`crate::ThemeStyled::rounded_full_style`] when styling an element.
+    pub fn radius_full(&self) -> Pixels {
+        if self.radius.is_zero() {
+            px(0.)
+        } else {
+            RADIUS_FULL
+        }
+    }
+
     pub fn radius_tokens(&self) -> RadiusTokens {
         RadiusTokens {
             none: px(0.),
@@ -335,7 +389,7 @@ impl Theme {
             md: self.radius,
             lg: self.radius_lg,
             xl: self.radius * 2.,
-            full: px(9999.),
+            full: RADIUS_FULL,
         }
     }
 
@@ -430,9 +484,9 @@ impl Theme {
 
 #[cfg(test)]
 mod semantic_token_tests {
-    use gpui::{Hsla, px};
+    use gpui::{Hsla, IsZero as _, px};
 
-    use super::Theme;
+    use super::{RADIUS_FULL, Theme};
 
     #[test]
     fn semantic_colors_are_a_live_projection_of_legacy_fields() {
@@ -460,6 +514,29 @@ mod semantic_token_tests {
         assert_eq!(theme.danger, tokens.colors.destructive);
         assert_eq!(theme.radius, px(10.));
         assert_eq!(theme.button_primary, component_color);
+    }
+
+    #[test]
+    fn square_themes_square_off_pills_and_circles() {
+        let mut theme = Theme::default();
+        assert_eq!(theme.radius_full(), RADIUS_FULL);
+        assert_eq!(theme.radius_tokens().full, RADIUS_FULL);
+
+        // An application asking for square corners gets them everywhere, not
+        // just on the elements whose radius happens to come from `radius`.
+        theme.radius = px(0.);
+        assert_eq!(theme.radius_full(), px(0.));
+    }
+
+    #[test]
+    fn base_projection_carries_a_square_radius_to_the_scrollbar() {
+        let mut theme = Theme::default();
+        assert!(!theme.base_theme().tokens.radius.md.is_zero());
+
+        // The scrollbar paints from the Base layer's copy of the theme, so a
+        // square theme has to reach it or the thumb stays a pill.
+        theme.radius = px(0.);
+        assert!(theme.base_theme().tokens.radius.md.is_zero());
     }
 
     #[test]

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -117,7 +117,7 @@ impl Render for Tooltip {
                 .border_1()
                 .border_color(cx.theme().border)
                 .shadow_md()
-                .rounded(px(6.))
+                .rounded(cx.theme().radius)
                 .justify_between()
                 .py_0p5()
                 .px_2()

--- a/docs/STYLING-AND-MOTION.md
+++ b/docs/STYLING-AND-MOTION.md
@@ -153,6 +153,39 @@ to mutate arbitrary descendants.
 Keep state-independent geometry in the part's ordinary builder chain and put
 state-dependent color, border, fill, or opacity in its semantic style context.
 
+## Corner Radius
+
+Every corner an application-owned component draws comes from the theme. An
+application that sets `Theme::radius` to zero gets square corners everywhere,
+including the elements that read as circles or pills — avatar, badge dot, radio
+mark, slider thumb, stepper indicator, pill tab, progress bar.
+
+```text
+Theme::radius            the general radius
+Theme::radius_lg         dialogs, notifications, large surfaces
+Theme::radius_full()     circle or pill; zero when `radius` is zero
+ThemeStyled::rounded_full_style(cx)   the same, applied to an element
+```
+
+Do not write a literal radius. `rounded_full()`, `rounded_md()`,
+`rounded(px(6.))` and friends survive `radius` being set to zero, which leaves
+a handful of permanently round elements in a UI that is square everywhere else.
+Derive from the theme instead, scaling with `radius.half()` or `radius * 2.`
+where a component needs a tighter or looser curve than the base.
+
+The Base layer keeps its own copy of the theme, because it paints the scrollbar
+and the resize handles without going through `gpui-component`. `Theme::change`
+refreshes that copy; writing to the theme's public fields does not. After
+mutating the theme directly, call `Theme::sync_base(cx)` or the scrollbar thumb
+keeps the radius it was last given.
+
+Two deliberate exceptions:
+
+- A radius the caller passes in explicitly, such as `Tag::rounded_full()` or
+  `Avatar::rounded(px(20.))`. The application asked for that shape.
+- Plotted geometry — a scatter marker, a pie slice, a chart data dot. Those are
+  data, not chrome, and do not follow the interface's radius.
+
 ## Motion Ownership
 
 Ordinary semantic controls do not install default fade, slide, spring, or size
@@ -252,3 +285,4 @@ may continue to use its module-qualified API.
 7. Part styling is explicit and typed; base does not traverse arbitrary child
    trees to apply styles.
 8. Reduced-motion preferences are honored by generic transitions.
+9. Corner radius is derived from the theme, never written as a literal.

--- a/examples/root_borderless/src/main.rs
+++ b/examples/root_borderless/src/main.rs
@@ -30,7 +30,7 @@ impl Render for RootBorderlessExample {
                     .gap_3()
                     .child(
                         div()
-                            .rounded_md()
+                            .rounded(cx.theme().radius)
                             .border_1()
                             .border_color(cx.theme().border)
                             .px_3()
@@ -39,7 +39,7 @@ impl Render for RootBorderlessExample {
                     )
                     .child(
                         div()
-                            .rounded_md()
+                            .rounded(cx.theme().radius)
                             .border_1()
                             .border_color(cx.theme().border)
                             .px_3()

--- a/examples/text_selection/src/main.rs
+++ b/examples/text_selection/src/main.rs
@@ -37,7 +37,7 @@ impl ChatExample {
             div()
                 .max_w(px(420.))
                 .p_3()
-                .rounded_lg()
+                .rounded(cx.theme().radius_lg)
                 .bg(if mine {
                     cx.theme().primary.opacity(0.1)
                 } else {


### PR DESCRIPTION
Setting `Theme::radius` to `0` used to leave a scatter of permanently round elements behind. This routes every hardcoded radius through the theme so one setting governs the whole UI.

New in `crates/ui`:

- `Theme::radius_full()` — the circle/pill radius, which is `0` when `radius` is.
- `ThemeStyled::rounded_full_style(cx)` — the element form, replacing `rounded_full()`.
- `Theme::sync_base(cx)` — pushes the theme down to the Base layer.

Fixed: avatar, badge, radio mark, slider thumb/ring/bar, stepper indicator, Pill and Outline tabs, progress bar, tooltip surface, `DescriptionList` frame, plot legend swatch, the code-fold button, and matching chrome across the story gallery and examples.

Two separate bugs surfaced along the way. The segmented tab's inner radius went **negative** at radius 0 (`radius − 2px`); it is now floored at zero. And the scrollbar paints from the Base layer's own copy of the theme, which was only rebuilt inside `Theme::change` — so writing to `Theme::radius` directly never reached it and the thumb kept its old radius. That projection is now `Theme::base_theme()`, and `Theme::sync_base(cx)` pushes it down.

Left alone deliberately: caller-supplied radii in the "Custom shape/style" stories, plotted data marks (scatter dots, pie, radar), and the `gpui-fps` HUD, which has no `gpui-component` dependency.

The rule and its exceptions are written up in `docs/STYLING-AND-MOTION.md § Corner Radius`.

No breaking changes — the public API additions are additive.

> AI-generated with Claude Code, reviewed by @huacnlee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
