### PR TITLE
Fix typo in getting-started.md

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -88,7 +88,7 @@ This is required for theming and other global settings to work correctly.
 
 GPUI Component uses stateless [RenderOnce] elements, making them simple and predictable. State management is handled at the view level, not in individual components.
 
-The are all implemented [IntoElement] types.
+They are all implemented [IntoElement] types.
 
 For example:
 


### PR DESCRIPTION
Simple typo fix on the https://longbridge.github.io/gpui-component/docs/getting-started

## Description

Simple typo fix, replace `The` with `They`

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
