### PR TITLE
input: Keep highlight runs on char boundaries of the shaped text

### DIFF
--- a/crates/base/src/input/base/element.rs
+++ b/crates/base/src/input/base/element.rs
@@ -2942,23 +2942,23 @@ mod tests {
         };
         let lens = |runs: &[TextRun]| runs.iter().map(|run| run.len).collect::<Vec<_>>();
 
-        // "成交量" is 9 bytes; boundaries at 0, 3, 6, 9.
-        let text = "成交量";
+        // "你好，世界" is 15 bytes; boundaries at 0, 3, 6, 9, 12, 15.
+        let text = "你好，世界";
 
         // Aligned runs pass through untouched.
-        assert_eq!(align_runs_to_char_boundaries(text, &runs(&[3, 6])), None);
+        assert_eq!(align_runs_to_char_boundaries(text, &runs(&[3, 12])), None);
 
         // A mid-char boundary (4) snaps up to the next boundary (6).
-        let aligned = align_runs_to_char_boundaries(text, &runs(&[4, 5])).unwrap();
-        assert_eq!(lens(&aligned), vec![6, 3]);
+        let aligned = align_runs_to_char_boundaries(text, &runs(&[4, 11])).unwrap();
+        assert_eq!(lens(&aligned), vec![6, 9]);
 
         // Several boundaries inside the same char collapse into one run.
-        let aligned = align_runs_to_char_boundaries(text, &runs(&[1, 1, 7])).unwrap();
-        assert_eq!(lens(&aligned), vec![3, 6]);
+        let aligned = align_runs_to_char_boundaries(text, &runs(&[1, 1, 13])).unwrap();
+        assert_eq!(lens(&aligned), vec![3, 12]);
 
         // Overshooting runs are capped at the text length.
         let aligned = align_runs_to_char_boundaries(text, &runs(&[3, 20])).unwrap();
-        assert_eq!(lens(&aligned), vec![3, 6]);
+        assert_eq!(lens(&aligned), vec![3, 12]);
 
         // Undershooting runs keep the shortfall (the tail is left unshaped,
         // matching `runs_for_range` clipping).

