### PR TITLE
theme: Align dark syntax highlighting

### DIFF
--- a/crates/fps/src/monitor.rs
+++ b/crates/fps/src/monitor.rs
@@ -4,9 +4,12 @@ use instant::Instant;
 
 use gpui::{
     Bounds, Context, Div, Hsla, InteractiveElement as _, IntoElement, ParentElement, PathBuilder,
-    Pixels, Point, Render, StatefulInteractiveElement as _, Styled, Task, Window, canvas, div,
-    point, prelude::FluentBuilder as _, px, relative,
+    Pixels, Point, Render, StatefulInteractiveElement as _, Styled, Window, canvas, div, point,
+    prelude::FluentBuilder as _, px, relative,
 };
+
+#[cfg(not(target_family = "wasm"))]
+use gpui::Task;
 
 use crate::{
     FrameTraceGuard,
@@ -112,6 +115,7 @@ pub struct FpsMonitor {
     compact: bool,
     /// Upper bound of the chart's y axis, in seconds.
     axis_max: f32,
+    #[cfg(not(target_family = "wasm"))]
     resource_task: Option<Task<()>>,
     _frame_trace: FrameTraceGuard,
 }
@@ -131,6 +135,7 @@ impl FpsMonitor {
             resources: None,
             compact: false,
             axis_max: frame_budget.as_secs_f32() * 2.,
+            #[cfg(not(target_family = "wasm"))]
             resource_task: None,
             _frame_trace: FrameTraceGuard::acquire(),
         }

--- a/crates/ui/src/theme/default-theme.json
+++ b/crates/ui/src/theme/default-theme.json
@@ -323,7 +323,7 @@
         "created.background": "#0C4619",
         "deleted.background": "#46190C",
         "error.background": "#46190C",
-        "error.border": "#802207",
+        "error.border": "#E44A4F",
         "hidden": "#9E9E9E",
         "hint": "#b283f8",
         "hint.background": "#250c4b",
@@ -338,22 +338,22 @@
         "warning.border": "#7B6508",
         "syntax": {
           "attribute": {
-            "color": "#e7cb8f"
+            "color": "#7FAEF9"
           },
           "boolean": {
-            "color": "#E1D797"
+            "color": "#CC9E00"
           },
           "comment": {
-            "color": "#9E9E9E"
+            "color": "#9D9D9D"
           },
           "comment.doc": {
-            "color": "#9E9E9E"
+            "color": "#9D9D9D"
           },
           "constant": {
-            "color": "#E1D797"
+            "color": "#CC9E00"
           },
           "constructor": {
-            "color": "#b5af9a"
+            "color": "#0ABF9F"
           },
           "embedded": {
             "color": "#CACCCA"
@@ -365,13 +365,13 @@
             "font_weight": 700
           },
           "function": {
-            "color": "#fdd888"
+            "color": "#B3C5F3"
           },
           "keyword": {
-            "color": "#c28b12"
+            "color": "#87B1F6"
           },
           "link_text": {
-            "color": "#307BF6",
+            "color": "#419CFF",
             "font_style": "normal"
           },
           "link_uri": {
@@ -379,44 +379,44 @@
             "font_style": "italic"
           },
           "number": {
-            "color": "#E1D797"
+            "color": "#CC9E00"
           },
           "string": {
-            "color": "#62BA46"
+            "color": "#A3E09F"
           },
           "string.escape": {
-            "color": "#62BA46"
+            "color": "#68DC7C"
           },
           "string.regex": {
-            "color": "#62BA46"
+            "color": "#68DC7C"
           },
           "string.special": {
-            "color": "#E1D797"
+            "color": "#A3E09F"
           },
           "string.special.symbol": {
-            "color": "#E1D797"
+            "color": "#A3E09F"
           },
           "tag": {
-            "color": "#b5af9a"
+            "color": "#419CFF"
           },
           "text.literal": {
-            "color": "#E1D797"
+            "color": "#A3E09F"
           },
           "text.code.span": {
-            "color": "#E1D797"
+            "color": "#A3E09F"
           },
           "title": {
-            "color": "#fdd888",
+            "color": "#CC9E00",
             "font_weight": 600
           },
           "type": {
-            "color": "#c75828"
+            "color": "#0ABF9F"
           },
           "property": {
-            "color": "#CACCCA"
+            "color": "#BCC4E0"
           },
           "variable.special": {
-            "color": "#E19773"
+            "color": "#419CFF"
           }
         }
       }

