### PR TITLE
skills: Fix component paths and the Dialog example

### DIFF
--- a/skills/gpui-component/SKILL.md
+++ b/skills/gpui-component/SKILL.md
@@ -86,19 +86,19 @@ When you need a component, find it here. For full API, fetch its `.md` doc.
 | Component | Import | Notes |
 |-----------|--------|-------|
 | `Input` | `input::{Input, InputState}` | Stateful. Text, password, mask, validation |
-| `NumberInput` | `number_input::{NumberInput, NumberInputState}` | Stateful. Numeric with step |
-| `OtpInput` | `otp_input::{OtpInput, OtpInputState}` | Stateful. One-time password |
+| `NumberInput` | `input::{NumberInput, NumberInputEvent}` | Stateful. Numeric with step |
+| `OtpInput` | `input::OtpInput` | Stateful. One-time password |
 | `Select` | `select::{Select, SelectState}` | Stateful. Dropdown picker |
 | `Combobox` | `combobox::{Combobox, ComboboxState}` | Stateful. Searchable select |
 | `Checkbox` | `checkbox::Checkbox` | Stateless. `on_click(|&bool, ...|)` |
 | `Switch` | `switch::Switch` | Stateless. Toggle |
 | `Radio` | `radio::{Radio, RadioGroup}` | Stateless. |
 | `Slider` | `slider::{Slider, SliderState}` | Stateful. |
-| `Toggle` | `toggle::Toggle` | Stateless. |
+| `Toggle` | `button::Toggle` | Stateless. |
 | `Rating` | `rating::Rating` | Stateless. |
 | `Stepper` | `stepper::Stepper` | Stateless. Increment/decrement |
 | `ColorPicker` | `color_picker::{ColorPicker, ColorPickerState}` | Stateful. |
-| `DatePicker` | `time::date_picker::{DatePicker, DatePickerState}` | Stateful. |
+| `DatePicker` | `date_picker::{DatePicker, DatePickerState}` | Stateful. |
 | `Form` | `form::{v_form, h_form, field}` | Layout container for form fields |
 
 ### Display & Feedback
@@ -114,16 +114,15 @@ When you need a component, find it here. For full API, fetch its `.md` doc.
 | `Alert` | `alert::Alert` | Stateless. Info/success/warning/error |
 | `Spinner` | `spinner::Spinner` | Stateless. Loading indicator |
 | `Skeleton` | `skeleton::Skeleton` | Stateless. Loading placeholder |
-| `Progress` | `progress::{ProgressBar, ProgressCircle}` | Stateless. |
+| `Progress` | `progress::{Progress, ProgressCircle}` | Stateless. |
 | `Tooltip` | `tooltip::Tooltip` | Via `.tooltip()` on elements |
 | `HoverCard` | `hover_card::{HoverCard, HoverCardState}` | Stateful. |
-| `Image` | `image::Image` | Stateless. |
 | `Clipboard` | `clipboard::Clipboard` | Stateless. Copy button |
 
 ### Overlay & Popups
 | Component | Import | Notes |
 |-----------|--------|-------|
-| `Dialog` | `dialog::Dialog` + `WindowExt` | Via `window.open_modal(...)` |
+| `Dialog` | `dialog::Dialog` + `WindowExt` | Via `window.open_dialog(...)` |
 | `AlertDialog` | `WindowExt` | Via `window.open_alert_dialog(...)` |
 | `Sheet` | `sheet::Sheet` + `WindowExt` | Side panel, via `window.open_sheet(...)` |
 | `Notification` | `notification::Notification` + `WindowExt` | Via `window.push_notification(...)` |
@@ -136,15 +135,15 @@ When you need a component, find it here. For full API, fetch its `.md` doc.
 |-----------|--------|-------|
 | `Tabs` / `TabBar` | `tab::{Tab, TabBar}` | Tabbed interface |
 | `Sidebar` | `sidebar::{Sidebar, SidebarMenu, ...}` | App navigation panel |
