### PR TITLE
dock: Keep a split filled when its last slot is hidden

### DIFF
--- a/crates/base/src/dock/dock_area.rs
+++ b/crates/base/src/dock/dock_area.rs
@@ -1393,17 +1393,26 @@ impl DockArea {
                     Axis::Horizontal => h_resizable(("dock-split", node.id().as_u64())),
                     Axis::Vertical => v_resizable(("dock-split", node.id().as_u64())),
                 };
+                // A container whose every panel is hidden must not keep
+                // occupying its slot. No renderer hook could supply this:
+                // only the area can see the panels behind a node.
+                let shown: Vec<bool> = children
+                    .iter()
+                    .map(|child| self.is_node_visible(child, cx))
+                    .collect();
+                // The slot that absorbs the leftover has to be one that is
+                // actually drawn. A hidden slot renders nothing and grows
+                // nothing, so making it the flexible one leaves every drawn
+                // slot rigid and the split ends short of its container — the
+                // empty strip this picks the *last shown* slot to avoid.
+                let grows = shown.iter().rposition(|shown| *shown);
                 let panels: Vec<_> = children
                     .iter()
                     .zip(sizes.iter())
                     .enumerate()
                     .map(|(ix, (child, size))| {
                         resizable_panel()
-                            // A container whose every panel is hidden must
-                            // not keep occupying its slot. No renderer hook
-                            // could supply this: only the area can see the
-                            // panels behind a node.
-                            .visible(self.is_node_visible(child, cx))
+                            .visible(shown[ix])
                             .child(self.render_node(child, window, cx))
                             // `flex_none` is what makes the size stick.
                             // `ResizablePanel` sets `flex_grow: 1` on itself,
@@ -1411,7 +1420,7 @@ impl DockArea {
                             // as a flex-basis and still absorb an equal share
                             // of the leftover — a 200px sidebar rendering
                             // 1075px wide in a 1950px split.
-                            // The trailing slot absorbs container growth. A
+                            // The growth slot absorbs container growth. A
                             // drag records every measured size as pixels; if
                             // all of them became `flex_none`, a later viewport
                             // resize would leave an empty strip after the
@@ -1419,7 +1428,7 @@ impl DockArea {
                             .when_some(*size, |panel, size| {
                                 panel
                                     .size(size)
-                                    .when(ix + 1 < children.len(), |panel| panel.flex_none())
+                                    .when(Some(ix) != grows, |panel| panel.flex_none())
                             })
                     })
                     .collect();

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -787,7 +787,7 @@ mod tests {
     use std::cell::RefCell;
 
     use gpui::{
-        AppContext as _, Entity, EventEmitter, FocusHandle, Focusable, TestAppContext,
+        AppContext as _, Entity, EventEmitter, FocusHandle, Focusable, Pixels, TestAppContext,
         VisualTestContext,
     };
     use gpui_base::dock::{
@@ -796,7 +796,10 @@ mod tests {
     };
 
     use super::*;
-    use crate::dock::{DockSkin, Panel, panel_handle, test_support::MeasuredProbe};
+    use crate::dock::{
+        DockSkin, Panel, panel_handle,
+        test_support::{HideableProbe, MeasuredProbe},
+    };
 
     struct Probe {
         focus_handle: FocusHandle,
@@ -1192,6 +1195,114 @@ mod tests {
              got {:?} of {window_height:?}",
             centre.get()
         );
+    }
+
+    /// Whichever slots of a split are hidden, the drawn ones fill it.
+    ///
+    /// `render_node` pins every slot but one to a fixed size and lets the
+    /// remaining one absorb whatever the container has spare. Picking that
+    /// slot by tree position alone picks a hidden one whenever the trailing
+    /// container's panels are all hidden — nothing draws there, nothing
+    /// grows, and the split stops short of its frame, showing a band of the
+    /// frame's own background under the last visible panel. Hiding a slot is
+    /// an everyday event: a panel that is only meaningful for some symbols
+    /// answers `visible` with `false` for the rest.
+    ///
+    /// Every subset is covered because the defect is positional: only the
+    /// cases that hide the trailing slot fail, and a test that hid one fixed
+    /// slot would pass against a fix that only special-cased that slot.
+    #[gpui::test]
+    fn a_split_fills_its_container_whichever_slots_are_hidden(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            crate::init(cx);
+        });
+        let heights: Vec<Rc<Cell<Pixels>>> = (0..3).map(|_| Rc::new(Cell::new(px(0.)))).collect();
+        let (area, cx) = cx.add_window_view(|window, cx| {
+            let skin = DockSkin::new(cx);
+            DockArea::new("skin", None, window, cx).with_renderer(skin)
+        });
+
+        let slots = heights.clone();
+        let probes = cx.update(|window, cx| {
+            let probes: Vec<_> = slots
+                .iter()
+                .map(|height| HideableProbe::new(height.clone(), cx))
+                .collect();
+            area.update(cx, |area, cx| {
+                area.set_dock(
+                    DockPlacement::Right,
+                    probes.iter().zip([260., 320., 200.]).fold(
+                        DockLayout::v_split(),
+                        |split, (probe, size)| {
+                            split.child(
+                                DockLayout::tabs().panel_view(panel_handle(probe.clone()), cx),
+                                Some(px(size)),
+                            )
+                        },
+                    ),
+                    window,
+                    cx,
+                );
+                area.set_dock_size(DockPlacement::Right, px(380.), window, cx);
+            });
+            probes
+        });
+        cx.run_until_parked();
+        let draw = |cx: &mut VisualTestContext| {
+            cx.update(|window, _| window.refresh());
+            cx.update(|window, cx| window.draw(cx).clear(cx));
+            cx.update(|window, cx| window.draw(cx).clear(cx));
+        };
+        draw(cx);
+
+        let dock_height = cx.update(|window, _| window.viewport_size().height);
+        // Each slot spends a tab bar out of its height and the probe under it
+        // measures the rest, so the drawn slots account for the whole dock
+        // once one tab bar per drawn slot is added back.
+        let drawn: Pixels = heights.iter().map(|height| height.get()).sum();
+        let bar = (dock_height - drawn) / 3.;
+        assert!(
+            bar > px(0.) && bar < px(60.),
+            "the three slots fill the dock to begin with, one tab bar each; \
+             that leaves {bar:?} per slot of {dock_height:?}"
+        );
+
+        // Every subset except "all three hidden", which gives the whole node
+        // up to *its* parent and so has no container of its own to fill.
+        for hidden in 1..0b111u8 {
+            let shown = (0..3).filter(|slot| hidden & (1 << slot) == 0);
+            cx.update(|_, cx| {
+                for (slot, probe) in probes.iter().enumerate() {
+                    // A sentinel, so a slot that stopped drawing is not read
+                    // as one that kept the height it had.
+                    heights[slot].set(px(-1.));
+                    probe.update(cx, |probe, cx| {
+                        probe.set_visible(hidden & (1 << slot) == 0, cx)
+                    });
+                }
+            });
+            cx.run_until_parked();
+            draw(cx);
+
+            let mut count = 0;
+            let mut total = px(0.);
+            for slot in shown {
+                assert_ne!(
+                    heights[slot].get(),
+                    px(-1.),
+                    "hiding {hidden:03b}: slot {slot} is shown and must draw"
+                );
+                count += 1;
+                total += heights[slot].get();
+            }
+            let empty = dock_height - total - bar * count as f32;
+            assert!(
+                empty.abs() < px(1.),
+                "hiding {hidden:03b}: the drawn slots must take the hidden \
+                 ones' space between them; they left {empty:?} of \
+                 {dock_height:?} empty"
+            );
+        }
     }
 
     /// The old dock installed `ToggleZoom` and `ClosePanel` on the tab panel

--- a/crates/ui/src/dock/test_support.rs
+++ b/crates/ui/src/dock/test_support.rs
@@ -58,3 +58,57 @@ impl Render for MeasuredProbe {
             .on_prepaint(move |bounds, _, _| height.set(bounds.size.height))
     }
 }
+
+/// A [`MeasuredProbe`] whose `visible` can be switched off.
+///
+/// Hiding the only panel of a slot is the one edit that takes a whole slot out
+/// of a split without changing the tree, so it is the only way to ask whether
+/// the *drawn* slots still fill the split.
+pub(crate) struct HideableProbe {
+    focus_handle: FocusHandle,
+    visible: bool,
+    height: Rc<Cell<Pixels>>,
+}
+
+impl HideableProbe {
+    pub(crate) fn new(height: Rc<Cell<Pixels>>, cx: &mut App) -> Entity<Self> {
+        cx.new(|cx| Self {
+            focus_handle: cx.focus_handle(),
+            visible: true,
+            height,
+        })
+    }
+
+    pub(crate) fn set_visible(&mut self, visible: bool, cx: &mut Context<Self>) {
+        self.visible = visible;
+        cx.notify();
+    }
+}
+
+impl gpui_base::dock::Panel for HideableProbe {
+    fn panel_name(&self) -> &'static str {
+        "HideableProbe"
+    }
+
+    fn visible(&self, _: &App) -> bool {
+        self.visible
+    }
+}
+
+impl Panel for HideableProbe {}
+impl EventEmitter<PanelEvent> for HideableProbe {}
+
+impl Focusable for HideableProbe {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for HideableProbe {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        let height = self.height.clone();
+        div()
+            .size_full()
+            .on_prepaint(move |bounds, _, _| height.set(bounds.size.height))
+    }
+}