--- a/crates/base/src/input/base/element.rs
+++ b/crates/base/src/input/base/element.rs
@@ -1301,12 +1301,12 @@ impl<M: InputModeKind> TextElement<M> {
         let is_single_line = state.is_single_line();
 
         if is_single_line {
-            let shaped_line = window.text_system().shape_line(
-                display_text.to_string().into(),
-                font_size,
-                &runs,
-                None,
-            );
+            let text: SharedString = display_text.to_string().into();
+            let aligned_runs = align_runs_to_char_boundaries(&text, runs);
+            let line_runs = aligned_runs.as_deref().unwrap_or(runs);
+            let shaped_line = window
+                .text_system()
+                .shape_line(text, font_size, line_runs, None);
 
             let line_layout = LineLayout::new()
                 .lines(smallvec::smallvec![shaped_line])
@@ -1366,6 +1366,8 @@ impl<M: InputModeKind> TextElement<M> {
                 };
 
                 let sub_line: SharedString = line_text[range.clone()].to_string().into();
+                let line_runs =
+                    align_runs_to_char_boundaries(&sub_line, &line_runs).unwrap_or(line_runs);
                 let shaped_line = window
                     .text_system()
                     .shape_line(sub_line, font_size, &line_runs, None);
@@ -1441,28 +1443,34 @@ impl<M: InputModeKind> TextElement<M> {
         };
 
         let mut styles = Vec::with_capacity(visible_buffer_lines.len());
+        // Byte ranges of the flushed line groups; the composed styles are
+        // clipped to these at the end so the resulting runs cover exactly the
+        // visible (non-folded) lines' bytes.
+        let mut group_ranges: Vec<Range<usize>> = Vec::new();
 
         // Helper to flush a contiguous range of lines. These ranges are disjoint,
         // so appending avoids repeatedly cloning and recombining prior styles.
-        let flush_range = |start_line: usize, end_line: usize, skip: bool, styles: &mut Vec<_>| {
-            let byte_start = text.line_start_offset(start_line);
-            let byte_end = if is_multi_line {
-                // +1 for `\n`
-                text.line_start_offset(end_line + 1)
-            } else {
-                text.line_end_offset(end_line)
-            };
-            let range_styles = if skip {
-                vec![(byte_start..byte_end, HighlightStyle::default())]
-            } else {
-                highlighter.styles(
-                    &(byte_start..byte_end),
-                    state.editor_style.highlight_styles.as_ref(),
-                )
-            };
+        let mut flush_range =
+            |start_line: usize, end_line: usize, skip: bool, styles: &mut Vec<_>| {
+                let byte_start = text.line_start_offset(start_line);
+                let byte_end = if is_multi_line {
+                    // +1 for `\n`
+                    text.line_start_offset(end_line + 1)
+                } else {
+                    text.line_end_offset(end_line)
+                };
+                let range_styles = if skip {
+                    vec![(byte_start..byte_end, HighlightStyle::default())]
+                } else {
+                    highlighter.styles(
+                        &(byte_start..byte_end),
+                        state.editor_style.highlight_styles.as_ref(),
+                    )
+                };
 
-            styles.extend(range_styles);
-        };
+                group_ranges.push(byte_start..byte_end);
+                styles.extend(range_styles);
+            };
 
         // Group contiguous visible lines into ranges and call styles() once per range
         let mut visible_iter = visible_buffer_lines.iter().peekable();
@@ -1533,6 +1541,13 @@ impl<M: InputModeKind> TextElement<M> {
             .unwrap_or_default();
         }
         styles = gpui::combine_highlights(diagnostic_styles, styles).collect();
+
+        // Some sources reach outside the flushed groups — a diagnostic
+        // straddling the viewport edge, or any range inside a folded region —
+        // which would inject extra bytes into the runs coordinate space and
+        // shift every later run boundary (see `layout_lines`). Clip the
+        // composed styles back to the groups.
+        styles = clip_styles_to_ranges(styles, &group_ranges);
 
         Some(styles)
     }
@@ -2413,6 +2428,71 @@ pub(super) fn runs_for_range(
     result
 }
 
+/// Clip sorted `styles` to the sorted, disjoint `ranges`, splitting styles
+/// that span several ranges and dropping coverage in the gaps between them.
+fn clip_styles_to_ranges(
+    styles: Vec<(Range<usize>, HighlightStyle)>,
+    ranges: &[Range<usize>],
+) -> Vec<(Range<usize>, HighlightStyle)> {
+    let mut result = Vec::with_capacity(styles.len());
+    let mut range_ix = 0;
+
+    for (style_range, style) in styles {
+        while range_ix < ranges.len() && ranges[range_ix].end <= style_range.start {
+            range_ix += 1;
+        }
+
+        let mut ix = range_ix;
+        while ix < ranges.len() && ranges[ix].start < style_range.end {
+            let start = style_range.start.max(ranges[ix].start);
+            let end = style_range.end.min(ranges[ix].end);
+            if start < end {
+                result.push((start..end, style));
+            }
+            ix += 1;
+        }
+    }
+
+    result
+}
+
+/// Snap run boundaries to char boundaries of `text` and cap them at its
+/// length. Style ranges are byte offsets that can drift off char boundaries
+/// (a stale syntax tree, a range in the wrong coordinate space) and the
+/// platform text system panics when a run splits a multi-byte character.
+///
+/// Returns `None` when the runs are already aligned (the common case).
+pub(super) fn align_runs_to_char_boundaries(text: &str, runs: &[TextRun]) -> Option<Vec<TextRun>> {
+    let mut end = 0;
+    let aligned = runs.iter().all(|run| {
+        end += run.len;
+        end <= text.len() && text.is_char_boundary(end)
+    });
+    if aligned {
+        return None;
+    }
+
+    let mut result = Vec::with_capacity(runs.len());
+    let mut cursor = 0;
+    let mut raw_end = 0;
+    for run in runs {
+        raw_end = (raw_end + run.len).min(text.len());
+        let mut end = raw_end;
+        while !text.is_char_boundary(end) {
+            end += 1;
+        }
+        if end > cursor {
+            result.push(TextRun {
+                len: end - cursor,
+                ..run.clone()
+            });
+            cursor = end;
+        }
+    }
+
+    Some(result)
+}
+
 fn split_run_for_ime_underline(
     run: TextRun,
     run_range: Range<usize>,
@@ -2843,6 +2923,85 @@ mod tests {
             .map(|(_, line_runs)| line_runs.iter().map(|run| run.len).collect::<Vec<_>>())
             .collect::<Vec<_>>();
         assert_eq!(run_lengths, vec![vec![2], vec![], vec![1]]);
+    }
+
+    #[test]
+    fn test_align_runs_to_char_boundaries() {
+        let run = TextRun {
+            len: 0,
+            font: gpui::font(".SystemUIFont"),
+            color: gpui::blue(),
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+        };
+        let runs = |lens: &[usize]| {
+            lens.iter()
+                .map(|&len| TextRun { len, ..run.clone() })
+                .collect::<Vec<_>>()
+        };
+        let lens = |runs: &[TextRun]| runs.iter().map(|run| run.len).collect::<Vec<_>>();
+
+        // "成交量" is 9 bytes; boundaries at 0, 3, 6, 9.
+        let text = "成交量";
+
+        // Aligned runs pass through untouched.
+        assert_eq!(align_runs_to_char_boundaries(text, &runs(&[3, 6])), None);
+
+        // A mid-char boundary (4) snaps up to the next boundary (6).
+        let aligned = align_runs_to_char_boundaries(text, &runs(&[4, 5])).unwrap();
+        assert_eq!(lens(&aligned), vec![6, 3]);
+
+        // Several boundaries inside the same char collapse into one run.
+        let aligned = align_runs_to_char_boundaries(text, &runs(&[1, 1, 7])).unwrap();
+        assert_eq!(lens(&aligned), vec![3, 6]);
+
+        // Overshooting runs are capped at the text length.
+        let aligned = align_runs_to_char_boundaries(text, &runs(&[3, 20])).unwrap();
+        assert_eq!(lens(&aligned), vec![3, 6]);
+
+        // Undershooting runs keep the shortfall (the tail is left unshaped,
+        // matching `runs_for_range` clipping).
+        assert_eq!(align_runs_to_char_boundaries(text, &runs(&[3, 3])), None);
+    }
+
+    #[test]
+    fn test_clip_styles_to_ranges() {
+        let style = HighlightStyle::default();
+        let styles = vec![(0..4, style), (4..10, style), (12..20, style)];
+
+        // Ranges with a gap (a folded region) drop the gap coverage and split
+        // styles that span a range edge.
+        let clipped = clip_styles_to_ranges(styles.clone(), &[2..6, 14..18]);
+        assert_eq!(
+            clipped
+                .iter()
+                .map(|(range, _)| range.clone())
+                .collect::<Vec<_>>(),
+            vec![2..4, 4..6, 14..18]
+        );
+
+        // Styles fully inside the ranges are unchanged.
+        let clipped = clip_styles_to_ranges(styles.clone(), &[0..20]);
+        assert_eq!(
+            clipped
+                .iter()
+                .map(|(range, _)| range.clone())
+                .collect::<Vec<_>>(),
+            vec![0..4, 4..10, 12..20]
+        );
+
+        // A single style spanning several ranges splits into one piece per range.
+        let clipped = clip_styles_to_ranges(vec![(0..30, style)], &[5..10, 20..25]);
+        assert_eq!(
+            clipped
+                .iter()
+                .map(|(range, _)| range.clone())
+                .collect::<Vec<_>>(),
+            vec![5..10, 20..25]
+        );
+
+        assert!(clip_styles_to_ranges(styles, &[]).is_empty());
     }
 
     #[test]

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -4,7 +4,7 @@ use crate::highlighter::LanguageRegistry;
 
 use anyhow::{Context, Result, anyhow};
 use gpui::{HighlightStyle, SharedString};
-
+use gpui_base::input::RopeExt as _;
 use ropey::{ChunkCursor, Rope};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -13,6 +13,7 @@ use std::{
     ops::{ControlFlow, Range},
     usize,
 };
+use sum_tree::Bias;
 use tree_sitter::{
     InputEdit, ParseOptions, Parser, Point, Query, QueryCursor, StreamingIterator, Tree,
 };
@@ -1081,6 +1082,13 @@ impl SyntaxHighlighter {
             if node_range.start > node_range.end {
                 node_range.end = node_range.start;
             }
+            // The tree can be stale while a background reparse is pending
+            // (sync-parse timeout, or the large-text `edit_tree` path), so
+            // node offsets may fall inside multi-byte characters of the
+            // current text. Snap to char boundaries — text shaping panics on
+            // a mid-char style boundary.
+            node_range = self.text.clip_offset(node_range.start, Bias::Left)
+                ..self.text.clip_offset(node_range.end, Bias::Right);
             if node_range.is_empty() {
                 continue;
             }
@@ -1310,6 +1318,34 @@ mod tests {
         let mut highlighter = SyntaxHighlighter::new("no-such-language");
         assert!(highlighter.update(None, &rope, None));
         assert!(highlighter.tree().is_none());
+    }
+
+    /// While a background reparse is pending (sync-parse timeout, or the
+    /// large-text `edit_tree` path), `styles()` serves ranges from a stale
+    /// tree. Those must still land on char boundaries of the current text,
+    /// or text shaping panics on multi-byte characters.
+    #[cfg(feature = "tree-sitter-languages")]
+    #[test]
+    fn test_stale_tree_styles_snap_to_char_boundaries() {
+        let mut highlighter = SyntaxHighlighter::new("markdown");
+        let old = Rope::from("# hello world\n*emphasis* and `code` here\n");
+        assert!(highlighter.update(None, &old, None));
+        assert!(highlighter.tree().is_some());
+
+        // Swap the text without reparsing: the tree is now stale and its node
+        // offsets point into the middle of the new text's CJK characters.
+        let new = Rope::from("# 成交量提醒策略\n中文注释，*强调* 与 `代码`\n");
+        highlighter.edit_tree(None, &new);
+
+        let theme = HighlightTheme::default_dark();
+        let styles = highlighter.styles(&(0..new.len()), theme.as_ref());
+        assert!(!styles.is_empty());
+        for (range, _) in &styles {
+            assert!(
+                new.is_char_boundary(range.start) && new.is_char_boundary(range.end),
+                "style range {range:?} is not on char boundaries of the current text"
+            );
+        }
     }
 
     #[cfg(feature = "tree-sitter-languages")]

--- a/crates/ui/src/highlighter/highlighter.rs
+++ b/crates/ui/src/highlighter/highlighter.rs
@@ -1334,7 +1334,7 @@ mod tests {
 
         // Swap the text without reparsing: the tree is now stale and its node
         // offsets point into the middle of the new text's CJK characters.
-        let new = Rope::from("# 成交量提醒策略\n中文注释，*强调* 与 `代码`\n");
+        let new = Rope::from("# 你好，世界\n你好，*世界* 与 `代码`\n");
         highlighter.edit_tree(None, &new);
 
         let theme = HighlightTheme::default_dark();


### PR DESCRIPTION
## Summary

Fixes a crash in the editor when highlight run boundaries drift off the UTF-8 char boundaries of the line being shaped. The platform text system slices the line by run lengths (`text.split_at(run.len)` in `MacTextSystem::layout_line`) and panics inside a multi-byte character:

```
end byte index 9 is not a char boundary; it is inside '量' (bytes 8..11 of string)
```

Observed in Longbridge's quant script editor (Navi scripts with Chinese comments), crashing the whole app during prepaint.

## Root causes and fixes

Two real sources of drift, plus a last line of defense:

1. **Unclipped diagnostics shift the runs coordinate space.** `DiagnosticSet::range` returns an entry straddling the viewport edge (its seek target matches any entry *containing* the offset) — and any range inside a folded region also lands between the visible line groups. `combine_highlights` then emits coverage outside the visible lines, breaking `layout_lines`' invariant that the runs vec concatenates exactly the visible lines' bytes; every later run boundary shifts by the excess byte count. `highlight_lines` now records the flushed line-group ranges and clips the composed styles back to them (`clip_styles_to_ranges`).

2. **Stale-tree styles.** While a background reparse is pending (2ms sync-parse timeout, or the >256KB `edit_tree` path), `SyntaxHighlighter::styles` serves node offsets from a stale tree; they can fall inside multi-byte characters of the *current* text. Ranges are now snapped to char boundaries with `Rope::clip_offset` (same approach as #2700 for selections).

3. **Defense in depth.** `layout_lines` snaps run boundaries to char boundaries of the exact sub-line being shaped (`align_runs_to_char_boundaries`, zero-cost when already aligned) before every `shape_line` call, so any remaining mis-aligned source degrades to slightly-off colors for a frame instead of a panic.

## Test plan

- [x] `cargo test -p gpui-base --lib` (378 tests) — includes new unit tests for `align_runs_to_char_boundaries` and `clip_styles_to_ranges`
- [x] `cargo test -p gpui-component --features tree-sitter-languages --lib` (486 tests) — includes `test_stale_tree_styles_snap_to_char_boundaries`, verified to fail without the fix (`style range 2..13 is not on char boundaries`)
- [x] Manual repro (`crates/story/examples/cjk_diagnostic_panic.rs`, untracked): on `main` it panics right after the window opens (`end byte index 70 is not a char boundary; it is inside '例'`); on this branch it renders normally with the wavy underlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)