### PR TITLE
calendar: Fix month picker layout

### DIFF
--- a/crates/base/src/calendar.rs
+++ b/crates/base/src/calendar.rs
@@ -5,7 +5,7 @@ use chrono::{Datelike, Local, NaiveDate, Weekday};
 use gpui::{
     AnyElement, App, Context, ElementId, Empty, Entity, EventEmitter, FocusHandle,
     InteractiveElement, IntoElement, ParentElement, Render, RenderOnce, SharedString,
-    StatefulInteractiveElement, StyleRefinement, Styled, Window, div,
+    StatefulInteractiveElement, StyleRefinement, Styled, Window, div, px,
 };
 
 /// A controlled calendar value.
@@ -150,6 +150,14 @@ impl CalendarView {
     }
     pub fn is_year(self) -> bool {
         self == Self::Year
+    }
+}
+
+fn picker_grid_layout(view: CalendarView) -> Option<(u16, f32)> {
+    match view {
+        CalendarView::Day => None,
+        CalendarView::Month => Some((3, 4.)),
+        CalendarView::Year => Some((5, 4.)),
     }
 }
 
@@ -701,10 +709,11 @@ impl RenderOnce for Calendar {
             (self.item)(item, st, window, cx)
         });
 
-        let mut body = if view.is_day() {
-            h_flex().justify_around()
-        } else {
-            h_flex().flex_wrap()
+        let mut body = match picker_grid_layout(view) {
+            None => h_flex().justify_around(),
+            Some((columns, horizontal_gap)) => {
+                div().grid().grid_cols(columns).gap_x(px(horizontal_gap))
+            }
         };
         if view.is_day() {
             for offset in 0..count {
@@ -943,6 +952,13 @@ mod tests {
             s.select_year(2032);
             assert_eq!((s.view(), s.current_year()), (CalendarView::Day, 2032));
         });
+    }
+
+    #[test]
+    fn picker_views_use_stable_grid_layouts() {
+        assert_eq!(picker_grid_layout(CalendarView::Month), Some((3, 4.)));
+        assert_eq!(picker_grid_layout(CalendarView::Year), Some((5, 4.)));
+        assert_eq!(picker_grid_layout(CalendarView::Day), None);
     }
 
     #[gpui::test]

--- a/crates/ui/src/time/calendar.rs
+++ b/crates/ui/src/time/calendar.rs
@@ -1,7 +1,7 @@
 use chrono::Weekday;
 use gpui::{
     App, ElementId, Entity, InteractiveElement, IntoElement, ParentElement, RenderOnce,
-    SharedString, StyleRefinement, Styled, Window, prelude::FluentBuilder as _, px, relative,
+    SharedString, StyleRefinement, Styled, Window, prelude::FluentBuilder as _, px,
 };
 use rust_i18n::t;
 
@@ -27,6 +27,10 @@ fn month_name(month: i32) -> SharedString {
         _ => "".into(),
     }
     .into()
+}
+
+fn uses_compact_text(kind: CalendarItemKind) -> bool {
+    kind == CalendarItemKind::Month
 }
 
 /// Styled facade for the complete behavior and structure in `gpui-base`.
@@ -122,6 +126,7 @@ impl RenderOnce for Calendar {
                         .font_normal()
                         .text_color(cx.theme().muted_foreground)
                 })
+                .when(uses_compact_text(state.kind()), |this| this.text_xs())
                 .when(
                     matches!(
                         state.kind(),
@@ -136,7 +141,7 @@ impl RenderOnce for Calendar {
                     ),
                     |this| {
                         this.when(state.kind() == CalendarItemKind::Month, |this| {
-                            this.w(relative(0.3)).m_1()
+                            this.w_full().my_1()
                         })
                         .when(state.kind() == CalendarItemKind::MonthToggle, |this| {
                             this.w_auto().px_2()
@@ -150,7 +155,7 @@ impl RenderOnce for Calendar {
                     ),
                     |this| {
                         this.when(state.kind() == CalendarItemKind::Year, |this| {
-                            this.w(relative(0.16)).m_1()
+                            this.w_full().my_1()
                         })
                         .when(state.kind() == CalendarItemKind::YearToggle, |this| {
                             this.w_auto().px_2()
@@ -202,7 +207,7 @@ impl RenderOnce for Calendar {
 
 #[cfg(test)]
 mod tests {
-    use super::Date;
+    use super::{CalendarItemKind, Date, uses_compact_text};
     use chrono::NaiveDate;
 
     #[test]
@@ -212,5 +217,12 @@ mod tests {
             "2024-08-03"
         );
         assert_eq!(Date::Single(None).to_string(), "nil");
+    }
+
+    #[test]
+    fn only_month_options_use_compact_text() {
+        assert!(uses_compact_text(CalendarItemKind::Month));
+        assert!(!uses_compact_text(CalendarItemKind::MonthToggle));
+        assert!(!uses_compact_text(CalendarItemKind::Day));
     }
 }


### PR DESCRIPTION
## Summary

- render month and year pickers with explicit 3-column and 5-column grids
- add horizontal gutter spacing without changing the calendar container width
- use compact typography for month options so longer names fit cleanly
- add regression coverage for picker layout and month-only compact text

## Root cause

The picker used percentage-width items inside a wrapping flex container. At the default 248px calendar width, item widths plus margins caused the month view to wrap into two columns. Switching to a grid fixed the column count, but without a gutter the labels remained visually crowded.

## Validation

- `cargo fmt --check`
- `cargo test -p gpui-base calendar::tests`
- `cargo test -p gpui-component time::calendar::tests`
- `cargo check -p gpui-component`
- `git diff --check HEAD^ HEAD`