### PR DESCRIPTION
## Summary

A dock split pins every slot to a fixed size with `flex_none` and leaves one flexible, to absorb whatever the container has spare. `render_node` picked that slot by tree position — the last child — without asking whether the slot is drawn at all.

A slot whose container holds only hidden panels renders a bare `div` and grows nothing. When that is the trailing slot, every drawn slot stays rigid and the split stops short of its frame, leaving a band of `split_frame`'s own `tab_bar` background under the last visible panel. Hiding a slot is an everyday event: a panel that only applies to some symbols answers `visible` with `false` for the rest.

This is a regression from #2772. The old `StackPanel::render` never sized a slot, so every one of them carried `ResizablePanel`'s `flex_grow: 1` and the leftover was always shared out; the rigid slots arrived with the layout engine.

`render_node` now picks the last *shown* slot.

The new test builds a three-slot dock over `HideableProbe`, measures what each slot is really drawn at, and walks every subset of hidden slots. Only the subsets that hide the trailing slot regress — a 1080px dock left 277px empty — which is what makes the fix positional rather than a special case.

No public API change.

## Test plan

- [x] `cargo test -p gpui-base --lib` — 555 passed
- [x] `cargo test -p gpui-component --lib` — 447 passed
- [x] `cargo clippy -p gpui-base -p gpui-component --all-targets` — no new warnings
- [x] `cargo fmt --check` — clean for the changed files
- [x] Reverting the one-line pick makes `a_split_fills_its_container_whichever_slots_are_hidden` fail on exactly the trailing-slot subsets

🤖 Generated with [Claude Code](https://claude.com/claude-code)