### PR TITLE
scrollable: Add explicit scroll identity for Scrollable

### DIFF
--- a/crates/ui/src/scroll/scrollable.rs
+++ b/crates/ui/src/scroll/scrollable.rs
@@ -82,11 +82,12 @@ where
             axis: axis.into(),
         }
     }
-    /// Sets a stable identity for the scroll state of this scrollable.
+
+    /// Set a specific element id, default is the [`std::panic::Location::caller`].
     ///
-    /// This is useful when multiple scrollable elements are created from
-    /// the same call site, such as inside a list or virtual list.
-    pub fn scroll_id(mut self, id: impl Into<ElementId>) -> Self {
+    /// Only needed when one call site creates several scrollables, which would
+    /// otherwise share a single scroll position.
+    pub fn id(mut self, id: impl Into<ElementId>) -> Self {
         self.id = id.into();
         self
     }
@@ -790,7 +791,7 @@ mod tests {
                         .w(px(100.))
                         .h(px(40.))
                         .overflow_x_scrollbar()
-                        .scroll_id(format!("dynamic-scroll-{ix}"))
+                        .id(format!("dynamic-scroll-{ix}"))
                         .child(
                             div()
                                 .w(px(200.))

--- a/crates/ui/src/scroll/scrollable.rs
+++ b/crates/ui/src/scroll/scrollable.rs
@@ -82,6 +82,14 @@ where
             axis: axis.into(),
         }
     }
+    /// Sets a stable identity for the scroll state of this scrollable.
+    ///
+    /// This is useful when multiple scrollable elements are created from
+    /// the same call site, such as inside a list or virtual list.
+    pub fn scroll_id(mut self, id: impl Into<ElementId>) -> Self {
+        self.id = id.into();
+        self
+    }
 }
 
 impl<E> Styled for Scrollable<E>
@@ -769,6 +777,79 @@ mod tests {
         assert_eq!(
             second_after_scroll.left() - first_after_scroll.right(),
             px(10.)
+        );
+    }
+    struct IndependentDynamicScrollablesTest;
+
+    impl Render for IndependentDynamicScrollablesTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            crate::v_flex()
+                .w(px(100.))
+                .children((0..2).map(|ix| {
+                    crate::h_flex()
+                        .w(px(100.))
+                        .h(px(40.))
+                        .overflow_x_scrollbar()
+                        .scroll_id(format!("dynamic-scroll-{ix}"))
+                        .child(
+                            div()
+                                .w(px(200.))
+                                .h(px(20.))
+                                .flex_shrink_0()
+                                .when(ix == 0, |this| {
+                                    this.debug_selector(|| {
+                                        "dynamic-scroll-first".to_string()
+                                    })
+                                })
+                                .when(ix == 1, |this| {
+                                    this.debug_selector(|| {
+                                        "dynamic-scroll-second".to_string()
+                                    })
+                                }),
+                        )
+                }))
+        }
+    }
+
+    #[gpui::test]
+    fn dynamic_scrollables_with_unique_scroll_ids_keep_independent_state(
+        cx: &mut TestAppContext,
+    ) {
+        cx.update(crate::init);
+
+        let (_, cx) = cx.add_window_view(|_, _| IndependentDynamicScrollablesTest);
+        let cx: &mut VisualTestContext = cx;
+
+        draw(cx);
+
+        let first_initial = cx
+            .debug_bounds("dynamic-scroll-first")
+            .unwrap();
+
+        let second_initial = cx
+            .debug_bounds("dynamic-scroll-second")
+            .unwrap();
+
+        // Scroll horizontally inside the first row.
+        scroll(cx, 10., 10., -50., 0.);
+
+        let first_after_scroll = cx
+            .debug_bounds("dynamic-scroll-first")
+            .unwrap();
+
+        let second_after_scroll = cx
+            .debug_bounds("dynamic-scroll-second")
+            .unwrap();
+
+        // First scrollable should move horizontally.
+        assert!(
+            first_after_scroll.left() < first_initial.left()
+        );
+
+        // Second scrollable must keep its own independent scroll state.
+        assert_eq!(
+            second_after_scroll.left(),
+            second_initial.left()
         );
     }
 }


### PR DESCRIPTION
## Description

Add `Scrollable::scroll_id` to allow callers to provide a stable and unique identity for a scrollable element.

`Scrollable` currently uses `caller_id()` as the key for its internally managed `ScrollHandle`. This works for statically declared scrollables, but multiple scrollables created from the same call site, such as inside an iterator or virtual list, may resolve to the same keyed scroll state.

For example, multiple horizontal scrollables created from the same iterator call site can share their scroll position, causing all rows to move when scrolling one of them.

This change adds an optional `scroll_id`:

```rust
.children((0..10).map(|ix| {
    div()
        .overflow_x_scrollbar()
        .scroll_id(format!("row-{ix}"))
        .child(...)
}))
```

When `scroll_id` is not specified, the existing `caller_id()` behavior remains unchanged.

A regression test is included to verify that dynamically created scrollables with unique scroll IDs maintain independent scroll state.

## Screenshot

Not applicable. This change does not introduce any visual changes.

## How to Test

Run the regression test:

```sh
cargo test dynamic_scrollables_with_unique_scroll_ids_keep_independent_state
```

The test creates multiple horizontal scrollables from the same call site with different `scroll_id` values, scrolls the first one, and verifies that the second scrollable remains unchanged.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)