### PR TITLE
command: Move the row inset onto the virtual list

### DIFF
--- a/crates/ui/src/command/state.rs
+++ b/crates/ui/src/command/state.rs
@@ -850,13 +850,17 @@ impl Render for CommandState {
                     .role(Role::ListBox)
                     .relative()
                     .flex_1()
-                    .p_1()
+                    // The rows carry their inset on the virtual list itself so
+                    // that a mid-scroll clip edge sits flush against the
+                    // surrounding dividers; only the empty slot needs the
+                    // container padding.
+                    .when(rows_count == 0, |this| this.p_1())
                     .on_prepaint({
                         let measure_state = command_state.clone();
                         move |bounds, window, cx| {
                             measure_state.update(cx, |state, cx| {
-                                // `p_1` is one quarter rem on each side. Its
-                                // rem-dependent padding and inherited
+                                // The list's `p_1` is one quarter rem on each
+                                // side. Its rem-dependent padding and inherited
                                 // layout-relevant text style participate in
                                 // the row-size cache key.
                                 let text_style = window.text_style();
@@ -903,6 +907,11 @@ impl Render for CommandState {
                                         .collect::<Vec<_>>()
                                 },
                             )
+                            // Padding on the virtual list acts like CSS
+                            // scroll-padding: the scroll ends keep their inset
+                            // while scrolled-under rows paint and clip at the
+                            // list edge.
+                            .p_1()
                             .with_sizing_behavior(ListSizingBehavior::Infer)
                             .track_scroll(&self.scroll_handle),
                         )


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="399" height="277" alt="Before" src="https://github.com/user-attachments/assets/be1b1b92-e0fd-4f86-bb09-3780988a1e7e" /> | <img width="403" height="279" alt="After" src="https://github.com/user-attachments/assets/241dc6d7-1e4c-4a34-a9d2-fa0dd1e08796" /> |