### PR TITLE
build: Stop compiling gpui's test-support into the story examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Lint
         if: ${{ matrix.run_on == 'macos-latest' }}
         run: |
-          cargo clippy -- --deny warnings
+          cargo clippy -p gpui-component -p gpui-component-story -p gpui-component-assets -- --deny warnings
       - name: Check without default features (tree-sitter disabled)
         if: ${{ matrix.run_on == 'ubuntu-latest' }}
         run: |
@@ -62,13 +62,13 @@ jobs:
       - name: Test Linux
         if: ${{ matrix.run_on == 'ubuntu-latest' }}
         run: |
-          cargo test --all
+          cargo test --all --features gpui-component-story/test-support
       - name: Test Windows
         if: ${{ matrix.run_on == 'windows-latest' }}
         run: |
-          cargo test --all
+          cargo test --all --features gpui-component-story/test-support
       - name: Test MacOS
         if: ${{ matrix.run_on == 'macos-latest' }}
         run: |
-          cargo test --all
+          cargo test --all --features gpui-component-story/test-support
           cargo test -p gpui-component --doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-default-members = ["crates/ui", "crates/story", "crates/assets"]
+default-members = ["crates/story"]
 members = [
     "crates/base",
     "crates/base/examples/wasm",

--- a/crates/story/Cargo.toml
+++ b/crates/story/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 [features]
 inspector = ["gpui-component/inspector"]
 tree-sitter = ["gpui-component/tree-sitter-languages"]
+test-support = ["gpui/test-support"]
 default = ["tree-sitter"]
 
 [dependencies]
@@ -29,7 +30,11 @@ regex = "1"
 serde = "1"
 serde_json = "1"
 tracing.workspace = true
-tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt", "registry"], default-features = false }
+tracing-subscriber = { version = "0.3.22", features = [
+  "env-filter",
+  "fmt",
+  "registry",
+], default-features = false }
 unindent = "0.2.3"
 rust-i18n.workspace = true
 dirs = "6.0.0"
@@ -54,7 +59,6 @@ getrandom = { version = "0.2", features = ["js"] }
 gtk = { version = "0.18" }
 
 [dev-dependencies]
-gpui = { workspace = true, features = ["test-support"] }
 gpui-base.workspace = true
 
 [lints]

--- a/crates/story/src/app_menus.rs
+++ b/crates/story/src/app_menus.rs
@@ -132,7 +132,7 @@ fn language_menu(_: &App) -> MenuItem {
     })
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-support"))]
 mod tests {
     use gpui::TestAppContext;
 

--- a/crates/story/src/themes.rs
+++ b/crates/story/src/themes.rs
@@ -226,7 +226,7 @@ fn theme_item(theme: &ThemeConfig, active_name: &SharedString) -> CommandItem {
         .action(Box::new(SwitchTheme(name)))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-support"))]
 mod tests {
     use super::*;
     use gpui::{TestAppContext, px};


### PR DESCRIPTION
## Description

There are some issues that complain about "laggy scrolling" and similar, I believe this comes from the story crate pulling in `test-support` which has the downside of `App::flush_effects` synchronously drawing at the end of every `App::update`.
I've only tested this on Linux, maybe it doesn't affect macOS as much?

This moves the dependency into a feature on crates/story, and narrows the default members.

## Videos

### Before

https://github.com/user-attachments/assets/16a8f40e-d602-4355-8728-2b06fab7bb37


### After

https://github.com/user-attachments/assets/b46f127a-41ea-46b9-856b-2d65780fecc6


## How to Test

Tested by running any example and scrolling. Also verified by grepping the symbol table for `TestAppContext`,
```sh
nm target/release/examples/markdown | grep TestAppContext
0000000004be36c0 t _RINvXs8_NtCsjjYRrL0dF1h_4gpui3appNtB6_3AppNtB8_10AppContext13update_windowuNCNCINvMsr_NtB8_6windowNtB1m_6Window5deferNCNCINvMs7_B6_Bv_11open_windowNtNtB8_7element5EmptyNCNvMs_NtB6_12test_contextNtB2N_14TestAppContext16add_empty_window0E00E00EB8_
```
None after this change.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
