### PR TITLE
docs: Correct the i18n override docs

### DIFF
--- a/website/docs/i18n.md
+++ b/website/docs/i18n.md
@@ -6,7 +6,7 @@ order: -3
 
 # I18n
 
-GPUI Component includes translations for its components. Applications can add a language or override individual translations without copying the complete built-in locale files.
+GPUI Component includes translations for its components, currently `en`, `zh-CN`, and `zh-HK`. Applications can add a language or override individual translations without copying the complete built-in locale files.
 
 This feature requires `rust-i18n` 4.2 or later.
 
@@ -81,12 +81,34 @@ This deep-merge behavior means that:
 
 For example, defining only `gpui_component.Calendar.month.January.en` changes January's English label while all other English calendar labels still come from GPUI Component.
 
-## Select a locale
+### The namespace applies to component lookups only
 
-Use rust-i18n to change the active locale:
+`extend!` changes how GPUI Component resolves *its* keys. It does not give the application's own `t!` calls access to the built-in translations:
 
 ```rust
-rust_i18n::set_locale("fr");
+// Inside a GPUI Component component: application value first, built-in second.
+t!("Calendar.month.February")             // -> "February"
+
+// In application code: reads the application's locale files only.
+t!("gpui_component.Calendar.month.February")   // -> the key, unless you defined it
 ```
 
-Components will then resolve their translated labels using the selected locale and the priority described above.
+Read component strings by rendering the component, not by looking the key up yourself.
+
+## Select a locale
+
+`gpui-component` re-exports the locale accessors, so an application does not have to reach for `rust-i18n` to switch languages:
+
+```rust
+gpui_component::set_locale("fr");
+let current = gpui_component::locale();
+```
+
+Components then resolve their translated labels using the selected locale and the priority described above.
+
+The active locale is global state that GPUI does not track, so changing it does not schedule a repaint on its own. A view that displays translated text must notify itself:
+
+```rust
+gpui_component::set_locale("fr");
+cx.notify();
+```

--- a/website/zh-CN/docs/i18n.md
+++ b/website/zh-CN/docs/i18n.md
@@ -6,7 +6,7 @@ order: -3
 
 # 国际化
 
-GPUI Component 为组件提供了内置翻译。应用可以新增语言或覆盖个别翻译，而不需要复制完整的内置 locale 文件。
+GPUI Component 为组件提供了内置翻译，目前包含 `en`、`zh-CN`、`zh-HK`。应用可以新增语言或覆盖个别翻译，而不需要复制完整的内置 locale 文件。
 
 此功能需要 `rust-i18n` 4.2 或更高版本。
 
@@ -81,12 +81,34 @@ GPUI Component 内置 locales
 
 例如，只定义 `gpui_component.Calendar.month.January.en` 会修改一月份的英文标签，其他英文日历标签仍然来自 GPUI Component。
 
-## 切换语言
+### 命名空间只对组件内部的查找生效
 
-使用 rust-i18n 修改当前 locale：
+`extend!` 改变的是 GPUI Component 查找**自身** key 的方式，它不会让应用自己的 `t!` 调用能访问到内置翻译：
 
 ```rust
-rust_i18n::set_locale("fr");
+// GPUI Component 组件内部：先查应用，再查内置。
+t!("Calendar.month.February")             // -> "February"
+
+// 应用代码中：只会读取应用自己的 locale 文件。
+t!("gpui_component.Calendar.month.February")   // -> 未定义时返回 key 本身
+```
+
+组件文案应当通过渲染组件来呈现，不要自己去查这些 key。
+
+## 切换语言
+
+`gpui-component` 已经再导出 locale 相关方法，应用无需直接依赖 `rust-i18n` 即可切换语言：
+
+```rust
+gpui_component::set_locale("fr");
+let current = gpui_component::locale();
 ```
 
 组件随后会按照上述优先级，使用当前 locale 查找翻译文本。
+
+当前 locale 属于 GPUI 不感知的全局状态，修改它本身不会触发重绘。展示翻译文本的 view 需要自行通知：
+
+```rust
+gpui_component::set_locale("fr");
+cx.notify();
+```


### PR DESCRIPTION
Three corrections to the I18n page, in both locales.

**`extend!` only redirects lookups made inside GPUI Component.** The page said "keys not supplied by the application continue to use the built-in value", which reads as though the application's own `t!` participates in the merge. It does not:

```rust
// Inside a component: application value first, built-in second.
t!("Calendar.month.February")                  // -> "February"

// In application code: reads the application's locale files only.
t!("gpui_component.Calendar.month.February")   // -> the key, unless you defined it
```

I hit this by writing the second form and getting the raw key back. The page now says so explicitly.

**Changing locale does not repaint.** `set_locale` writes global state GPUI does not track, so a view showing translated text keeps the old string until it is notified. The page now shows the `cx.notify()`.

**Two smaller ones.** The page sent readers to `rust_i18n::set_locale`, but the library re-exports `set_locale` and `locale` (`crates/ui/src/lib.rs:144,149`), so an application does not need a direct `rust-i18n` dependency just to switch languages. And it did not say which locales ship built in — `en`, `zh-CN`, `zh-HK`.

`rust_i18n::extend!` and its namespace semantics were checked against rust-i18n 4.2.0's own source (`src/lib.rs:199-219`) rather than taken from the existing page.

Both `website/docs/i18n.md` and `website/zh-CN/docs/i18n.md` keep the same six sections.

<sub>AI-assisted (Claude Code).</sub>
