### PR TITLE
input: Close the IME undo transaction when text is committed

### DIFF
--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -2746,6 +2746,12 @@ impl<M: InputModeKind> EntityInputHandler for InputBaseState<M> {
                 None,
             );
         }
+        // A commit ends the IME composition: macOS delivers `insertText:` for
+        // the confirmed candidate without a following `unmarkText`, so close
+        // the transaction here. Leaving it open would keep merging every later
+        // edit into the same change, which then carries the text and selection
+        // of the first composition.
+        self.undo_manager.commit_transaction();
         if let Some(diagnostics) = self.mode.diagnostics_mut() {
             diagnostics.reset(&self.text)
         }
@@ -4389,6 +4395,69 @@ mod tests {
                 assert_eq!(state.value(), "a");
                 state.redo(&Redo, window, cx);
                 assert_eq!(state.value(), "a是");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_consecutive_compositions_are_separate_groups(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                // First composition: "jin" -> "今天"
+                state.replace_and_mark_text_in_range(None, "j", None, window, cx);
+                state.replace_and_mark_text_in_range(None, "jin", None, window, cx);
+                state.replace_text_in_range(None, "今天", window, cx);
+                // Second composition: "wo" -> "我们"
+                state.replace_and_mark_text_in_range(None, "w", None, window, cx);
+                state.replace_and_mark_text_in_range(None, "wo", None, window, cx);
+                state.replace_text_in_range(None, "我们", window, cx);
+                assert_eq!(state.value(), "今天我们");
+                assert_eq!(state.selected_range(), 12..12);
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "今天");
+                assert_eq!(state.selected_range(), 6..6);
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
+                assert_eq!(state.selected_range(), 0..0);
+
+                state.redo(&Redo, window, cx);
+                assert_eq!(state.value(), "今天");
+                assert_eq!(state.selected_range(), 6..6);
+
+                state.redo(&Redo, window, cx);
+                assert_eq!(state.value(), "今天我们");
+                assert_eq!(state.selected_range(), 12..12);
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_undo_manager_typing_after_composition_is_a_separate_group(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.replace_and_mark_text_in_range(None, "n", None, window, cx);
+                state.replace_text_in_range(None, "你", window, cx);
+                state.undo_manager.pending_intent = Some(EditIntent::Typing);
+                state.replace_text_in_range(None, "a", window, cx);
+                state.undo_manager.pending_intent = Some(EditIntent::Typing);
+                state.replace_text_in_range(None, "b", window, cx);
+                assert_eq!(state.value(), "你ab");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "你");
+
+                state.undo(&Undo, window, cx);
+                assert_eq!(state.value(), "");
             });
         });
     }


### PR DESCRIPTION
## Summary

Fixes #2761 — on macOS, undo after Chinese Pinyin IME input produced text and caret jumps that did not match any coherent previous edit state.

An IME composition opens an undo transaction in `replace_and_mark_text_in_range`, but nothing closed it when the candidate was confirmed. `replace_text_in_range` cleared `ime_marked_range` without calling `commit_transaction`, and GPUI's macOS layer does not send `unmarkText` after `insertText:replacementRange:`.

The transaction therefore stayed open and every later edit merged into the same pending change. That merge only updates `new_range`, `new_text`, and `selection_after`, so the change kept the `old_text` and `selection_before` of the *first* composition:

- After typing 今天 then 我们, one `Cmd-Z` restored 今天 but moved the caret back to offset 0.
- Plain typing after an IME commit — which also arrives through `insertText:` on macOS — was swallowed into the same group, so each undo emitted only the last character.

Commit the transaction once the replacement is recorded. Merging within a single composition is unchanged, so a composition is still one undo step, and the `Atomic` push sets the coalescing boundary that keeps later typing in its own group. `commit_transaction` is a no-op when no transaction is open, so cut, paste, undo, and redo are unaffected.

No public API change, so no breaking changes.

## Test Plan

Two new tests, both failing before this change:

- `test_undo_manager_consecutive_compositions_are_separate_groups` — two compositions undo and redo separately, asserting both text and caret.
- `test_undo_manager_typing_after_composition_is_a_separate_group` — typing after an IME commit is not merged into the composition's group.

`cargo test -p gpui-base --lib` (557 passed) and `cargo test -p gpui-component --lib` (452 passed) are green, and `cargo clippy -p gpui-base --all-targets` is clean.

Not verified by hand: driving a real Pinyin IME through the Story app is not scriptable, so the on-device walkthrough from the issue still needs a manual pass.

## AI Assistance

Diagnosis, fix, and tests were written with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
