### PR TITLE
dock: Stop clipping descenders in the single-panel title bar

### DIFF
--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -14,7 +14,7 @@ use gpui::{
     DragMoveEvent, Empty, Entity, EntityId, EventEmitter, FocusHandle, Focusable,
     InteractiveElement as _, IntoElement, ParentElement, Pixels, Point, Render, ScrollHandle,
     SharedString, StatefulInteractiveElement, StyleRefinement, Styled, WeakEntity, Window, div,
-    point, prelude::FluentBuilder, px, rems,
+    point, prelude::FluentBuilder, px,
 };
 use rust_i18n::t;
 
@@ -774,7 +774,6 @@ impl TabPanel {
 
             return h_flex()
                 .justify_between()
-                .line_height(rems(1.0))
                 .h(px(30.))
                 .py_2()
                 .pl_3()


### PR DESCRIPTION
Closes #2768

## Description

The single-panel dock title bar clipped the descenders off panel titles: a panel
titled `Agent` lost the tail of its `g`, and anything with `g/j/p/q/y` was cut the
same way. It affected every dock region holding one panel, since that is the
default `PanelStyle::Auto` path.

`crates/ui/src/dock/tab_panel.rs` pinned the row's line height to `rems(1.0)`,
which is exactly the 16px default font size. `h_flex()` centres rather than
stretches (`crates/base/src/styled.rs:75-77`), so the title wrapper is sized by
that line box rather than by the row, and its own `overflow_hidden()` turns those
16px into the content mask for the glyphs painted inside it. Glyph ink is ~19px at
that size, and gpui centres ink in the line box instead of clamping it
(`padding_top = (line_height - ascent - descent) / 2` in gpui's `text_system.rs`),
so the descent overhung the mask by ~1.3px and was clipped away.

### How the three pieces drifted apart

`git blame` shows this is a leftover rather than a deliberate constraint:

- **c5c8e46a** (New Dock, #172) introduced `.py_2().px_3().line_height(rems(1.0))`
  with the title as a direct child. There was no `.h()` yet, so the line height
  *was* the row-sizing mechanism: 16px line + 8+8 padding = a 32px row. There was
  no `overflow_hidden()` either, so the ~1.3px of ink overhang simply painted
  outside the line box, harmlessly.
- **7b5efd19** (Better Panel resize, #178) added `.overflow_hidden()` together
  with `.whitespace_nowrap()` to the title wrapper, to keep long titles from
  blowing out the panel when the window shrinks. **9768755e** (#181) then added
  `.text_ellipsis()`. That intent is horizontal, but the side effect is vertical:
  from then on the line box doubles as a glyph mask.
- **6f1be83b** (#291) added `.h(px(30.))` to the row and moved `py_2()` up onto
  it. The explicit height took over the sizing job, which left `line_height`
  without a purpose — but it stayed.

So the override is vestigial, and the clipping is the accidental interaction of
two changes made a month apart for unrelated reasons.

### The fix

This drops the override, letting the line height fall back to gpui's `phi()`
default (~26px). The row height stays pinned by `.h(px(30.))`, so nothing in the
layout moves — only the mask grows enough to hold the ink. `rems` had no other use
in the file, so its import goes with it.

`overflow_hidden()` is deliberately left alone: it carries the horizontal
truncation that #178 and #181 added, so moving it off the text wrapper would
break the ellipsis behaviour.

One effect worth naming: the line height cascades to the row's other children, so
a `Panel::title_suffix()` made of bare text now inherits ~26px instead of 16px.
The row is still pinned at 30px with its children centred, and the toolbar and
dock buttons carry their own heights, so nothing shifts — but it is a behaviour
change in the cascade, not only in the title.

The `PanelStyle::TabBar` path was already correct and is unchanged:
`crates/ui/src/tab/tab.rs:704-711` uses the same 1.0 line height but puts
`overflow_hidden()` on the element carrying the 30px height rather than on the
text wrapper, so its mask is 30px and the ink fits.

## Screenshot

Title bar of a single-panel dock region, magnified 6× — the offset is ~1.3px, so
it needs magnifying to read on a screenshot.

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="1440" height="204" alt="before-zoom" src="https://github.com/user-attachments/assets/70d29bc3-89be-4a5f-b859-b645bfe6dbfd" /> | <img width="1440" height="204" alt="after-zoom" src="https://github.com/user-attachments/assets/22d1529e-243e-4b28-8518-a7a90b4351fd" />|

## How to Test

1. Build any `DockArea` region holding exactly one panel, leaving `PanelStyle` at
   its default, and give the panel a title containing a descender:

   ```rust
   impl Panel for MyPanel {
       fn title(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
           SharedString::from("Agent Projects Pages")
       }
   }
   ```

2. Run it and magnify the title bar. Before this change the tails of `g/j/p` are
   sheared flat against the baseline; after it they are intact.

3. For a side-by-side control, render a second `DockArea` with
   `.panel_style(PanelStyle::TabBar)` and the same panel — that path renders the
   title correctly both before and after, so the two should now match.

4. Shrink the window until the title no longer fits, to confirm the horizontal
   ellipsis added by #178/#181 still works.

Verified on Linux/Wayland with the default theme. `cargo clippy` and
`cargo fmt --check` are clean.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)

## AI Assistance

The root-cause analysis and this description were written with Claude Code. The
code change itself is a two-line deletion — the `line_height` override and the now
unused `rems` import — which I reviewed and verified visually before and after.
The change is not platform-specific: it is a layout constraint, not a text-shaping
or backend detail, so the clipping happens on every platform.
