### PR TITLE
input: Stop copying the value into InputPresentation

### DIFF
--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -408,7 +408,6 @@ pub struct InputPresentation {
     code_editor: bool,
     text_align: TextAlign,
     placeholder: SharedString,
-    value: Rope,
     mask_placeholder: Option<String>,
 }
 
@@ -456,10 +455,6 @@ impl InputPresentation {
         &self.placeholder
     }
 
-    pub fn value(&self) -> &Rope {
-        &self.value
-    }
-
     /// The placeholder derived from the mask pattern, e.g.: `(___) ___-____`.
     pub fn mask_placeholder(&self) -> Option<&str> {
         self.mask_placeholder.as_deref()
@@ -498,7 +493,6 @@ impl<M: InputModeKind> InputBaseState<M> {
             code_editor: self.is_code_editor(),
             text_align: self.text_align,
             placeholder: self.placeholder.clone(),
-            value: self.text.clone(),
             mask_placeholder: self.mask_pattern.placeholder(),
         }
     }
@@ -1095,13 +1089,19 @@ impl<M: InputModeKind> InputBaseState<M> {
         self
     }
 
-    /// Return the value of the input field.
+    /// Return the value of the input field as an owned string.
+    ///
+    /// The string is materialized on each call. See [`Self::text`] for the
+    /// [`Rope`] the state owns, which is borrowed and costs nothing to read.
     pub fn value(&self) -> SharedString {
         SharedString::new(self.text.to_string())
     }
 
     /// Return the portion of the value within the input field that
-    /// is selected by the user
+    /// is selected by the user, as an owned string.
+    ///
+    /// The string is materialized on each call. See [`Self::selected_text`]
+    /// for the same selection borrowed out of the [`Rope`] the state owns.
     pub fn selected_value(&self) -> SharedString {
         SharedString::new(self.selected_text().to_string())
     }
@@ -1120,6 +1120,9 @@ impl<M: InputModeKind> InputBaseState<M> {
     pub fn prepare(&mut self, _: &mut Window, _: &mut Context<Self>) {}
 
     /// Return the text [`Rope`] of the input field.
+    ///
+    /// Borrowed from the state, so reading even a large document copies
+    /// nothing. See [`Self::value`] when an owned string is wanted.
     pub fn text(&self) -> &Rope {
         &self.text
     }
@@ -2507,7 +2510,11 @@ impl<M: InputModeKind> InputBaseState<M> {
         }
     }
 
-    pub(super) fn selected_text(&self) -> RopeSlice<'_> {
+    /// Return the selected portion of the text, borrowed out of the [`Rope`]
+    /// the state owns.
+    ///
+    /// See [`Self::selected_value`] when an owned string is wanted.
+    pub fn selected_text(&self) -> RopeSlice<'_> {
         let range_utf16 = self.range_to_utf16(&self.selected_range.into());
         let range = self.range_from_utf16(&range_utf16);
         self.text.slice(range)

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -408,7 +408,7 @@ pub struct InputPresentation {
     code_editor: bool,
     text_align: TextAlign,
     placeholder: SharedString,
-    value: String,
+    value: Rope,
     mask_placeholder: Option<String>,
 }
 
@@ -456,7 +456,7 @@ impl InputPresentation {
         &self.placeholder
     }
 
