### PR TITLE
virtual_list: Measure the sample item at the viewport width for vertical lists

### DIFF
--- a/crates/base/src/virtual_list.rs
+++ b/crates/base/src/virtual_list.rs
@@ -31,9 +31,7 @@ use crate::{AxisExt, InteractiveElementExt as _};
 struct VirtualListScrollHandleState {
     axis: Axis,
     items_count: usize,
-    /// The content bounds size (excluding padding and border) of the list in
-    /// the last frame, used to measure the sample item with a definite
-    /// cross-axis constraint.
+    /// Content bounds size (excluding padding and border) from the last frame.
     last_content_size: Option<Size<Pixels>>,
     pub deferred_scroll_to_item: Option<DeferredScrollToItem>,
 }
@@ -384,14 +382,10 @@ impl Element for VirtualList {
         let rem_size = window.rem_size();
         let font_size = window.text_style().font_size.to_pixels(rem_size);
         let mut size_layout = ItemSizeLayout::default();
-        // For vertical lists, measure the sample item with the last known
-        // content width, so relative widths and text truncation resolve the
-        // same way as the visible items (which are laid out at the content
-        // bounds width in prepaint). An unconstrained (`MinContent`) measure
-        // lets a single long non-wrapping text report its full width, which
-        // then becomes a phantom horizontal scroll range with blank space.
-        // Items wider than the viewport (e.g. with `min_w`) still measure
-        // larger and keep the horizontal scrolling.
+        // Measure vertical lists at the last known content width so relative
+        // widths and text truncation resolve like the visible rows; an
+        // unconstrained measure would turn one long non-wrapping text into a
+        // phantom horizontal scroll range.
         let list_width = if self.axis.is_vertical() {
             self.scroll_handle
                 .state

--- a/crates/base/src/virtual_list.rs
+++ b/crates/base/src/virtual_list.rs
@@ -31,6 +31,10 @@ use crate::{AxisExt, InteractiveElementExt as _};
 struct VirtualListScrollHandleState {
     axis: Axis,
     items_count: usize,
+    /// The content bounds size (excluding padding and border) of the list in
+    /// the last frame, used to measure the sample item with a definite
+    /// cross-axis constraint.
+    last_content_size: Option<Size<Pixels>>,
     pub deferred_scroll_to_item: Option<DeferredScrollToItem>,
 }
 
@@ -90,6 +94,7 @@ impl VirtualListScrollHandle {
             state: Rc::new(RefCell::new(VirtualListScrollHandleState {
                 axis: Axis::Vertical,
                 items_count: 0,
+                last_content_size: None,
                 deferred_scroll_to_item: None,
             })),
             base_handle: ScrollHandle::default(),
@@ -379,7 +384,25 @@ impl Element for VirtualList {
         let rem_size = window.rem_size();
         let font_size = window.text_style().font_size.to_pixels(rem_size);
         let mut size_layout = ItemSizeLayout::default();
-        let longest_item_size = self.measure_item(None, window, cx);
+        // For vertical lists, measure the sample item with the last known
+        // content width, so relative widths and text truncation resolve the
+        // same way as the visible items (which are laid out at the content
+        // bounds width in prepaint). An unconstrained (`MinContent`) measure
+        // lets a single long non-wrapping text report its full width, which
+        // then becomes a phantom horizontal scroll range with blank space.
+        // Items wider than the viewport (e.g. with `min_w`) still measure
+        // larger and keep the horizontal scrolling.
+        let list_width = if self.axis.is_vertical() {
+            self.scroll_handle
+                .state
+                .borrow()
+                .last_content_size
+                .map(|size| size.width)
+                .filter(|width| !width.is_zero())
+        } else {
+            None
+        };
+        let longest_item_size = self.measure_item(list_width, window, cx);
 
         let layout_id = self.base.interactivity().request_layout(
             global_id,
@@ -587,6 +610,7 @@ impl Element for VirtualList {
         let mut scroll_state = self.scroll_handle.state.borrow_mut();
         scroll_state.axis = axis;
         scroll_state.items_count = self.items_count;
+        scroll_state.last_content_size = Some(content_bounds.size);
 
         let mut scroll_offset = self.scroll_handle.offset();
         if let Some(scroll_to_item) = scroll_state.deferred_scroll_to_item.take() {


### PR DESCRIPTION
## Summary

- Fixes phantom horizontal scrolling in vertical lists: when the sample item used for size measurement (by default the first row) contains a long non-wrapping text (e.g. `.truncate()`), measuring it with `AvailableSpace::MinContent` reports the full untruncated text width. That width becomes the list's horizontal scroll content size (`content_size.width`), while the visible rows are actually laid out at the viewport width — so the list can be scrolled sideways into blank space.
- Record the content bounds size (excluding padding and border) in `VirtualListScrollHandleState` during prepaint, and pass it as a definite width constraint to `measure_item` for vertical lists. Relative widths (`flex_1`, `w_1_4`, …) and text truncation then resolve exactly the same way as for the visible rows, so the measured width matches the real layout.
- Items that are genuinely wider than the viewport (e.g. via `min_w`) still measure larger than the definite constraint and keep their horizontal scroll range. Horizontal lists are unchanged. On the first frame (no recorded size yet) the old `MinContent` behavior is used and the measurement converges on the next frame.

Observed in Longbridge's watchlist list mode: a long stock name in the first row made the whole list horizontally scrollable with a blank area on the right, even though the name itself was properly truncated with an ellipsis.

## Related PRs

- Regression surfaced by #2571: before it, `VirtualList` always measured flattened item `0` — for `List` that is the (often empty) section-header entry, so `content_size.width` was ~0 and the phantom scroll range never appeared. #2571 correctly routes the real first data row into the measurement (needed for the completion menu's intrinsic width), which exposed the unconstrained `MinContent` measurement fixed here. This PR keeps #2571's behavior intact — `ListSizingBehavior::Infer` still measures intrinsic width on the first frame, and the completion popover constraints are unchanged.

## Test plan

- [x] `cargo test -p gpui-base` (369 tests, including the `virtual_list` visible-range/deferred-scroll tests)
- [x] Verified in the Longbridge desktop app via a path patch: with a long name in the first watchlist row, the list no longer scrolls horizontally and no blank area appears; truncation still shows the ellipsis
- [ ] Verify a vertical list whose rows are intentionally wider than the viewport still scrolls horizontally
- [ ] Verify the editor completion menu still sizes to its longest row (#2571's scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)