### PR TITLE
notification: Bridge notifications to the OS notification center

### DIFF
--- a/crates/story/src/main.rs
+++ b/crates/story/src/main.rs
@@ -9,6 +9,9 @@ fn main() {
 
     app.run(move |cx| {
         init(cx);
+        // Required for system notifications on Windows; macOS only shows them
+        // when running from a bundled .app.
+        cx.set_app_identity("com.longbridge.gpui-component.story", "GPUI Component");
         cx.activate(true);
 
         create_new_window(

--- a/crates/story/src/stories/notification_story.rs
+++ b/crates/story/src/stories/notification_story.rs
@@ -398,6 +398,56 @@ impl Render for NotificationStory {
                             }))
                     })),
             )
+            .child({
+                struct SystemNotificationKind;
+
+                section("System notification")
+                    .description(
+                        "Deliver to the OS notification center; click the system \
+                        notification to refocus the app. macOS shows them only when \
+                        running from a bundled .app; Windows requires \
+                        cx.set_app_identity().",
+                    )
+                    .child(
+                        Button::new("show-notify-system")
+                            .outline()
+                            .label("System only")
+                            .on_click(cx.listener(|_, _, window, cx| {
+                                window.push_notification(
+                                    Notification::info(
+                                        "Delivered straight to the notification center.",
+                                    )
+                                    .id::<SystemNotificationKind>()
+                                    .title("Build finished")
+                                    .system()
+                                    .on_click(|_, _, _| {
+                                        println!("[notification] system notification clicked");
+                                    }),
+                                    cx,
+                                )
+                            })),
+                    )
+                    .child(
+                        Button::new("show-notify-in-app-and-system")
+                            .outline()
+                            .label("In-app and system")
+                            .on_click(cx.listener(|_, _, window, cx| {
+                                window.push_notification(
+                                    Notification::info(
+                                        "Shown as a toast and in the notification center.",
+                                    )
+                                    .id::<SystemNotificationKind>()
+                                    .title("Build finished")
+                                    .in_app_and_system()
+                                    .autohide(false)
+                                    .on_click(|_, _, _| {
+                                        println!("[notification] system notification clicked");
+                                    }),
+                                    cx,
+                                )
+                            })),
+                    )
+            })
             .child(
                 section("Custom content")
                     .description("Render application-owned notification content.")

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -132,6 +132,7 @@ pub fn init(cx: &mut App) {
     sheet::init(cx);
     list::init(cx);
     command::init(cx);
+    notification::init(cx);
     popover::init(cx);
     menu::init(cx);
     table::init(cx);

--- a/crates/ui/src/notification.rs
+++ b/crates/ui/src/notification.rs
@@ -1,10 +1,11 @@
 use std::{any::TypeId, borrow::Cow, collections::HashMap, rc::Rc, time::Duration};
 
 use gpui::{
-    Anchor, Animation, AnimationExt, AnyElement, App, AppContext, ClickEvent, Context,
-    DismissEvent, ElementId, Entity, EventEmitter, FocusHandle, InteractiveElement as _,
-    IntoElement, ParentElement as _, Pixels, Render, SharedString, StatefulInteractiveElement,
-    StyleRefinement, Styled, Subscription, Window, div, prelude::FluentBuilder, px,
+    Anchor, Animation, AnimationExt, AnyElement, AnyWindowHandle, App, AppContext, ClickEvent,
+    Context, DismissEvent, ElementId, Entity, EventEmitter, FocusHandle, Global,
+    InteractiveElement as _, IntoElement, ParentElement as _, Pixels, Render, SharedString,
+    StatefulInteractiveElement, StyleRefinement, Styled, Subscription, SystemNotification,
+    SystemNotificationResponse, WeakEntity, Window, WindowId, div, prelude::FluentBuilder, px,
 };
 use gpui_base::{
     Toast as BaseToast, ToastManager, ToastMotion, ToastOptions, ToastStack, ToastStackState,
@@ -45,10 +46,48 @@ impl NotificationType {
     }
 }
 
+/// Where a notification is presented: as an in-app toast, in the operating
+/// system's notification center, or both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NotificationDelivery {
+    /// Show only the in-app toast.
+    #[default]
+    InApp,
+    /// Post only to the OS notification center; no in-app toast is shown.
+    System,
+    /// Show the in-app toast and post to the OS notification center.
+    InAppAndSystem,
+}
+
+impl NotificationDelivery {
+    /// Whether this delivery shows an in-app toast.
+    pub fn includes_in_app(&self) -> bool {
+        matches!(self, Self::InApp | Self::InAppAndSystem)
+    }
+
+    /// Whether this delivery posts to the OS notification center.
+    pub fn includes_system(&self) -> bool {
+        matches!(self, Self::System | Self::InAppAndSystem)
+    }
+}
+
+/// Namespaces the library's system-notification tags away from tags the
+/// application posts itself, so the response handler can tell them apart.
+const SYSTEM_TAG_PREFIX: &str = "gpui-component/notification/";
+
 #[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub(crate) enum NotificationId {
     Id(TypeId),
     IdAndElementId(TypeId, ElementId),
+}
+
+impl NotificationId {
+    /// Stable OS-notification tag for this id within a running binary, so a
+    /// repeat push with the same id replaces the previous system
+    /// notification, mirroring the in-app replace semantics.
+    fn system_tag(&self) -> SharedString {
+        format!("{SYSTEM_TAG_PREFIX}{self:?}").into()
+    }
 }
 
 impl From<TypeId> for NotificationId {
@@ -76,6 +115,7 @@ pub struct Notification {
     message: Option<SharedString>,
     icon: Option<Icon>,
     placement: Option<Anchor>,
+    delivery: Option<NotificationDelivery>,
     autohide: bool,
     action_builder: Option<Rc<dyn Fn(&mut Self, &mut Window, &mut Context<Self>) -> Button>>,
     content_builder: Option<Rc<dyn Fn(&mut Self, &mut Window, &mut Context<Self>) -> AnyElement>>,
@@ -135,6 +175,7 @@ impl Notification {
             type_: None,
             icon: None,
             placement: None,
+            delivery: None,
             autohide: true,
             action_builder: None,
             content_builder: None,
@@ -224,6 +265,48 @@ impl Notification {
     pub fn placement(mut self, placement: Anchor) -> Self {
         self.placement = Some(placement);
         self
+    }
+
+    /// Set where this notification is delivered, overriding the global
+    /// [`NotificationSettings::delivery`].
+    ///
+    /// System delivery uses the OS notification center: the title and message
+    /// become the system notification's title and body (a notification with
+    /// neither is not posted). Pushing again with the same [`Notification::id`]
+    /// replaces the previous system notification. Clicking the system
+    /// notification activates the window, closes the in-app toast (if any),
+    /// and fires [`Notification::on_click`]; with
+    /// [`NotificationDelivery::System`] the toast never exists, so
+    /// [`Notification::on_close`] is never called.
+    ///
+    /// Platform requirements: on macOS the application must run from a bundled
+    /// `.app` in a location the system trusts, such as `/Applications` (posts
+    /// are silently dropped under plain `cargo run`, and the first post
+    /// triggers the authorization prompt); on Windows the application must
+    /// call [`gpui::App::set_app_identity`] early in startup; on Linux a
+    /// notification daemon must be present and retraction is unsupported
+    /// (dismissed notifications age out).
+    pub fn delivery(mut self, delivery: NotificationDelivery) -> Self {
+        self.delivery = Some(delivery);
+        self
+    }
+
+    /// Deliver this notification only to the OS notification center.
+    ///
+    /// Shorthand for [`Notification::delivery`] with
+    /// [`NotificationDelivery::System`]; see there for platform requirements.
+    pub fn system(self) -> Self {
+        self.delivery(NotificationDelivery::System)
+    }
+
+    /// Deliver this notification as an in-app toast and to the OS
+    /// notification center.
+    ///
+    /// Shorthand for [`Notification::delivery`] with
+    /// [`NotificationDelivery::InAppAndSystem`]; see there for platform
+    /// requirements.
+    pub fn in_app_and_system(self) -> Self {
+        self.delivery(NotificationDelivery::InAppAndSystem)
     }
 
     /// Set the auto hide of the notification, default is true.
@@ -454,6 +537,10 @@ pub struct NotificationSettings {
     pub max_items: usize,
     /// The width of the notifications, default: 382px
     pub width: Pixels,
+    /// Where notifications are delivered, default: [`NotificationDelivery::InApp`]
+    ///
+    /// A single notification can override this with [`Notification::delivery`].
+    pub delivery: NotificationDelivery,
 }
 
 impl Default for NotificationSettings {
@@ -469,7 +556,129 @@ impl Default for NotificationSettings {
             },
             max_items: 10,
             width: DEFAULT_NOTIFICATION_WIDTH,
+            delivery: NotificationDelivery::default(),
         }
+    }
+}
+
+/// Registers the app-global system-notification response handler.
+///
+/// gpui keeps a single such handler (later registrations replace earlier
+/// ones), so gpui-component owns it: applications must not call
+/// [`gpui::App::on_system_notification_response`] after `gpui_component::init`.
+/// Responses to notifications the application posts itself are ignored here.
+pub(crate) fn init(cx: &mut App) {
+    cx.on_system_notification_response(SystemNotificationRegistry::handle_response);
+}
+
+struct SystemNotificationEntry {
+    window: AnyWindowHandle,
+    list: WeakEntity<NotificationList>,
+    id: NotificationId,
+    on_click: Option<Rc<dyn Fn(&ClickEvent, &mut Window, &mut App)>>,
+}
+
+const MAX_SYSTEM_NOTIFICATION_ENTRIES: usize = 100;
+
+/// App-global map from system-notification tag to the state needed to
+/// dispatch the user's response, ordered oldest-first so overflow prunes the
+/// stalest entries.
+#[derive(Default)]
+struct SystemNotificationRegistry {
+    entries: Vec<(SharedString, SystemNotificationEntry)>,
+}
+
+impl Global for SystemNotificationRegistry {}
+
+impl SystemNotificationRegistry {
+    fn insert(cx: &mut App, tag: SharedString, entry: SystemNotificationEntry) {
+        let entries = &mut cx.default_global::<Self>().entries;
+        entries.retain(|(existing, _)| *existing != tag);
+        entries.push((tag, entry));
+        if entries.len() > MAX_SYSTEM_NOTIFICATION_ENTRIES {
+            let overflow = entries.len() - MAX_SYSTEM_NOTIFICATION_ENTRIES;
+            entries.drain(..overflow);
+        }
+    }
+
+    /// Retract the system notification for `id`, but only if it was posted
+    /// from the given window: another window pushing the same id owns the tag
+    /// now, and this window's local dismiss must not clobber it.
+    fn dismiss(cx: &mut App, id: &NotificationId, window_id: WindowId) {
+        let tag = id.system_tag();
+        let entries = &mut cx.default_global::<Self>().entries;
+        let Some(ix) = entries.iter().position(|(existing, entry)| {
+            *existing == tag && entry.window.window_id() == window_id
+        }) else {
+            return;
+        };
+        entries.remove(ix);
+        cx.dismiss_system_notification(&tag);
+    }
+
+    /// Retract all of the window's system notifications whose id matches the
+    /// given [`TypeId`], regardless of the [`NotificationId`] variant.
+    fn dismiss_by_type(cx: &mut App, type_id: TypeId, window_id: WindowId) {
+        Self::dismiss_matching(cx, window_id, |id| match id {
+            NotificationId::Id(t) | NotificationId::IdAndElementId(t, _) => *t == type_id,
+        });
+    }
+
+    /// Retract all system notifications posted from the given window.
+    fn dismiss_all(cx: &mut App, window_id: WindowId) {
+        Self::dismiss_matching(cx, window_id, |_| true);
+    }
+
+    fn dismiss_matching(
+        cx: &mut App,
+        window_id: WindowId,
+        matches: impl Fn(&NotificationId) -> bool,
+    ) {
+        let entries = &mut cx.default_global::<Self>().entries;
+        let mut tags = Vec::new();
+        entries.retain(|(tag, entry)| {
+            if entry.window.window_id() == window_id && matches(&entry.id) {
+                tags.push(tag.clone());
+                false
+            } else {
+                true
+            }
+        });
+        for tag in tags {
+            cx.dismiss_system_notification(&tag);
+        }
+    }
+
+    fn handle_response(response: SystemNotificationResponse, cx: &mut App) {
+        if !response.tag.starts_with(SYSTEM_TAG_PREFIX) {
+            return;
+        }
+        // Platforms usually remove a clicked notification themselves; retract
+        // explicitly for the ones that keep it in the notification center.
+        cx.dismiss_system_notification(&response.tag);
+        // The prefix already proves the notification is ours, so activate even
+        // when nothing is left to dispatch to: the platform can deliver a
+        // response for a notification posted before the process restarted, and
+        // entries are pruned past `MAX_SYSTEM_NOTIFICATION_ENTRIES`.
+        cx.activate(true);
+        let entries = &mut cx.default_global::<Self>().entries;
+        let Some(ix) = entries.iter().position(|(tag, _)| *tag == response.tag) else {
+            return;
+        };
+        let (_, entry) = entries.remove(ix);
+        // Errs when the window is already closed: the entry is removed and the
+        // application is still brought to the foreground.
+        let _ = entry.window.update(cx, |_, window, cx| {
+            window.activate_window();
+            if let Some(list) = entry.list.upgrade() {
+                // No-op when the toast already closed or was never created
+                // (system-only delivery).
+                list.update(cx, |list, cx| list.close(entry.id.clone(), window, cx));
+            }
+            if let Some(on_click) = entry.on_click {
+                on_click(&ClickEvent::default(), window, cx);
+            }
+        });
     }
 }
 
@@ -569,12 +778,23 @@ impl NotificationList {
     pub fn push(
         &mut self,
         notification: impl Into<Notification>,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let notification = notification.into();
+        let delivery = notification
+            .delivery
+            .unwrap_or(cx.theme().notification.delivery);
+        if delivery.includes_system() {
+            Self::push_system(&notification, window, cx);
+        }
+        if !delivery.includes_in_app() {
+            return;
+        }
+
         let id = notification.id.clone();
         let autohide = notification.autohide;
+        let window_id = window.window_handle().window_id();
 
         let notification = cx.new(|_| notification);
 
@@ -589,6 +809,7 @@ impl NotificationList {
                     if let Some(note) = view.notifications.get(&dismiss_id) {
                         note.update(cx, |note, cx| note.begin_close(cx));
                     }
+                    SystemNotificationRegistry::dismiss(cx, &dismiss_id, window_id);
                 }
             }),
         );
@@ -602,6 +823,31 @@ impl NotificationList {
             cx.background_executor().now(),
         );
         cx.notify();
+    }
+
+    /// Post the notification to the OS notification center and register the
+    /// state needed to dispatch the user's response back to this window.
+    fn push_system(notification: &Notification, window: &Window, cx: &mut Context<Self>) {
+        let (title, body) = match (&notification.title, &notification.message) {
+            (Some(title), message) => (title.clone(), message.clone().unwrap_or_default()),
+            (None, Some(message)) => (message.clone(), SharedString::default()),
+            // A content-only notification has nothing textual to show.
+            (None, None) => return,
+        };
+        let tag = notification.id.system_tag();
+        let entry = SystemNotificationEntry {
+            window: window.window_handle(),
+            list: cx.entity().downgrade(),
+            id: notification.id.clone(),
+            on_click: notification.on_click.clone(),
+        };
+        SystemNotificationRegistry::insert(cx, tag.clone(), entry);
+        cx.show_system_notification(SystemNotification {
+            tag,
+            title,
+            body,
+            actions: Vec::new(),
+        });
     }
 
     fn advance(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -631,10 +877,13 @@ impl NotificationList {
     pub(crate) fn close(
         &mut self,
         id: impl Into<NotificationId>,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let id: NotificationId = id.into();
+        // Unconditional: a system-only notification has no toast to dismiss,
+        // but its system counterpart must still be retracted.
+        SystemNotificationRegistry::dismiss(cx, &id, window.window_handle().window_id());
         if self
             .notifications
             .dismiss(&id, cx.background_executor().now())
@@ -651,9 +900,14 @@ impl NotificationList {
     pub(crate) fn close_by_type(
         &mut self,
         type_id: TypeId,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        SystemNotificationRegistry::dismiss_by_type(
+            cx,
+            type_id,
+            window.window_handle().window_id(),
+        );
         let matched: Vec<_> = self
             .notifications
             .iter()
@@ -675,7 +929,8 @@ impl NotificationList {
         cx.notify();
     }
 
-    pub fn clear(&mut self, _: &mut Window, cx: &mut Context<Self>) {
+    pub fn clear(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        SystemNotificationRegistry::dismiss_all(cx, window.window_handle().window_id());
         for id in self
             .notifications
             .dismiss_all(cx.background_executor().now())
@@ -808,12 +1063,52 @@ mod tests {
             .message("message")
             .with_type(NotificationType::Success)
             .placement(Anchor::BottomLeft)
+            .delivery(NotificationDelivery::System)
             .autohide(false);
         assert_eq!(note.title, Some("title".into()));
         assert_eq!(note.message, Some("message".into()));
         assert!(matches!(note.type_, Some(NotificationType::Success)));
         assert_eq!(note.placement, Some(Anchor::BottomLeft));
+        assert_eq!(note.delivery, Some(NotificationDelivery::System));
         assert!(!note.autohide);
+
+        assert_eq!(Notification::new().delivery, None);
+        assert_eq!(
+            Notification::new().system().delivery,
+            Some(NotificationDelivery::System)
+        );
+        assert_eq!(
+            Notification::new().in_app_and_system().delivery,
+            Some(NotificationDelivery::InAppAndSystem)
+        );
+    }
+
+    #[test]
+    fn notification_delivery_includes() {
+        assert!(NotificationDelivery::InApp.includes_in_app());
+        assert!(!NotificationDelivery::InApp.includes_system());
+        assert!(!NotificationDelivery::System.includes_in_app());
+        assert!(NotificationDelivery::System.includes_system());
+        assert!(NotificationDelivery::InAppAndSystem.includes_in_app());
+        assert!(NotificationDelivery::InAppAndSystem.includes_system());
+    }
+
+    #[test]
+    fn system_tag_is_stable_and_namespaced() {
+        let by_type = NotificationId::from(TypeId::of::<FooKind>());
+        assert_eq!(by_type.system_tag(), by_type.clone().system_tag());
+        assert!(by_type.system_tag().starts_with(SYSTEM_TAG_PREFIX));
+
+        let key1 = NotificationId::from((TypeId::of::<FooKind>(), ElementId::from(1usize)));
+        let key2 = NotificationId::from((TypeId::of::<FooKind>(), ElementId::from(2usize)));
+        assert_ne!(key1.system_tag(), key2.system_tag());
+        assert_ne!(by_type.system_tag(), key1.system_tag());
+
+        // Default (uuid) ids never collide, so they never replace each other.
+        assert_ne!(
+            Notification::new().id.system_tag(),
+            Notification::new().id.system_tag()
+        );
     }
 
     /// A stack's element id must not depend on how many other placements are
@@ -1151,5 +1446,183 @@ mod tests {
         flush_dismiss(cx);
 
         assert_eq!(ids(&list, cx).len(), 1);
+    }
+
+    /// Applications may post their own system notifications; a response for
+    /// one of those must not be retracted or dispatched by the library.
+    #[gpui::test]
+    fn response_for_a_foreign_tag_is_ignored(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            init(cx);
+            cx.set_app_identity("com.example.test", "Test");
+        });
+        cx.simulate_system_notification_response(SystemNotificationResponse {
+            tag: "com.example.app/own-tag".into(),
+            action_id: None,
+        });
+        cx.run_until_parked();
+        assert!(cx.dismissed_system_notifications().is_empty());
+    }
+
+    #[gpui::test]
+    fn system_delivery_posts_to_center_without_in_app_toast(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.set_global(Theme::default());
+            init(cx);
+            // The test platform drops posts until an identity is set,
+            // mirroring Windows.
+            cx.set_app_identity("com.example.test", "Test");
+        });
+        let (root, cx) = cx.add_window_view(|window, cx| TestRoot {
+            list: cx.new(|cx| NotificationList::new(window, cx)),
+            other_focus: cx.focus_handle(),
+        });
+        let list = root.read_with(cx, |r, _| r.list.clone());
+
+        list.update_in(cx, |list, window, cx| {
+            list.push(
+                Notification::info("body text")
+                    .title("Title")
+                    .id::<FooKind>()
+                    .delivery(NotificationDelivery::System),
+                window,
+                cx,
+            );
+            // Message-only: the message becomes the system title.
+            list.push(
+                Notification::info("message only")
+                    .id::<BarKind>()
+                    .delivery(NotificationDelivery::System),
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+
+        let shown = cx.shown_system_notifications();
+        assert_eq!(shown.len(), 2);
+        assert_eq!(
+            shown[0].tag,
+            NotificationId::Id(TypeId::of::<FooKind>()).system_tag()
+        );
+        assert_eq!(shown[0].title, "Title");
+        assert_eq!(shown[0].body, "body text");
+        assert_eq!(shown[1].title, "message only");
+        assert_eq!(shown[1].body, "");
+        assert!(ids(&list, cx).is_empty(), "no in-app toast should exist");
+
+        // System-only notifications are still retractable through the
+        // regular close path even though no toast entity exists.
+        list.update_in(cx, |list, window, cx| {
+            list.close(TypeId::of::<FooKind>(), window, cx);
+        });
+        assert_eq!(
+            cx.dismissed_system_notifications(),
+            vec![NotificationId::Id(TypeId::of::<FooKind>()).system_tag()]
+        );
+    }
+
+    #[gpui::test]
+    fn system_click_activates_window_closes_toast_and_fires_on_click(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.set_global(Theme::default());
+            init(cx);
+            cx.set_app_identity("com.example.test", "Test");
+        });
+        let (root, cx) = cx.add_window_view(|window, cx| TestRoot {
+            list: cx.new(|cx| NotificationList::new(window, cx)),
+            other_focus: cx.focus_handle(),
+        });
+        let list = root.read_with(cx, |r, _| r.list.clone());
+
+        let clicked = Rc::new(std::cell::Cell::new(false));
+        let on_click_flag = clicked.clone();
+        list.update_in(cx, |list, window, cx| {
+            list.push(
+                Notification::info("message")
+                    .title("Title")
+                    .id::<FooKind>()
+                    .delivery(NotificationDelivery::InAppAndSystem)
+                    .autohide(false)
+                    .on_click(move |_, _, _| on_click_flag.set(true)),
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+        assert_eq!(ids(&list, cx).len(), 1);
+        assert_eq!(cx.shown_system_notifications().len(), 1);
+
+        cx.simulate_system_notification_response(SystemNotificationResponse {
+            tag: NotificationId::Id(TypeId::of::<FooKind>()).system_tag(),
+            action_id: None,
+        });
+        cx.run_until_parked();
+
+        assert!(clicked.get(), "on_click should fire on system response");
+        flush_dismiss(cx);
+        assert!(
+            ids(&list, cx).is_empty(),
+            "the in-app counterpart should be closed"
+        );
+    }
+
+    #[gpui::test]
+    fn explicit_close_retracts_system_notification_but_autohide_does_not(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.set_global(Theme::default());
+            init(cx);
+            cx.set_app_identity("com.example.test", "Test");
+        });
+        let (root, cx) = cx.add_window_view(|window, cx| TestRoot {
+            list: cx.new(|cx| NotificationList::new(window, cx)),
+            other_focus: cx.focus_handle(),
+        });
+        cx.update(|window, _| window.activate_window());
+        let list = root.read_with(cx, |r, _| r.list.clone());
+
+        // Autohide expiry leaves the system notification in the center.
+        list.update_in(cx, |list, window, cx| {
+            list.push(
+                Notification::info("auto")
+                    .id::<FooKind>()
+                    .delivery(NotificationDelivery::InAppAndSystem),
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+        cx.background_executor.advance_clock(Duration::from_secs(6));
+        cx.run_until_parked();
+        flush_dismiss(cx);
+        assert!(
+            ids(&list, cx).is_empty(),
+            "the toast should have autohidden"
+        );
+        assert!(
+            cx.dismissed_system_notifications().is_empty(),
+            "autohide must not retract the system notification"
+        );
+
+        // An explicit close retracts it.
+        list.update_in(cx, |list, window, cx| {
+            list.push(
+                Notification::info("manual")
+                    .id::<BarKind>()
+                    .delivery(NotificationDelivery::InAppAndSystem)
+                    .autohide(false),
+                window,
+                cx,
+            );
+        });
+        cx.run_until_parked();
+        list.update_in(cx, |list, window, cx| {
+            list.close(TypeId::of::<BarKind>(), window, cx);
+        });
+        flush_dismiss(cx);
+        assert_eq!(
+            cx.dismissed_system_notifications(),
+            vec![NotificationId::Id(TypeId::of::<BarKind>()).system_tag()]
+        );
     }
 }

--- a/website/docs/components/notification.md
+++ b/website/docs/components/notification.md
@@ -193,6 +193,51 @@ Then remove the notification with `window.remove_notification::<UpdateNotificati
 window.remove_notification::<UpdateNotification>(cx);
 ```
 
+### System Notification
+
+A notification can also be delivered to the operating system's notification
+center. Use `NotificationDelivery` to choose where a notification goes: as an
+in-app toast (`InApp`, the default), in the OS notification center (`System`),
+or both (`InAppAndSystem`).
+
+```rust
+use gpui_component::notification::{Notification, NotificationDelivery};
+
+// Per-notification override; `.system()` and `.in_app_and_system()` are
+// shorthands for `.delivery(NotificationDelivery::...)`.
+Notification::info("Your download is ready.")
+    .title("Download complete")
+    .system()
+
+// Or set a global default for all notifications
+Theme::global_mut(cx).notification.delivery = NotificationDelivery::InAppAndSystem;
+```
+
+The notification's title and message become the system notification's title
+and body; a notification with neither is not posted. Pushing again with the
+same `.id::<T>()` replaces the previous system notification, and
+`window.remove_notification::<T>(cx)` / `window.clear_notifications(cx)`
+retract it. When the toast auto-hides, the system notification stays in the
+notification center.
+
+Clicking the system notification activates the application and its window,
+closes the in-app toast (if any), and fires `on_click` with a default
+`ClickEvent`. With `NotificationDelivery::System` no toast exists, so
+`on_close` is never called.
+
+`gpui_component::init` registers the app-global
+`on_system_notification_response` handler, so do not register your own after
+it — gpui keeps only one. Notifications your application posts directly via
+`cx.show_system_notification` are left untouched.
+
+Platform requirements:
+
+| Platform | Requirement | Retraction |
+| --- | --- | --- |
+| macOS | Must run from a bundled `.app` in a trusted location (e.g. `/Applications`); silently disabled under plain `cargo run`. The first post triggers the system authorization prompt; a denial is remembered and later posts fail silently | Supported |
+| Windows | Call `cx.set_app_identity(identifier, name)` early in startup | Supported |
+| Linux | An XDG notification daemon must be present | Unsupported (ages out) |
+
 ## Examples
 
 ### Form Validation Error

--- a/website/zh-CN/docs/components/notification.md
+++ b/website/zh-CN/docs/components/notification.md
@@ -175,6 +175,37 @@ window.remove_notification::<UpdateNotification>(cx);
 
 来移除对应通知。
 
+### 系统通知
+
+通知也可以投递到操作系统的通知中心。使用 `NotificationDelivery` 选择通知的去向：应用内 toast（`InApp`，默认）、系统通知中心（`System`）、或两者都发（`InAppAndSystem`）。
+
+```rust
+use gpui_component::notification::{Notification, NotificationDelivery};
+
+// 单条通知覆盖；`.system()` 和 `.in_app_and_system()` 是
+// `.delivery(NotificationDelivery::...)` 的简写。
+Notification::info("Your download is ready.")
+    .title("Download complete")
+    .system()
+
+// 或为所有通知设置全局默认值
+Theme::global_mut(cx).notification.delivery = NotificationDelivery::InAppAndSystem;
+```
+
+通知的标题和消息分别成为系统通知的标题和正文；两者都缺失时不会投递。用相同的 `.id::<T>()` 再次推送会替换之前的系统通知，`window.remove_notification::<T>(cx)` / `window.clear_notifications(cx)` 会将其撤回。toast 自动隐藏时，系统通知会保留在通知中心。
+
+点击系统通知会激活应用及其窗口、关闭对应的应用内 toast（如有）、并以默认的 `ClickEvent` 触发 `on_click`。`NotificationDelivery::System` 模式下没有 toast，因此 `on_close` 不会被调用。
+
+`gpui_component::init` 会注册应用级的 `on_system_notification_response` 处理器，之后请勿再自行注册——gpui 只保留一个。应用通过 `cx.show_system_notification` 直接发送的系统通知不受影响。
+
+平台要求：
+
+| 平台 | 要求 | 撤回 |
+| --- | --- | --- |
+| macOS | 必须从可信位置（如 `/Applications`）的打包 `.app` 运行；`cargo run` 裸跑时静默禁用。首次投递会触发系统授权弹窗，拒绝后系统会记住该选择，后续投递静默失败 | 支持 |
+| Windows | 启动早期调用 `cx.set_app_identity(identifier, name)` | 支持 |
+| Linux | 需要 XDG 通知守护进程 | 不支持（自然过期） |
+
 ## 示例
 
 ### 表单校验失败


### PR DESCRIPTION
## Description

Notifications were in-app toasts only. This adds an opt-in bridge to the operating system's notification center, built on gpui's `SystemNotification` API — no new dependencies.

- `NotificationDelivery` selects where a notification goes: `InApp` (default), `System`, or `InAppAndSystem`. Global default via `NotificationSettings::delivery`, per-notification override via `Notification::delivery`, with `.system()` / `.in_app_and_system()` shorthands.
- The title and message map to the system notification; pushing the same `.id::<T>()` replaces it, and explicit dismissal (close button, `remove_notification`, `clear_notifications`) retracts it. Autohide expiry leaves it in the notification center.
- Clicking the system notification activates the app and window, closes the in-app counterpart, and fires `on_click`. `gpui_component::init` owns the single app-global response handler.
- Platform requirements are documented (macOS needs a bundled `.app` in a trusted location, Windows needs `set_app_identity`, Linux needs a notification daemon); plain `cargo run` degrades to in-app only.

The story adds a "System notification" section; docs updated in en and zh-CN.

Note: `NotificationSettings` gains a `delivery` field, so code constructing it exhaustively without `..Default::default()` needs to add the field.