-    pub fn value(&self) -> &str {
+    pub fn value(&self) -> &Rope {
         &self.value
     }
 
@@ -498,7 +498,7 @@ impl<M: InputModeKind> InputBaseState<M> {
             code_editor: self.is_code_editor(),
             text_align: self.text_align,
             placeholder: self.placeholder.clone(),
-            value: self.text.to_string(),
+            value: self.text.clone(),
             mask_placeholder: self.mask_pattern.placeholder(),
         }
     }

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -486,7 +486,7 @@ impl RenderOnce for Input {
         // accessibility tree, so skip it when no client is listening.
         let accessibility_value = (window.is_a11y_active()
             && exposes_accessibility_value(presentation.is_masked(), content_type))
-        .then(|| presentation.value().to_string());
+        .then(|| state.text(cx).to_string());
         let input_focused =
             presentation.focus_handle().is_focused(window) && !presentation.is_disabled();
         if input_focused {
@@ -523,7 +523,7 @@ impl RenderOnce for Input {
         let show_clear_button = self.cleanable
             && presentation.is_editable()
             && !presentation.is_loading()
-            && presentation.value().len() > 0
+            && state.text(cx).len() > 0
             && !presentation.is_multi_line();
         let has_suffix =
             suffix.is_some() || presentation.is_loading() || self.mask_toggle || show_clear_button;

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -486,7 +486,7 @@ impl RenderOnce for Input {
         // accessibility tree, so skip it when no client is listening.
         let accessibility_value = (window.is_a11y_active()
             && exposes_accessibility_value(presentation.is_masked(), content_type))
-        .then(|| presentation.value().to_owned());
+        .then(|| presentation.value().to_string());
         let input_focused =
             presentation.focus_handle().is_focused(window) && !presentation.is_disabled();
         if input_focused {
@@ -523,7 +523,7 @@ impl RenderOnce for Input {
         let show_clear_button = self.cleanable
             && presentation.is_editable()
             && !presentation.is_loading()
-            && !presentation.value().is_empty()
+            && presentation.value().len() > 0
             && !presentation.is_multi_line();
         let has_suffix =
             suffix.is_some() || presentation.is_loading() || self.mask_toggle || show_clear_button;

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -1,5 +1,6 @@
 use gpui::{App, Entity, FocusHandle, Focusable as _, SharedString, Window};
 use gpui_base::OtpState;
+use ropey::Rope;
 
 use super::{EditorState, InputState, TextareaState};
 use crate::Root;
@@ -57,6 +58,13 @@ impl TextInputState {
 
     pub(crate) fn presentation(&self, cx: &App) -> gpui_base::input::InputPresentation {
         dispatch!(self, |state| state.read(cx).presentation())
+    }
+
+    /// The text of the input, borrowed from the state that owns it.
+    ///
+    /// The state holds the only copy; nothing on the render path snapshots it.
+    pub(crate) fn text<'a>(&self, cx: &'a App) -> &'a Rope {
+        dispatch!(self, |state| state.read(cx).text())
     }
 
     pub(crate) fn focus(&self, window: &mut Window, cx: &mut App) {


### PR DESCRIPTION
## Description

The presentation layer split regressed a bit in memory usage, because the value being a `String`. So each `state.presentation(cx)` would copy the entire document, three times per render.

Rather than making that copy cheaper, the value is now gone from the snapshot. `InputPresentation` is rebuilt on every frame, and the state already owns the only `Rope` and hands it out through `InputBaseState::text`, so the render path borrows it directly. `InputPresentation` is read-only styling data again, as its doc says.

Neither of the two places that read the value needs the text itself:

- the accessibility value stays behind the `is_a11y_active()` gate, and materializes a string only when a client is listening
- the clear button only needs the length

`selected_text` is now public, so the selection has a borrowed counterpart to `selected_value`. The docs on both pairs point at each other: `value` / `selected_value` hand out an owned string, `text` / `selected_text` borrow the rope.

## How to Test

I used the alloc bench from https://github.com/longbridge/gpui-component/pull/2783 and measured it on the test.rs fixture repeated 20 times, after 50 draws:

  |                         | draw bytes  | draw blocks |
  |-------------------------|-------------|-------------|
  | main                    | 306,206,908 | 31,844      |
  | input-presentation-copy | 11,413,308  | 29,444      |

These numbers were measured on the `Rope` version of the snapshot. Dropping the field removes the remaining clone as well.

## Breaking Changes

`InputPresentation::value` is removed. Read the text from the state instead.

```diff
- let value = presentation.value();
+ let value = state.read(cx).text();
```

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
