### PR TITLE
title_bar: Skip drawn window controls under server-side decorations

### DIFF
--- a/crates/ui/src/title_bar.rs
+++ b/crates/ui/src/title_bar.rs
@@ -254,6 +254,20 @@ impl RenderOnce for WindowControls {
             return div().id("window-controls");
         }
 
+        // Under server-side decorations the window manager already renders
+        // its own title bar, complete with min/max/close; drawing ours as
+        // well stacks a duplicate set of controls on top of it (most
+        // visibly two close buttons). gpui falls back to server-side
+        // decorations on X11 sessions without a compositor, and a Wayland
+        // compositor may grant server mode even when client mode was
+        // requested. Skip ours unless this window is actually client-side
+        // decorated, mirroring the `is_client_decorated` gating of the
+        // title bar's window-menu overlay.
+        #[cfg(target_os = "linux")]
+        if !matches!(window.window_decorations(), Decorations::Client { .. }) {
+            return div().id("window-controls");
+        }
+
         // The window manager declares which controls it can honor; a tiling
         // compositor may support neither minimize nor maximize. Close is
         // always ours to offer.


### PR DESCRIPTION
## Description

`WindowControls` draws min/max/close on every non-macOS platform **unconditionally**. When a window ends up with **server-side** decorations, the window manager renders its own title bar as well, so two sets of controls stack on top of each other — most visibly **two close buttons**.

This is not a corner case; gpui ends up with server-side decorations in common setups:

- **X11 without a compositor** (e.g. a default XFCE session): `request_decorations(Client)` falls back to server-side because client-side decorations need compositor support.
- **Wayland**: a compositor may grant **server mode** via xdg-decoration even when client mode was requested — `set_mode` is only a preference.

The title bar already gates its client-side window-menu overlay on `is_client_decorated` (title_bar.rs:320); this PR applies the same gating to the drawn controls, so exactly **one** set of window controls is visible in every combination:

| Decorations | Who shows min/max/close |
| --- | --- |
| Client-side (Windows, GNOME Wayland fallback, X11 with compositor) | our drawn controls |
| Server-side | the WM's controls (we draw nothing) |

The guard is `cfg(target_os = "linux")`; Windows and macOS behavior is unchanged.

> 🤖 **AI assistance:** the patch and this description were drafted with AI assistance and reviewed by a human. The same change is deployed in a downstream app built on gpui-component where the duplicated controls were first reported.

## Screenshot

Linux captures pending — the duplication needs a Linux session to reproduce (X11 without a compositor, or KWin with server-side decorations). Happy to attach before/after screenshots of a story if maintainers want them; the downstream app confirmed the behavior.

## How to Test

1. `cargo run` the story book and open any story rendering a `TitleBar`.
2. **X11, no compositor** (XFCE with compositing disabled, or a bare `startx` session): before this PR the window shows the WM title bar *plus* our drawn min/max/close; after, only the WM's controls.
3. **Wayland with server-side decorations** (e.g. KWin CSD disabled): same duplication before, single set after.
4. **macOS / Windows**: no change (guard is Linux-only).

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific) — macOS verified unchanged; Linux verified in the downstream app carrying the identical patch; Windows unaffected by construction.