-| `TitleBar` | `title_bar::TitleBar` | Window title bar |
+| `TitleBar` | `TitleBar` | Window title bar |
 | `Breadcrumb` | `breadcrumb::Breadcrumb` | Navigation breadcrumb |
 | `Pagination` | `pagination::Pagination` | Page navigation |
 | `Accordion` | `accordion::Accordion` | Collapsible sections |
 | `Collapsible` | `collapsible::Collapsible` | Single collapsible |
 | `GroupBox` | `group_box::GroupBox` | Labeled container |
-| `Resizable` | `resizable::Resizable` | Draggable split panes |
+| `Resizable` | `resizable::{h_resizable, v_resizable, resizable_panel, ResizableState}` | Draggable split panes |
 | `Scrollable` | `scroll::Scrollbar` | Custom scrollbar |
-| `FocusTrap` | `focus_trap::FocusTrap` | Keyboard trap for modals |
+| `FocusTrap` | `gpui_base::focus_trap::FocusTrapElement` | Keyboard trap for modals |
 
 ### Data Display
 | Component | Import | Notes |
@@ -153,14 +152,14 @@ When you need a component, find it here. For full API, fetch its `.md` doc.
 | `Table` | `table::{Table, ...}` | Simpler table |
 | `VirtualList` | `{v_virtual_list, h_virtual_list}` | High-perf large lists |
 | `List` | `list::{List, ListState, ListDelegate}` | Stateful. Searchable list |
-| `Tree` | `tree::{Tree, TreeState, TreeDelegate}` | Stateful. Hierarchy |
+| `Tree` | `tree::{Tree, TreeState, TreeItem, TreeEntry}` | Stateful. Hierarchy |
 | `DescriptionList` | `description_list::DescriptionList` | Key-value pairs |
-| `Settings` | `settings::Settings` | Settings panel |
+| `Settings` | `setting::Settings` | Settings panel |
 
 ### Charts
 | Component | Import | Notes |
 |-----------|--------|-------|
-| `Chart` | `chart::Chart` | Bar, line, area, pie charts |
+| `Chart` | `chart::{AreaChart, BarChart, LineChart, PieChart, RadarChart}` | Bar, line, area, pie charts |
 | `Plot` | `plot::Plot` | `#[derive(IntoPlot)]` for data |
 
 ## Reference Files

--- a/skills/gpui-component/references/usage.md
+++ b/skills/gpui-component/references/usage.md
@@ -196,18 +196,47 @@ Icon::new(IconName::Plus).large().text_color(cx.theme().primary)
 ### Dialog
 
 ```rust
-use gpui_component::dialog::Dialog;
+use gpui_component::dialog::{Dialog, DialogAction, DialogClose, DialogFooter};
 
-// Open from window context
-window.open_modal(cx, |modal, _, cx| {
-    modal
-        .title("Confirm")
-        .child(div().child("Are you sure?"))
-        .footer(|this, _, cx| {
-            this.child(Button::new("cancel").label("Cancel"))
-                .child(Button::new("ok").primary().label("OK")
-                    .on_click(|_, window, cx| { window.close_modal(cx); }))
-        })
+// Open from window context. `footer` takes an element, not a closure.
+// DialogClose dismisses the dialog, so no manual close call is needed.
+window.open_dialog(cx, |dialog, _, _| {
+    dialog
+        .title("Export Report")
+        .child("Choose a destination for the exported file.")
+        .footer(
+            DialogFooter::new()
+                .gap_2()
+                .child(DialogClose::new().child(
+                    Button::new("cancel").label("Cancel").outline(),
+                ))
+                .child(DialogAction::new().child(
+                    Button::new("export").label("Export").primary(),
+                )),
+        )
+});
+```
+
+### AlertDialog
+
+Use `AlertDialog` — not `Dialog` — to confirm a consequential action. It is not
+overlay-closable and has no close button, so the choice must be made. Name the
+object in the title and the result on the confirming button; see the Design
+Guides for the copy rules.
+
+```rust
+use gpui_component::{button::ButtonVariant, dialog::DialogButtonProps};
+
+window.open_alert_dialog(cx, |alert, _, _| {
+    alert
+        .title("Remove “Roadmap”?")
+        .description("Files on disk aren’t deleted.")
+        .button_props(
+            DialogButtonProps::default()
+                .ok_text("Remove")
+                .ok_variant(ButtonVariant::Danger)
+                .on_ok(|_, _, _| true),
+        )
 });
 ```
 


