### PR TITLE
story: Use the system menu bar on macOS

### DIFF
--- a/crates/story/src/app_menus.rs
+++ b/crates/story/src/app_menus.rs
@@ -6,11 +6,8 @@ use crate::{
     themes::{SelectTheme, SwitchThemeMode},
 };
 
-// Used to skip drawing the menus on macos. Possibly useful in some Linux contexts, also?
-const HAS_SYSTEM_MENU_BAR: bool = cfg!(target_os = "macos");
-
-pub fn init(title: impl Into<SharedString>, cx: &mut App) -> Option<Entity<AppMenuBar>> {
-    let app_menu_bar = (!HAS_SYSTEM_MENU_BAR).then(|| AppMenuBar::new(cx));
+pub fn init(title: impl Into<SharedString>, cx: &mut App) -> Entity<AppMenuBar> {
+    let app_menu_bar = AppMenuBar::new(cx);
     let title: SharedString = title.into();
     update_app_menu(title.clone(), app_menu_bar.clone(), cx);
 
@@ -36,18 +33,10 @@ pub fn init(title: impl Into<SharedString>, cx: &mut App) -> Option<Entity<AppMe
     app_menu_bar
 }
 
-fn update_app_menu(
-    title: impl Into<SharedString>,
-    app_menu_bar: Option<Entity<AppMenuBar>>,
-    cx: &mut App,
-) {
+fn update_app_menu(title: impl Into<SharedString>, app_menu_bar: Entity<AppMenuBar>, cx: &mut App) {
     let title: SharedString = title.into();
 
     cx.set_menus(build_menus(title.clone(), cx));
-    let Some(app_menu_bar) = app_menu_bar else {
-        return;
-    };
-
     let menus = build_menus(title, cx)
         .into_iter()
         .map(|menu| menu.owned())

--- a/crates/story/src/app_menus.rs
+++ b/crates/story/src/app_menus.rs
@@ -6,8 +6,11 @@ use crate::{
     themes::{SelectTheme, SwitchThemeMode},
 };
 
-pub fn init(title: impl Into<SharedString>, cx: &mut App) -> Entity<AppMenuBar> {
-    let app_menu_bar = AppMenuBar::new(cx);
+// Used to skip drawing the menus on macos. Possibly useful in some Linux contexts, also?
+const HAS_SYSTEM_MENU_BAR: bool = cfg!(target_os = "macos");
+
+pub fn init(title: impl Into<SharedString>, cx: &mut App) -> Option<Entity<AppMenuBar>> {
+    let app_menu_bar = (!HAS_SYSTEM_MENU_BAR).then(|| AppMenuBar::new(cx));
     let title: SharedString = title.into();
     update_app_menu(title.clone(), app_menu_bar.clone(), cx);
 
@@ -33,10 +36,18 @@ pub fn init(title: impl Into<SharedString>, cx: &mut App) -> Entity<AppMenuBar> 
     app_menu_bar
 }
 
-fn update_app_menu(title: impl Into<SharedString>, app_menu_bar: Entity<AppMenuBar>, cx: &mut App) {
+fn update_app_menu(
+    title: impl Into<SharedString>,
+    app_menu_bar: Option<Entity<AppMenuBar>>,
+    cx: &mut App,
+) {
     let title: SharedString = title.into();
 
     cx.set_menus(build_menus(title.clone(), cx));
+    let Some(app_menu_bar) = app_menu_bar else {
+        return;
+    };
+
     let menus = build_menus(title, cx)
         .into_iter()
         .map(|menu| menu.owned())

--- a/crates/story/src/lib.rs
+++ b/crates/story/src/lib.rs
@@ -73,7 +73,8 @@ actions!(
         TabPrev,
         ShowPanelInfo,
         ToggleListActiveHighlight,
-        ToggleFpsMonitor
+        ToggleFpsMonitor,
+        ToggleAppMenuBar
     ]
 );
 
@@ -84,6 +85,12 @@ pub struct AppState {
     /// Whether the window root renders the performance HUD. Toggled from the
     /// title bar's settings menu, read by [`StoryRoot`].
     pub show_fps_monitor: bool,
+    /// Whether the title bar draws the in-window [`AppMenuBar`] instead of the
+    /// window title. Toggled from the title bar's settings menu, read by
+    /// [`AppTitleBar`].
+    ///
+    /// [`AppMenuBar`]: gpui_component::menu::AppMenuBar
+    pub show_app_menu_bar: bool,
     pub(crate) previewing_theme: bool,
 }
 impl AppState {
@@ -91,6 +98,10 @@ impl AppState {
         let state = Self {
             invisible_panels: cx.new(|_| Vec::new()),
             show_fps_monitor: false,
+            // macOS draws the app menus in the system menu bar, so an in-window
+            // menu bar would be a second copy of them. Off by default there,
+            // but still switchable so the component stays demoable on a Mac.
+            show_app_menu_bar: !cfg!(target_os = "macos"),
             previewing_theme: false,
         };
         cx.set_global::<AppState>(state);

--- a/crates/story/src/title_bar.rs
+++ b/crates/story/src/title_bar.rs
@@ -14,13 +14,13 @@ use gpui_component::{
 };
 
 use crate::{
-    AppState, SelectFont, SelectRadius, SelectScrollbarMode, ToggleFpsMonitor,
+    AppState, SelectFont, SelectRadius, SelectScrollbarMode, ToggleAppMenuBar, ToggleFpsMonitor,
     ToggleListActiveHighlight, app_menus,
 };
 
 pub struct AppTitleBar {
     title: SharedString,
-    app_menu_bar: Option<Entity<AppMenuBar>>,
+    app_menu_bar: Entity<AppMenuBar>,
     font_size_selector: Entity<FontSizeSelector>,
     child: Rc<dyn Fn(&mut Window, &mut App) -> AnyElement>,
     _subscriptions: Vec<Subscription>,
@@ -58,25 +58,24 @@ impl AppTitleBar {
 impl Render for AppTitleBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let notifications_count = window.notifications(cx).len();
+        let show_app_menu_bar = AppState::global(cx).show_app_menu_bar;
 
         TitleBar::new()
             // left side
-            .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .children(self.app_menu_bar.clone())
-                    // when the system draws the menus elsewhere, add a title to the window
-                    .when_none(&self.app_menu_bar, |this| {
-                        this.child(
-                            div()
-                                .text_sm()
-                                .font_weight(FontWeight::MEDIUM)
-                                .text_color(cx.theme().foreground)
-                                .child(self.title.clone()),
-                        )
-                    }),
-            )
+            .child(div().flex().items_center().map(|this| {
+                if show_app_menu_bar {
+                    this.child(self.app_menu_bar.clone())
+                } else {
+                    // The system menu bar owns the menus, so the freed up left
+                    // side names the window the way a Mac app does.
+                    this.child(
+                        div()
+                            .text_sm()
+                            .font_weight(FontWeight::MEDIUM)
+                            .child(self.title.clone()),
+                    )
+                }
+            }))
             .child(
                 div()
                     .flex()
@@ -181,6 +180,17 @@ impl FontSizeSelector {
         state.show_fps_monitor = !state.show_fps_monitor;
         window.refresh();
     }
+
+    fn on_toggle_app_menu_bar(
+        &mut self,
+        _: &ToggleAppMenuBar,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let state = AppState::global_mut(cx);
+        state.show_app_menu_bar = !state.show_app_menu_bar;
+        window.refresh();
+    }
 }
 
 impl Render for FontSizeSelector {
@@ -190,6 +200,7 @@ impl Render for FontSizeSelector {
         let radius = cx.theme().radius.as_f32() as i32;
         let scroll_show = cx.theme().scrollbar_mode;
         let show_fps_monitor = AppState::global(cx).show_fps_monitor;
+        let show_app_menu_bar = AppState::global(cx).show_app_menu_bar;
 
         div()
             .id("font-size-selector")
@@ -199,6 +210,7 @@ impl Render for FontSizeSelector {
             .on_action(cx.listener(Self::on_select_scrollbar_mode))
             .on_action(cx.listener(Self::on_toggle_list_active_highlight))
             .on_action(cx.listener(Self::on_toggle_fps_monitor))
+            .on_action(cx.listener(Self::on_toggle_app_menu_bar))
             .child(
                 Button::new("btn")
                     .small()
@@ -253,6 +265,11 @@ impl Render for FontSizeSelector {
                                 "FPS Monitor",
                                 show_fps_monitor,
                                 Box::new(ToggleFpsMonitor),
+                            )
+                            .menu_with_check(
+                                "App Menu Bar",
+                                show_app_menu_bar,
+                                Box::new(ToggleAppMenuBar),
                             )
                     })
                     .anchor(Anchor::TopRight),

--- a/crates/story/src/title_bar.rs
+++ b/crates/story/src/title_bar.rs
@@ -1,9 +1,9 @@
 use std::rc::Rc;
 
 use gpui::{
-    Anchor, AnyElement, App, AppContext, Context, Entity, FocusHandle, InteractiveElement as _,
-    IntoElement, MouseButton, ParentElement as _, Render, SharedString, Styled as _, Subscription,
-    Window, div, px,
+    Anchor, AnyElement, App, AppContext, Context, Entity, FocusHandle, FontWeight,
+    InteractiveElement as _, IntoElement, MouseButton, ParentElement as _, Render, SharedString,
+    Styled as _, Subscription, Window, div, prelude::FluentBuilder as _, px,
 };
 use gpui_component::{
     ActiveTheme as _, IconName, Side, Sizable as _, Theme, TitleBar, WindowExt as _,
@@ -19,7 +19,8 @@ use crate::{
 };
 
 pub struct AppTitleBar {
-    app_menu_bar: Entity<AppMenuBar>,
+    title: SharedString,
+    app_menu_bar: Option<Entity<AppMenuBar>>,
     font_size_selector: Entity<FontSizeSelector>,
     child: Rc<dyn Fn(&mut Window, &mut App) -> AnyElement>,
     _subscriptions: Vec<Subscription>,
@@ -31,10 +32,12 @@ impl AppTitleBar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let app_menu_bar = app_menus::init(title, cx);
+        let title: SharedString = title.into();
+        let app_menu_bar = app_menus::init(title.clone(), cx);
         let font_size_selector = cx.new(|cx| FontSizeSelector::new(window, cx));
 
         Self {
+            title,
             app_menu_bar,
             font_size_selector,
             child: Rc::new(|_, _| div().into_any_element()),
@@ -58,7 +61,22 @@ impl Render for AppTitleBar {
 
         TitleBar::new()
             // left side
-            .child(div().flex().items_center().child(self.app_menu_bar.clone()))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .children(self.app_menu_bar.clone())
+                    // when the system draws the menus elsewhere, add a title to the window
+                    .when_none(&self.app_menu_bar, |this| {
+                        this.child(
+                            div()
+                                .text_sm()
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(cx.theme().foreground)
+                                .child(self.title.clone()),
+                        )
+                    }),
+            )
             .child(
                 div()
                     .flex()


### PR DESCRIPTION
Mac applications generally put their application menus in the global menubar at the top of the screen.

This changes the story example to have MacOS draw the menubar at the top of the screen, and also draw the title in the window, to behave more like a typical mac application.

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

### Before

https://l.e42.us/VVTYdCrh

### After

https://l.e42.us/TbVdmDWq

**Note**: This change does nothing on platforms other than macos right now. I don't think a global menubar is currently common anywhere else, although I'm sure some KDE configurations could prove me wrong. I've tested Linux and Mac to ensure that the change is only active on Mac. The Linux behavior was unchanged. I don't have a Windows machine to test with, but I'm confident `cfg!(target_os = "macos")` will work as well there as it did on Linux.

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [X] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
