### PR TITLE
markdown: Share the parsed block list instead of cloning it every frame

### DIFF
--- a/crates/ui/src/text/document.rs
+++ b/crates/ui/src/text/document.rs
@@ -3,7 +3,7 @@ use gpui::{
     Styled as _, Window, div,
 };
 
-use std::ops::RangeInclusive;
+use std::{ops::RangeInclusive, sync::Arc};
 
 use crate::text::{
     SelectionFormat,
@@ -14,7 +14,7 @@ use crate::text::{
 #[derive(Debug, Clone, PartialEq, Default)]
 pub(crate) struct ParsedDocument {
     pub(crate) source: SharedString,
-    pub(crate) blocks: Vec<BlockNode>,
+    pub(crate) blocks: Arc<Vec<BlockNode>>,
 }
 
 #[derive(Default, Clone, Copy)]

--- a/crates/ui/src/text/format/html.rs
+++ b/crates/ui/src/text/format/html.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ops::Range;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use gpui::{DefiniteLength, Hsla, SharedString, px, relative};
 use html5ever::tendril::TendrilSink;
@@ -75,7 +76,7 @@ pub(crate) fn parse(source: &str, cx: &mut NodeContext) -> Result<ParsedDocument
 
     Ok(ParsedDocument {
         source: source.to_string().into(),
-        blocks: vec![node],
+        blocks: Arc::new(vec![node]),
     })
 }
 
@@ -658,6 +659,7 @@ fn consume_paragraph(children: &mut Vec<BlockNode>, paragraph: &mut Paragraph) {
 #[cfg(test)]
 mod tests {
     use gpui::{px, relative};
+    use std::sync::Arc;
 
     use crate::text::{
         document::ParsedDocument,
@@ -766,7 +768,7 @@ mod tests {
             node,
             ParsedDocument {
                 source: html.to_string().into(),
-                blocks: vec![BlockNode::Paragraph(Paragraph {
+                blocks: Arc::new(vec![BlockNode::Paragraph(Paragraph {
                     span: None,
                     children: vec![InlineNode::image(ImageNode {
                         url: "https://example.com/image.png".to_string().into(),
@@ -777,7 +779,7 @@ mod tests {
                         ..Default::default()
                     })],
                     ..Default::default()
-                })]
+                })])
             }
         );
 
@@ -787,7 +789,7 @@ mod tests {
             node,
             ParsedDocument {
                 source: html.to_string().into(),
-                blocks: vec![BlockNode::Paragraph(Paragraph {
+                blocks: Arc::new(vec![BlockNode::Paragraph(Paragraph {
                     span: None,
                     children: vec![InlineNode::image(ImageNode {
                         url: "https://example.com/image.png".to_string().into(),
@@ -798,7 +800,7 @@ mod tests {
                         ..Default::default()
                     })],
                     ..Default::default()
-                })]
+                })])
             }
         );
     }

--- a/crates/ui/src/text/format/markdown.rs
+++ b/crates/ui/src/text/format/markdown.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use std::{ops::Range, sync::Arc};
 
 use gpui::SharedString;
 use markdown::mdast::{self, Node};
@@ -239,7 +239,9 @@ fn parse_paragraph(paragraph: &mut Paragraph, node: &mdast::Node, cx: &mut NodeC
         }
         Node::Html(val) => match super::html::parse(&val.value, cx) {
             Ok(el) => {
-                if let Some(inline_text) = append_inline_html_blocks(paragraph, el.blocks) {
+                if let Some(inline_text) =
+                    append_inline_html_blocks(paragraph, Arc::unwrap_or_clone(el.blocks))
+                {
                     text = inline_text;
                 } else {
                     if cfg!(debug_assertions) {
@@ -305,7 +307,7 @@ fn ast_to_document(source: &str, root: mdast::Node, cx: &mut NodeContext) -> Par
         .collect();
     ParsedDocument {
         source: source.to_string().into(),
-        blocks,
+        blocks: Arc::new(blocks),
     }
 }
 
@@ -400,7 +402,7 @@ fn ast_to_node(source: &str, value: mdast::Node, cx: &mut NodeContext) -> BlockN
         )),
         Node::Html(val) => match super::html::parse(&val.value, cx) {
             Ok(el) => BlockNode::Root {
-                children: el.blocks,
+                children: Arc::unwrap_or_clone(el.blocks),
                 span: new_span(val.position, cx),
             },
             Err(err) => {

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -2885,7 +2885,7 @@ mod tests {
 
         let document = ParsedDocument {
             source: source.into(),
-            blocks: vec![
+            blocks: Arc::new(vec![
                 BlockNode::Paragraph(selected_paragraph("start")),
                 BlockNode::List {
                     ordered: true,
@@ -2902,7 +2902,7 @@ mod tests {
                     }),
                 },
                 BlockNode::Paragraph(selected_paragraph("end")),
-            ],
+            ]),
         };
 
         assert_eq!(
@@ -2929,11 +2929,11 @@ mod tests {
 
         let document = ParsedDocument {
             source: source.into(),
-            blocks: vec![
+            blocks: Arc::new(vec![
                 BlockNode::Paragraph(selected_paragraph("before")),
                 BlockNode::Paragraph(image),
                 BlockNode::Paragraph(selected_paragraph("after")),
-            ],
+            ]),
         };
         assert_eq!(
             document.selected_text(SelectionFormat::Source, None),
@@ -2952,7 +2952,8 @@ mod tests {
             blocks: vec![
                 BlockNode::Paragraph(selected_paragraph("before")),
                 BlockNode::Paragraph(image_paragraph("alt", "u")),
-            ],
+            ]
+            .into(),
         };
         assert_eq!(
             document.selected_text(SelectionFormat::Source, None),
@@ -3044,7 +3045,8 @@ mod tests {
                         },
                     ],
                 },
-            ],
+            ]
+            .into(),
         };
 
         assert_eq!(

--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -2885,7 +2885,7 @@ mod tests {
 
         let document = ParsedDocument {
             source: source.into(),
-            blocks: Arc::new(vec![
+            blocks: vec![
                 BlockNode::Paragraph(selected_paragraph("start")),
                 BlockNode::List {
                     ordered: true,
@@ -2902,7 +2902,8 @@ mod tests {
                     }),
                 },
                 BlockNode::Paragraph(selected_paragraph("end")),
-            ]),
+            ]
+            .into(),
         };
 
         assert_eq!(
@@ -2929,11 +2930,12 @@ mod tests {
 
         let document = ParsedDocument {
             source: source.into(),
-            blocks: Arc::new(vec![
+            blocks: vec![
                 BlockNode::Paragraph(selected_paragraph("before")),
                 BlockNode::Paragraph(image),
                 BlockNode::Paragraph(selected_paragraph("after")),
-            ]),
+            ]
+            .into(),
         };
         assert_eq!(
             document.selected_text(SelectionFormat::Source, None),

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -745,17 +745,33 @@ fn parse_content(
         ..NodeContext::default()
     };
 
+    // Re-parse the last block together with the appended text, so a block the
+    // new text continues (an unclosed list, a fenced code block) is not split
+    // in two. A block without a span cannot be located in `source` — the HTML
+    // parser never records spans — so it is left in place and only the
+    // appended text is parsed, positioned at the end of the current source.
+    let last_span = options
+        .append
+        .then(|| {
+            content
+                .document
+                .blocks
+                .last()
+                .and_then(|block| block.span())
+        })
+        .flatten();
+
     let mut source = String::new();
-    if options.append
-        && let Some(last_block) = Arc::make_mut(&mut content.document.blocks).pop()
-        && let Some(span) = last_block.span()
-    {
+    if let Some(span) = last_span {
+        Arc::make_mut(&mut content.document.blocks).pop();
         node_cx.offset = span.start;
-        let last_source = &content.document.source[span.start..];
-        source.push_str(last_source);
+        source.push_str(&content.document.source[span.start..]);
         source.push_str(&options.pending_text);
     } else {
-        source = options.pending_text.to_string();
+        if options.append {
+            node_cx.offset = content.document.source.len();
+        }
+        source.push_str(&options.pending_text);
     }
 
     let new_document = match format {
@@ -850,6 +866,31 @@ mod tests {
         state.read_with(cx, |state, _| {
             assert_eq!(state.text.as_str(), expected.as_str());
             assert_eq!(state.source().as_str(), expected.as_str());
+        });
+    }
+
+    #[gpui::test]
+    fn html_push_str_keeps_earlier_blocks(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let state = cx.update(|cx| cx.new(|cx| TextViewState::html("<p>first</p>", cx)));
+        cx.run_until_parked();
+
+        state.update(cx, |state, cx| {
+            state.push_str("<p>second</p>", cx);
+        });
+        cx.run_until_parked();
+
+        state.read_with(cx, |state, _| {
+            assert_eq!(state.source().as_str(), "<p>first</p><p>second</p>");
+            let text = state
+                .parsed_content
+                .document
+                .blocks
+                .iter()
+                .map(|block| block.text())
+                .collect::<String>();
+            assert!(text.contains("first"), "lost the first block: {text:?}");
+            assert!(text.contains("second"), "lost the appended block: {text:?}");
         });
     }
 

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -747,7 +747,7 @@ fn parse_content(
 
     let mut source = String::new();
     if options.append
-        && let Some(last_block) = content.document.blocks.pop()
+        && let Some(last_block) = Arc::make_mut(&mut content.document.blocks).pop()
         && let Some(span) = last_block.span()
     {
         node_cx.offset = span.start;
@@ -766,7 +766,8 @@ fn parse_content(
     if options.append {
         content.document.source =
             format!("{}{}", content.document.source, options.pending_text).into();
-        content.document.blocks.extend(new_document.blocks);
+        Arc::make_mut(&mut content.document.blocks)
+            .extend(Arc::unwrap_or_clone(new_document.blocks));
     } else {
         content.document = new_document;
     }


### PR DESCRIPTION
## Description

A document's blocks could potentially be cloned two times every frame, once (always) at https://github.com/longbridge/gpui-component/blob/14359a0cdd00657eb68fa946bfd99cd83c26e002/crates/ui/src/text/state.rs#L558 and again at  https://github.com/longbridge/gpui-component/blob/14359a0cdd00657eb68fa946bfd99cd83c26e002/crates/ui/src/text/document.rs#L218

This wraps the blocks in Arc so it's just a pointer bump.

Markdown preview, `test.md`, 800x600, 60 scrolled frames, release build:

| | before | after |
|---|---|---|
| per frame | 1,403,801 B / 3,786 allocs | 947,500 B / 1,871 allocs |

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
