### PR TITLE
input: Fix search feedback loop

### DIFF
--- a/crates/ui/src/input/overlay.rs
+++ b/crates/ui/src/input/overlay.rs
@@ -308,23 +308,31 @@ impl<M: OverlayMode> InputOverlayHost<M> {
             search_session.anchor_offset,
         );
         if search_signature != self.search_signature {
+            let (was_open, was_replace, _, was_anchor) = &self.search_signature;
+            let query_echo = search_open
+                && *was_open
+                && *was_replace == replace_mode
+                && *was_anchor == search_session.anchor_offset
+                && self.search.read(cx).query(cx) == search_session.query;
             self.search_signature = search_signature;
-            self.search.update(cx, |panel, cx| {
-                if search_open {
-                    let selected = Rope::from(search_session.query.clone());
-                    let visible = search_session.anchor_offset.map(|offset| offset..offset);
-                    panel.show_with_focus(
-                        &selected,
-                        replace_mode,
-                        visible,
-                        !cfg!(test),
-                        window,
-                        cx,
-                    );
-                } else {
-                    panel.hide_with_focus(!cfg!(test), window, cx);
-                }
-            });
+            if !query_echo {
+                self.search.update(cx, |panel, cx| {
+                    if search_open {
+                        let selected = Rope::from(search_session.query.clone());
+                        let visible = search_session.anchor_offset.map(|offset| offset..offset);
+                        panel.show_with_focus(
+                            &selected,
+                            replace_mode,
+                            visible,
+                            !cfg!(test),
+                            window,
+                            cx,
+                        );
+                    } else {
+                        panel.hide_with_focus(!cfg!(test), window, cx);
+                    }
+                });
+            }
         }
 
         if let (Some(lsp), Some(snapshot)) = (self.lsp.as_mut(), snapshot.as_ref()) {

--- a/crates/ui/src/input/search.rs
+++ b/crates/ui/src/input/search.rs
@@ -73,6 +73,11 @@ impl<M: crate::input::overlay::OverlayMode> SearchPanel<M> {
         self.session = session.clone();
     }
 
+    /// The query the panel's search input currently holds.
+    pub(super) fn query(&self, cx: &App) -> gpui::SharedString {
+        self.search_input.read(cx).value()
+    }
+
     pub(crate) fn new(
         editor: Entity<InputBaseState<M>>,
         window: &mut Window,


### PR DESCRIPTION
## Description

The gpui-base refactor accidentally broke the search with a echo/feedback loop. The query kept getting reset. What was happening:

  1. Typing in the search panel fires InputEvent::Change, which writes the query into the editor's search_session
  2. InputOverlayHost::sync runs every frame and compares a signature (open, replace_mode, query, anchor_offset) to decide whether to re-show the panel
     The panels own write changed the query component, so every keystroke triggered show_with_focus again
  3. show_with_focus runs set_value + select_all, so the next keystroke replaced the entire query

This fix skips the re-opening like the original code intended.

## Videos

### Before

https://github.com/user-attachments/assets/54d83ff2-983d-473f-a11d-f3c0881a60a0

### After

https://github.com/user-attachments/assets/c594e5a6-a333-4b2f-a378-ff1b1d97a419

## How to Test

Try searching in the editor example

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
