### PR TITLE
command: Add a `filterable` option for externally filtered palettes

### DIFF
--- a/crates/ui/src/command/command.rs
+++ b/crates/ui/src/command/command.rs
@@ -59,6 +59,7 @@ pub struct Command {
     state: Entity<CommandState>,
     entries: Vec<CommandEntry>,
     searchable: bool,
+    filterable: bool,
     on_query: Option<Rc<OnQuery>>,
     on_select: Option<Rc<OnIndex>>,
     on_confirm: Option<Rc<OnIndex>>,
@@ -73,6 +74,7 @@ impl Command {
             state: state.clone(),
             entries: Vec::new(),
             searchable: true,
+            filterable: true,
             on_query: None,
             on_select: None,
             on_confirm: None,
@@ -109,6 +111,17 @@ impl Command {
     /// Show or hide the query field and local filtering.
     pub fn searchable(mut self, searchable: bool) -> Self {
         self.searchable = searchable;
+        self
+    }
+
+    /// Keep the query field but toggle the local filtering, default: `true`.
+    ///
+    /// Turn it off when an external source already answers the query, such as
+    /// an async search: every supplied item stays visible, the query still
+    /// reports through [`Self::on_query`], and a query change hands the
+    /// highlight back to the first item instead of a local textual match.
+    pub fn filterable(mut self, filterable: bool) -> Self {
+        self.filterable = filterable;
         self
     }
 
@@ -230,6 +243,7 @@ impl RenderOnce for Command {
         let model = CommandModel {
             entries: self.entries,
             searchable: self.searchable,
+            filterable: self.filterable,
             on_query: self.on_query,
             on_select: self.on_select,
             on_confirm: self.on_confirm,

--- a/crates/ui/src/command/state.rs
+++ b/crates/ui/src/command/state.rs
@@ -37,6 +37,7 @@ pub(crate) type OnCancel = dyn Fn(&mut Window, &mut App);
 pub(crate) struct CommandModel {
     pub(crate) entries: Vec<CommandEntry>,
     pub(crate) searchable: bool,
+    pub(crate) filterable: bool,
     pub(crate) on_query: Option<Rc<OnQuery>>,
     pub(crate) on_select: Option<Rc<OnIndex>>,
     pub(crate) on_confirm: Option<Rc<OnIndex>>,
@@ -48,6 +49,7 @@ impl Default for CommandModel {
         Self {
             entries: Vec::new(),
             searchable: true,
+            filterable: true,
             on_query: None,
             on_select: None,
             on_confirm: None,
@@ -300,7 +302,7 @@ impl CommandState {
     // MARK: Matching
 
     fn item_matches(&self, item: &CommandItem, query: &str) -> bool {
-        if !self.model.searchable || query.is_empty() {
+        if !self.model.searchable || !self.model.filterable || query.is_empty() {
             true
         } else {
             item.matches(query)
@@ -1474,6 +1476,39 @@ mod tests {
                 assert_eq!(state.matched_count(), 0);
                 assert!(state.rows.is_empty());
                 assert_eq!(state.selected_index(), None);
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn filterable_off_keeps_every_item_and_resets_the_highlight(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+
+        cx.update(|window, cx| {
+            let state = cx.new(|cx| {
+                let mut state = CommandState::new(window, cx);
+                state.install_model(
+                    CommandModel {
+                        entries: suggestion_entries(),
+                        filterable: false,
+                        ..CommandModel::default()
+                    },
+                    cx,
+                );
+                state
+            });
+
+            state.update(cx, |state, cx| {
+                state.set_selected_index(Some(IndexPath::new(1).section(1)), window, cx);
+
+                // "Bil" would locally match only "Billing"; an unfiltered
+                // palette keeps every row and hands the highlight back to the
+                // first item instead of the textual match.
+                state.set_query("Bil", window, cx);
+
+                assert_eq!(state.matched_count(), 5);
+                assert_eq!(state.selected_index(), Some(IndexPath::new(0).section(0)));
             });
         });
     }


### PR DESCRIPTION
## Summary

- Add `Command::filterable(bool)` (default `true`): keeps the query field, spinner and key bindings, but skips the local substring filtering so every supplied item stays visible.
- For an externally filtered source (e.g. an async server-side search) the local filter only gets in the way: it drops matches the backend understood (pinyin, ticker formats), and a query change re-filters the stale items and hands the highlight to an arbitrary textual match. With `filterable(false)` a query change resets the highlight to the first item, and the query still reports through `on_query`.
- Existing palettes are unaffected; `searchable(false)` behavior is unchanged.

## Test plan

- [ ] `cargo test -p gpui-component command` (33 tests, including the new `filterable_off_keeps_every_item_and_resets_the_highlight`)
- [ ] Story: the Command examples still filter and highlight as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)