--- a/crates/ui/src/theme/default-theme.json
+++ b/crates/ui/src/theme/default-theme.json
@@ -365,10 +365,10 @@
             "font_weight": 700
           },
           "function": {
-            "color": "#B3C5F3"
+            "color": "#8FA6D8"
           },
           "keyword": {
-            "color": "#87B1F6"
+            "color": "#78A9F5"
           },
           "link_text": {
             "color": "#419CFF",

--- a/crates/ui/src/theme/default-theme.json
+++ b/crates/ui/src/theme/default-theme.json
@@ -365,10 +365,10 @@
             "font_weight": 700
           },
           "function": {
-            "color": "#8FA6D8"
+            "color": "#B3C5F3"
           },
           "keyword": {
-            "color": "#78A9F5"
+            "color": "#87B1F6"
           },
           "link_text": {
             "color": "#419CFF",

--- a/crates/ui/src/theme/default-theme.json
+++ b/crates/ui/src/theme/default-theme.json
@@ -353,7 +353,7 @@
             "color": "#CC9E00"
           },
           "constructor": {
-            "color": "#0ABF9F"
+            "color": "#CBA6F7"
           },
           "embedded": {
             "color": "#CACCCA"
@@ -410,7 +410,7 @@
             "font_weight": 600
           },
           "type": {
-            "color": "#0ABF9F"
+            "color": "#CBA6F7"
           },
           "property": {
             "color": "#BCC4E0"

--- a/themes/macos-classic.json
+++ b/themes/macos-classic.json
@@ -222,7 +222,7 @@
             "color": "#CC9E00"
           },
           "constructor": {
-            "color": "#0ABF9F"
+            "color": "#CBA6F7"
           },
           "embedded": {
             "color": "#CACCCA"
@@ -273,7 +273,7 @@
             "font_weight": 600
           },
           "type": {
-            "color": "#0ABF9F"
+            "color": "#CBA6F7"
           },
           "property": {
             "color": "#BCC4E0"

--- a/themes/macos-classic.json
+++ b/themes/macos-classic.json
@@ -228,10 +228,10 @@
             "color": "#CACCCA"
           },
           "function": {
-            "color": "#B3C5F3"
+            "color": "#8FA6D8"
           },
           "keyword": {
-            "color": "#87B1F6"
+            "color": "#78A9F5"
           },
           "link_text": {
             "color": "#419CFF",

--- a/themes/macos-classic.json
+++ b/themes/macos-classic.json
@@ -149,6 +149,7 @@
         "border": "#303030",
         "ring": "#077CFD",
         "foreground": "#DEDEDE",
+        "danger.background": "#E44A4F",
         "list.even.background": "#232323",
         "list.active.background": "#0059D115",
         "list.active.border": "#077CFD",
@@ -191,7 +192,7 @@
         "created.background": "#0C4619",
         "deleted.background": "#46190C",
         "error.background": "#46190C",
-        "error.border": "#802207",
+        "error.border": "#E44A4F",
         "hidden": "#9E9E9E",
         "hint": "#b283f8",
         "hint.background": "#250c4b",
@@ -206,34 +207,34 @@
         "warning.border": "#7B6508",
         "syntax": {
           "attribute": {
-            "color": "#e7cb8f"
+            "color": "#7FAEF9"
           },
           "boolean": {
-            "color": "#E1D797"
+            "color": "#CC9E00"
           },
           "comment": {
-            "color": "#9E9E9E"
+            "color": "#9D9D9D"
           },
           "comment.doc": {
-            "color": "#9E9E9E"
+            "color": "#9D9D9D"
           },
           "constant": {
-            "color": "#E1D797"
+            "color": "#CC9E00"
           },
           "constructor": {
-            "color": "#b5af9a"
+            "color": "#0ABF9F"
           },
           "embedded": {
             "color": "#CACCCA"
           },
           "function": {
-            "color": "#fdd888"
+            "color": "#B3C5F3"
           },
           "keyword": {
-            "color": "#c28b12"
+            "color": "#87B1F6"
           },
           "link_text": {
-            "color": "#307BF6",
+            "color": "#419CFF",
             "font_style": "normal"
           },
           "link_uri": {
@@ -241,41 +242,44 @@
             "font_style": "italic"
           },
           "number": {
-            "color": "#E1D797"
+            "color": "#CC9E00"
           },
           "string": {
-            "color": "#62BA46"
+            "color": "#A3E09F"
+          },
+          "text.code.span": {
+            "color": "#A3E09F"
           },
           "string.escape": {
-            "color": "#62BA46"
+            "color": "#68DC7C"
           },
           "string.regex": {
-            "color": "#62BA46"
+            "color": "#68DC7C"
           },
           "string.special": {
-            "color": "#E1D797"
+            "color": "#A3E09F"
           },
           "string.special.symbol": {
-            "color": "#E1D797"
+            "color": "#A3E09F"
           },
           "tag": {
-            "color": "#b5af9a"
+            "color": "#419CFF"
           },
           "text.literal": {
-            "color": "#E1D797"
+            "color": "#A3E09F"
           },
           "title": {
-            "color": "#fdd888",
+            "color": "#CC9E00",
             "font_weight": 600
           },
           "type": {
-            "color": "#c75828"
+            "color": "#0ABF9F"
           },
           "property": {
-            "color": "#CACCCA"
+            "color": "#BCC4E0"
           },
           "variable.special": {
-            "color": "#E19773"
+            "color": "#419CFF"
           }
         }
       }