### PR DESCRIPTION
Follow-up to #2805. Now that the Design and Coding Guides ship inside the `gpui-component` skill, the rest of that skill was audited against `crates/` — every import path in the component table and every `window.*` / `cx.*` call in the examples.

Twelve of 53 table rows named a module or type that does not exist. An agent following them writes code that will not compile.

## Component table

| Row | Was | Now |
| --- | --- | --- |
| `NumberInput` | `number_input::{NumberInput, NumberInputState}` | `input::{NumberInput, NumberInputEvent}` |
| `OtpInput` | `otp_input::{OtpInput, OtpInputState}` | `input::OtpInput` |
| `Toggle` | `toggle::Toggle` | `button::Toggle` |
| `DatePicker` | `time::date_picker::{…}` | `date_picker::{…}` |
| `Progress` | `progress::{ProgressBar, …}` | `progress::{Progress, ProgressCircle}` |
| `TitleBar` | `title_bar::TitleBar` | `TitleBar` |
| `Resizable` | `resizable::Resizable` | `resizable::{h_resizable, v_resizable, resizable_panel, ResizableState}` |
| `FocusTrap` | `focus_trap::FocusTrap` | `gpui_base::focus_trap::FocusTrapElement` |
| `Tree` | `tree::{…, TreeDelegate}` | `tree::{Tree, TreeState, TreeItem, TreeEntry}` |
| `Settings` | `settings::Settings` | `setting::Settings` |
| `Chart` | `chart::Chart` | `chart::{AreaChart, BarChart, LineChart, PieChart, RadarChart}` |
| `Image` | `image::Image` | removed |

Notes on the less obvious ones:

- `number_input` and `otp_input` are not modules. Both types are re-exported from `input` (`crates/ui/src/input/mod.rs:40-41`), and `NumberInputState` / `OtpInputState` do not exist anywhere.
- `mod title_bar` and `mod time` are private (`crates/ui/src/lib.rs:15-16`). `TitleBar` reaches the outside only through `pub use title_bar::*`, and `date_picker` through `pub use time::{calendar, date_picker}`.
- There is no `FocusTrap` type. `crates/base/src/focus_trap.rs` defines the `FocusTrapElement` trait and a `FocusTrapContainer`, and `gpui-component` does not re-export either.
- No `Image` component exists in `crates/ui` — the only match anywhere is `text::node::ImageNode`, which is a markdown/HTML internal.

## Dialog example

`references/usage.md` called `window.open_modal` and `window.close_modal`. Neither exists in `crates/` any more; the API is `open_dialog` / `close_dialog` (`crates/ui/src/window_ext.rs:30,59`). It also passed a closure to `.footer(…)`, which takes `impl IntoElement` (`crates/ui/src/dialog/dialog.rs:317`) — the real shape is `DialogFooter` / `DialogClose` / `DialogAction`.

Its copy was `title("Confirm")` / `"Are you sure?"` / `OK`, which is precisely the pattern the Design Guides now bundled in the same skill forbid. An agent read "never write this" in one file and a worked example of it in the next. The example is now an ordinary dialog, and a new `AlertDialog` section carries the confirmation case with guide-conformant copy.

`SKILL.md` also pointed `Dialog` at `window.open_modal(...)`; corrected.

## Verification

Re-ran the audit after the change: no module, type, or method named in `SKILL.md`, `usage.md`, or `style-guide.md` is now missing from `crates/` or from gpui. The vendored guide copies are still byte-identical to `website/docs/` (#2805's CI check stays green), `typos` passes, and the website skills loader resolves all three skills.

## Not fixed here

`crates/story/src/stories/alert_dialog_story.rs:110` uses "Are you sure you want to delete this file? This action cannot be undone." — the same copy pattern the guides forbid, in shipped story code rather than in a skill. Left alone as out of scope; worth a separate pass over the stories.

<sub>Audit and changes were AI-assisted (Claude Code).</sub>
