### PR TITLE
editor: Improve outdent performance

### DIFF
--- a/crates/base/src/input/editor/indent.rs
+++ b/crates/base/src/input/editor/indent.rs
@@ -342,12 +342,13 @@ impl<M: InputModeKind> InputBaseState<M> {
             let start_offset = self.selected_range.start;
             let offset = self.start_of_line_of_selection(window, cx);
             let offset = self.offset_from_utf16(self.offset_to_utf16(offset));
-            // FIXME: To improve performance
+
             if self
                 .text
                 .slice(offset..self.text.len())
-                .to_string()
-                .starts_with(tab_indent.as_ref())
+                .chars()
+                .take(tab_indent.chars().count())
+                .eq(tab_indent.chars())
             {
                 self.replace_text_in_range_silent(
                     Some(self.range_to_utf16(&(offset..offset + tab_indent.len()))),


### PR DESCRIPTION
## Description

Outdent without a selection would copy the rest of the document just to see if the string starts with `tab_indent`. Replaced with a cheap iterator check instead.

## How to Test

Outdent in the editor example.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
