### PR TITLE
input: Rewrap lines without copying them out of the rope

### DIFF
--- a/crates/base/src/input/editor/display_map/text_wrapper.rs
+++ b/crates/base/src/input/editor/display_map/text_wrapper.rs
@@ -1,4 +1,5 @@
 use gpui::Half;
+use std::borrow::Cow;
 use std::ops::Range;
 
 use gpui::{
@@ -321,25 +322,24 @@ impl TextWrapper {
 
         // To add the new lines.
         let new_start_row = changed_text.offset_to_point(range.start).row;
-        let new_start_offset = changed_text.line_start_offset(new_start_row);
         let new_end_row = changed_text
             .offset_to_point(range.start + new_text.len())
             .row;
-        let new_end_offset = changed_text.line_end_offset(new_end_row);
-        let new_range = new_start_offset..new_end_offset;
 
-        let mut new_lines = vec![];
+        let mut new_lines = Vec::with_capacity(new_end_row.saturating_sub(new_start_row) + 1);
         let wrap_width = self.wrap_width;
 
         // line not contains `\n`.
-        for line in Rope::from(changed_text.slice(new_range)).iter_lines() {
-            let line_str = line.to_string();
+        for row in new_start_row..=new_end_row {
+            let line = changed_text.slice_line(row);
             let mut wrapped_lines = SmallVec::<[Range<usize>; 1]>::new();
             let mut prev_boundary_ix = 0;
             let mut indent_chars = 0;
 
             // If wrap_width is Pixels::MAX, skip wrapping to disable word wrap
             if let Some(wrap_width) = wrap_width {
+                // Borrowed for lines within a single rope chunk.
+                let line_str: Cow<str> = line.into();
                 match self.wrapping_indent {
                     WrappingIndent::Same => {
                         // Here only have wrapped line, if there is no wrap meet, the `line_wraps`
@@ -353,9 +353,8 @@ impl TextWrapper {
                     WrappingIndent::None => {
                         // The first visual line keeps the line's leading indentation, so it is
                         // wrapped as is.
-                        let bondaries = wrap_line(&line_str, wrap_width);
-                        if let Some(first) = bondaries.first() {
-                            let first_ix = first.ix;
+                        let boundaries = wrap_line(&line_str, wrap_width);
+                        if let Some(first_ix) = boundaries.first().map(|b| b.ix) {
                             wrapped_lines.push(prev_boundary_ix..first_ix);
                             prev_boundary_ix = first_ix;
 
@@ -370,7 +369,7 @@ impl TextWrapper {
             }
 
             // Reset of the line
-            if !line_str[prev_boundary_ix..].is_empty() || prev_boundary_ix == 0 {
+            if prev_boundary_ix < line.len() || prev_boundary_ix == 0 {
                 wrapped_lines.push(prev_boundary_ix..line.len());
             }
 


### PR DESCRIPTION
## Description

Previously the code copied each line twice, once at `Rope::from(changed_text.slice(new_range))` and then again at `line.to_string()`. Now it is doing essentially the same as the rope iter_lines(), but without copying it into a new rope, and instead of copying the line it is borrowing it when it can.
This affects all re-wrapping, like opening files, resizing and editing.

  
  | branch                                |     bytes      | blocks   |
  |-------------------------------------|---------------- |------------|
  | main                                   | 31,602,003 | 82,470 |
  | reduce-wrapper-alloc      | 20,632,839 | 8,342   |
  
## How to Test

I'm using this test with dhat, maybe it's worth committing?
```rust
use gpui::{
    AppContext as _, Bounds, Context, Entity, IntoElement, ParentElement as _, Render, Styled as _,
    TestAppContext, VisualTestContext, Window, WindowBounds, WindowOptions, div, px, size,
};
use gpui_component::input::{Editor, EditorState};

#[global_allocator]
static ALLOC: dhat::Alloc = dhat::Alloc;

const FRAMES: usize = 50;
const FIXTURES: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../story/examples/fixtures");

struct Root(Entity<EditorState>);

impl Render for Root {
    fn render(&mut self, _: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
        div().size_full().child(Editor::new(&self.0))
    }
}

fn language_for(ext: &str) -> &'static str {
    match ext {
        "rs" => "rust",
        "md" => "markdown",
        "js" => "javascript",
        "ts" => "typescript",
        "py" => "python",
        "rb" => "ruby",
        "kt" => "kotlin",
        "c" => "c",
        "go" => "go",
        "html" => "html",
        "json" => "json",
        "sql" => "sql",
        "zig" => "zig",
        "lua" => "lua",
        "php" => "php",
        _ => "",
    }
}

#[gpui::test]
fn measure_editor_allocations_per_fixture(cx: &mut TestAppContext) {
    let mut fixtures: Vec<(String, String, String)> = std::fs::read_dir(FIXTURES)
        .expect("fixtures dir")
        .filter_map(|entry| {
            let path = entry.ok()?.path();
            let ext = path.extension()?.to_str()?.to_string();
            let language = language_for(&ext);
            if language.is_empty() {
                return None;
            }
            let name = path.file_name()?.to_str()?.to_string();
            let content = std::fs::read_to_string(&path).ok()?;
            Some((name, language.to_string(), content))
        })
        .collect();
    // A synthetic large file (test.rs repeated, ~20k lines)
    if let Some(rust) = fixtures.iter().find(|(name, _, _)| name == "test.rs") {
        fixtures.push(("test.rs x20".into(), "rust".into(), rust.2.repeat(20)));
    }
    // Largest first so the headline number is up top.
    fixtures.sort_by_key(|(_, _, content)| std::cmp::Reverse(content.len()));

    cx.update(gpui_component::init);
    println!("== alloc_dhat: per-fixture, load + {FRAMES} draw frames, 800x600, soft wrap ==");

    for (name, language, content) in fixtures {
        let lines = content.lines().count();
        let mut state = None;
        let window = cx.update(|cx| {
            cx.open_window(
                WindowOptions {
                    window_bounds: Some(WindowBounds::Windowed(Bounds {
                        origin: Default::default(),
                        size: size(px(800.), px(600.)),
                    })),
                    ..Default::default()
                },
                |window, cx| {
                    let editor = cx.new(|cx| {
                        EditorState::new(window, cx)
                            .language(language.clone())
                            .soft_wrap(true)
                    });
                    state = Some(editor.clone());
                    cx.new(|_| Root(editor))
                },
            )
            .unwrap()
        });
        let state = state.unwrap();
        let mut cx = VisualTestContext::from_window(window.into(), cx);

        // Warm up an empty draw so window/theme one-time costs stay out.
        cx.update(|window, cx| window.draw(cx).clear(cx));

        let _profiler = dhat::Profiler::builder().testing().build();
        let before_load = dhat::HeapStats::get();
        cx.update(|window, cx| {
            state.update(cx, |state, cx| state.set_value(content.clone(), window, cx));
            window.draw(cx).clear(cx);
        });
        let after_load = dhat::HeapStats::get();

        let step = (content.len() / FRAMES).max(1);
        for frame in 0..FRAMES {
            cx.update(|_, cx| {
                state.update(cx, |state, cx| {
                    let offset = (frame * step).min(content.len());
                    state.set_selected_range(offset..offset, cx);
                    cx.notify();
                });
            });
            cx.update(|window, cx| window.draw(cx).clear(cx));
        }
        let after_draws = dhat::HeapStats::get();

        println!(
            "{name:>12} ({language}, {lines} lines): load {:>10} bytes / {:>6} blocks, {FRAMES} draws {:>10} bytes / {:>6} blocks",
            after_load.total_bytes - before_load.total_bytes,
            after_load.total_blocks - before_load.total_blocks,
            after_draws.total_bytes - after_load.total_bytes,
            after_draws.total_blocks - after_load.total_blocks,
        );
        drop(_profiler);
    }
}
```

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