--- a/themes/macos-classic.json
+++ b/themes/macos-classic.json
@@ -228,10 +228,10 @@
             "color": "#CACCCA"
           },
           "function": {
-            "color": "#8FA6D8"
+            "color": "#B3C5F3"
           },
           "keyword": {
-            "color": "#78A9F5"
+            "color": "#87B1F6"
           },
           "link_text": {
             "color": "#419CFF",

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -233,7 +233,7 @@ html.dark .alignment-dark {
   --code-string: #a3e09f;
   --code-comment: #9d9d9d;
   --code-fn: #b3c5f3;
-  --code-type: #0abf9f;
+  --code-type: #cba6f7;
 }
 
 html {

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -229,10 +229,10 @@ html.dark .alignment-dark {
   /* src/dark.theme.json ("macos-classic-dark") */
   --code-bg: #151515;
   --code-fg: #caccca;
-  --code-keyword: #87b1f6;
+  --code-keyword: #78a9f5;
   --code-string: #a3e09f;
   --code-comment: #9d9d9d;
-  --code-fn: #b3c5f3;
+  --code-fn: #8fa6d8;
   --code-type: #cba6f7;
 }
 

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -180,7 +180,7 @@ html.dark .alignment-dark {
   --muted-foreground: #a3a3a3;
   --accent: #262626;
   --accent-foreground: #fafafa;
-  --destructive: #f87171;
+  --destructive: #e44a4f;
   --border: #262626;
   --input: #2f2f2f;
   --ring: #d4d4d4;
@@ -205,11 +205,11 @@ html.dark .alignment-dark {
   --brand-subtle: #262626;
   --brand-line: color-mix(in srgb, var(--foreground) 26%, transparent);
 
-  --data-1: #e9a05a;
-  --data-2: #b54e05;
-  --data-3: #c9761f;
-  --data-4: #8f3d04;
-  --data-5: #6b2d03;
+  --data-1: #93c5fd;
+  --data-2: #419cff;
+  --data-3: #2563eb;
+  --data-4: #1d4ed8;
+  --data-5: #1e40af;
 
   --selection: #c2610a;
 
@@ -229,11 +229,11 @@ html.dark .alignment-dark {
   /* src/dark.theme.json ("macos-classic-dark") */
   --code-bg: #151515;
   --code-fg: #caccca;
-  --code-keyword: #c28b12;
-  --code-string: #76ba53;
-  --code-comment: #9e9e9e;
-  --code-fn: #fdd888;
-  --code-type: #b54e05;
+  --code-keyword: #87b1f6;
+  --code-string: #a3e09f;
+  --code-comment: #9d9d9d;
+  --code-fn: #b3c5f3;
+  --code-type: #0abf9f;
 }
 
 html {

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -229,10 +229,10 @@ html.dark .alignment-dark {
   /* src/dark.theme.json ("macos-classic-dark") */
   --code-bg: #151515;
   --code-fg: #caccca;
-  --code-keyword: #78a9f5;
+  --code-keyword: #87b1f6;
   --code-string: #a3e09f;
   --code-comment: #9d9d9d;
-  --code-fn: #8fa6d8;
+  --code-fn: #b3c5f3;
   --code-type: #cba6f7;
 }
 

--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -43,8 +43,8 @@ site and the documented components share one palette.
 | `--sidebar` | `#fafafa` | `#0f0f0f` | `sidebar.background` |
 | `--titlebar` | `#f8f8f8` | `#171717` | `title_bar.background` |
 | `--brand` | `#171717` | `#fafafa` | `primary.background` |
-| `--data-1…5` | `#93c5fd` → `#1e40af` | same | `chart_1…chart_5` |
-| logo accent | `#3b82f6` | `#b54e05` | `chart_2` / dark `entity.name.type` |
+| `--data-1…5` | `#93c5fd` → `#1e40af` | blue scale, keyed by `#419cff` | `chart_1…chart_5` |
+| logo accent | `#3b82f6` | `#419cff` | light `chart_2` / dark syntax link and tag blue |
 | `--selection` | `#55a0fc` | same | `selection.background` |
 | `--success` | `#22c55e` | same | `success.background` |
 | `--code-*` | macos-classic-light | macos-classic-dark | `src/*.theme.json` |
@@ -61,9 +61,9 @@ Rules that follow from this:
 - **Saturated colour is reserved for data**, exactly as the theme reserves
   `chart_*`. The capability diagrams and charts may use `--data-*`; marketing
   surfaces may not.
-- **The logo accent is per-theme**: `#3b82f6` (`chart_2`) on light, `#b54e05`
-  on dark — the latter is the dark syntax theme's `entity.name.type`, so the
-  mark stays keyed to the code colours a reader sees on that background. The
+- **The logo accent is per-theme**: `#3b82f6` (`chart_2`) on light and
+  `#419cff` (the dark syntax theme’s link and tag blue) on dark, so the mark follows
+  the code palette shown on the same background. The
   mark is split into two paths — an open `C`, and the bar-and-stem that turns it
   into a `G` — so that stroke can carry the accent while the rest stays neutral.
   The values are baked into `public/logo.svg` and `logo-dark.svg`; making them

--- a/website/public/alignment-spines-dark.svg
+++ b/website/public/alignment-spines-dark.svg
@@ -61,7 +61,7 @@
 
     <circle class="muted-surface" cx="146" cy="496" r="12"/><text class="ink" x="146" y="501" text-anchor="middle" font-size="11" font-weight="700">B</text>
     <text class="ink" x="174" y="501" font-size="15" font-weight="620">Beacon</text>
-    <circle cx="562" cy="496" r="4" fill="#f59e0b"/><text class="muted" x="574" y="501" font-size="14">Review</text>
+    <circle cx="562" cy="496" r="4" fill="#419cff"/><text class="muted" x="574" y="501" font-size="14">Review</text>
     <text class="muted" x="696" y="501" font-size="14">Yesterday</text>
     <g fill="#a3a3a3"><circle cx="810" cy="496" r="2"/><circle cx="816" cy="496" r="2"/><circle cx="822" cy="496" r="2"/></g>
 

--- a/website/public/alignment-spines.svg
+++ b/website/public/alignment-spines.svg
@@ -61,7 +61,7 @@
 
     <circle class="muted-surface" cx="146" cy="496" r="12"/><text class="ink" x="146" y="501" text-anchor="middle" font-size="11" font-weight="700">B</text>
     <text class="ink" x="174" y="501" font-size="15" font-weight="620">Beacon</text>
-    <circle cx="562" cy="496" r="4" fill="#f59e0b"/><text class="muted" x="574" y="501" font-size="14">Review</text>
+    <circle cx="562" cy="496" r="4" fill="#419cff"/><text class="muted" x="574" y="501" font-size="14">Review</text>
     <text class="muted" x="696" y="501" font-size="14">Yesterday</text>
     <g fill="#737373"><circle cx="810" cy="496" r="2"/><circle cx="816" cy="496" r="2"/><circle cx="822" cy="496" r="2"/></g>
 

--- a/website/public/logo-dark.svg
+++ b/website/public/logo-dark.svg
@@ -3,5 +3,5 @@
   <!-- The mark splits into two counters: an open C, and the bar-and-stem that
        turns it into a G. Together they cover exactly the original path. -->
   <path fill="#ECEDEF" d="M4 4h24v5H10v14h18v5H4V4Z"/>
-  <path fill="#B54E05" d="M16 13h12v10h-5v-5h-7v-5Z"/>
+  <path fill="#419CFF" d="M16 13h12v10h-5v-5h-7v-5Z"/>
 </svg>

--- a/website/public/og-template.html
+++ b/website/public/og-template.html
@@ -30,7 +30,7 @@
           --border: #262626;
           --rule-dim: #404040;
           --logo-c: #ecedef;
-          --logo-accent: #b54e05;
+          --logo-accent: #419cff;
         }
       }
 

--- a/website/src/dark.theme.json
+++ b/website/src/dark.theme.json
@@ -185,7 +185,7 @@
         "entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#87B1F6"
+        "foreground": "#78A9F5"
       }
     },
     {
@@ -201,7 +201,7 @@
         "meta.template.expression"
       ],
       "settings": {
-        "foreground": "#87B1F6"
+        "foreground": "#78A9F5"
       }
     },
     {
@@ -274,7 +274,7 @@
     {
       "scope": ["meta.function-call", "support.function", "entity.name.function"],
       "settings": {
-        "foreground": "#B3C5F3"
+        "foreground": "#8FA6D8"
       }
     },
     {

--- a/website/src/dark.theme.json
+++ b/website/src/dark.theme.json
@@ -216,7 +216,7 @@
         "entity.other.attribute-name.attribute.scss"
       ],
       "settings": {
-        "foreground": "#0ABF9F"
+        "foreground": "#CBA6F7"
       }
     },
     {
@@ -242,7 +242,7 @@
         "meta.instance.constructor"
       ],
       "settings": {
-        "foreground": "#0ABF9F"
+        "foreground": "#CBA6F7"
       }
     },
     {

--- a/website/src/dark.theme.json
+++ b/website/src/dark.theme.json
@@ -146,20 +146,19 @@
     {
       "scope": ["comment", "markup.fenced_code", "markup.inline"],
       "settings": {
-        "foreground": "#9E9E9E"
+        "foreground": "#9D9D9D"
       }
     },
     {
       "scope": "string",
       "settings": {
-        "foreground": "#76BA53"
+        "foreground": "#A3E09F"
       }
     },
     {
       "scope": [
         "variable.other.constant",
         "variable.other.class",
-        "meta.property-name",
         "meta.property-value",
         "support",
         "constant.language.boolean",
@@ -172,7 +171,7 @@
     {
       "scope": ["constant.language", "constant.other.color"],
       "settings": {
-        "foreground": "#ca8a04"
+        "foreground": "#CC9E00"
       }
     },
     {
@@ -186,13 +185,13 @@
         "entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#c28b12"
+        "foreground": "#87B1F6"
       }
     },
     {
       "scope": ["meta.tag.structure", "entity.name.tag"],
       "settings": {
-        "foreground": "#9a9576"
+        "foreground": "#419CFF"
       }
     },
     {
@@ -202,7 +201,7 @@
         "meta.template.expression"
       ],
       "settings": {
-        "foreground": "#AE9513"
+        "foreground": "#87B1F6"
       }
     },
     {
@@ -217,7 +216,13 @@
         "entity.other.attribute-name.attribute.scss"
       ],
       "settings": {
-        "foreground": "#AC98AD"
+        "foreground": "#0ABF9F"
+      }
+    },
+    {
+      "scope": ["support.type", "storage.type.built-in"],
+      "settings": {
+        "foreground": "#30D158"
       }
     },
     {
@@ -227,25 +232,33 @@
         "meta.definition.variable.scss"
       ],
       "settings": {
-        "foreground": "#E1D797"
+        "foreground": "#419CFF"
       }
     },
     {
       "scope": [
         "entity.name.type",
         "entity.other.inherited-class",
-        "variable.other.object.property",
         "meta.instance.constructor"
       ],
       "settings": {
-        "foreground": "#b54e05"
+        "foreground": "#0ABF9F"
+      }
+    },
+    {
+      "scope": [
+        "meta.property-name",
+        "support.type.property-name.json",
+        "string.quoted.double.json"
+      ],
+      "settings": {
+        "foreground": "#BCC4E0"
       }
     },
     {
       "scope": [
         "support.constant.property-value",
         "support.variable.property.dom",
-        "support.type.property-name.json",
         "punctuation.separator.key-value"
       ],
       "settings": {
@@ -253,27 +266,27 @@
       }
     },
     {
-      "scope": ["meta.function-call", "variable.parameter.function"],
+      "scope": ["variable.parameter.function"],
       "settings": {
-        "foreground": "#CACCCA"
+        "foreground": "#BCC4E0"
       }
     },
     {
-      "scope": ["support.function", "entity.name.function"],
+      "scope": ["meta.function-call", "support.function", "entity.name.function"],
       "settings": {
-        "foreground": "#fdd888"
+        "foreground": "#B3C5F3"
       }
     },
     {
       "scope": ["variable.other.constant", "variable.language.this"],
       "settings": {
-        "foreground": "#7D7A68"
+        "foreground": "#CC9E00"
       }
     },
     {
       "scope": ["constant.other.symbol"],
       "settings": {
-        "foreground": "#7D7A68"
+        "foreground": "#CC9E00"
       }
     },
     {
@@ -285,7 +298,19 @@
         "keyword.other.template"
       ],
       "settings": {
-        "foreground": "#62BA46"
+        "foreground": "#A3E09F"
+      }
+    },
+    {
+      "scope": ["constant.numeric"],
+      "settings": {
+        "foreground": "#CC9E00"
+      }
+    },
+    {
+      "scope": ["entity.other.attribute-name"],
+      "settings": {
+        "foreground": "#7FAEF9"
       }
     },
     {
@@ -303,7 +328,7 @@
     {
       "scope": "token.error-token",
       "settings": {
-        "foreground": "#cd3131"
+        "foreground": "#E44A4F"
       }
     },
     {

--- a/website/src/dark.theme.json
+++ b/website/src/dark.theme.json
@@ -185,7 +185,7 @@
         "entity.other.attribute-name"
       ],
       "settings": {
-        "foreground": "#78A9F5"
+        "foreground": "#87B1F6"
       }
     },
     {
@@ -201,7 +201,7 @@
         "meta.template.expression"
       ],
       "settings": {
-        "foreground": "#78A9F5"
+        "foreground": "#87B1F6"
       }
     },
     {
@@ -274,7 +274,7 @@
     {
       "scope": ["meta.function-call", "support.function", "entity.name.function"],
       "settings": {
-        "foreground": "#8FA6D8"
+        "foreground": "#B3C5F3"
       }
     },
     {


### PR DESCRIPTION
## Description

Align the macOS Classic Dark, default dark, and website code highlighting palettes with the terminal-inspired colors.

- Distinguish keywords, methods, types, parameters, strings, diagnostics, and literals.
- Replace the website's remaining orange/yellow dark accents with the blue accent, including the logo and illustrations.
- Keep the website theme documentation and Shiki/CSS token mappings in sync.
- Avoid storing the native resource sampling task on WASM, removing the `resource_task` dead-code warning without changing native behavior.

## Screenshot

Not included; the changes update theme colors and static website accents.

## How to Test

- `cargo build --target wasm32-unknown-unknown` from `crates/story-web`
- `cargo test -p gpui-fps`
- `cargo fmt -p gpui-fps --check`
- `bun run build` from `website`
- Parse the modified theme JSON files with `python -m json.tool`
- `git diff --check`

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)