### PR TITLE
input: Keep a masked value out of the clipboard, and settle boolean reader naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,10 +223,11 @@ Text input system based on Rope data structure:
    option set — keeps its fields private, is constructed with a builder, and is read
    through methods. Adding a `pub` field is a breaking change; adding one behind a builder
    is not. Setters and readers must not collide: an all-boolean type names setters after
-   the field and readers `is_`/`has_`/`can_`; a type with non-boolean fields prefixes every
-   setter with `with_` and keeps the field name for readers. Value types whose fields are
-   the definition and cannot grow (`Point`, `Selection`, `Edges`) are exempt. See the
-   "Public Data Types Across the Seam" section of `docs/ARCHITECTURE.md`.
+   the field and readers `is_<adjective>`/`has_<noun>`, never `can_`; a type with
+   non-boolean fields prefixes every setter with `with_` and keeps the field name for
+   readers. Value types whose fields are the definition and cannot grow (`Point`,
+   `Selection`, `Edges`) are exempt. See the "Public Data Types Across the Seam" section
+   of `docs/ARCHITECTURE.md`.
 8. **Spell `Context` out**: Name a context type `ComboboxTriggerContext`, never `…Ctx`.
    `cx` is reserved for GPUI's `App`, `Context<T>`, and `AsyncApp`, so `ctx` for anything
    else reads as a competing context. A callback receiving both takes the GPUI one as `cx`

--- a/crates/base/src/dock/dock_area.rs
+++ b/crates/base/src/dock/dock_area.rs
@@ -3525,14 +3525,14 @@ mod tests {
         let node = child_node(&area, 0, cx);
         let group = cx.read(|cx| area.read(cx).groups.get(&node).unwrap().entity.clone());
         assert!(
-            cx.read(|cx| group.read(cx).can_close(cx)),
+            cx.read(|cx| group.read(cx).is_closable(cx)),
             "an unlocked group's panel can be closed"
         );
 
         cx.update(|window, cx| area.update(cx, |area, cx| area.set_locked(true, window, cx)));
 
         assert!(
-            !cx.read(|cx| group.read(cx).can_close(cx)),
+            !cx.read(|cx| group.read(cx).is_closable(cx)),
             "the lock reaches every group through the constraints push"
         );
     }
@@ -4000,7 +4000,7 @@ mod tests {
 
     #[gpui::test]
     fn closing_a_tile_removes_its_panel(cx: &mut TestAppContext) {
-        // `TileContext::can_close` would otherwise be a control a skin can
+        // `TileContext::is_closable` would otherwise be a control a skin can
         // draw and never wire up.
         let log = log_of();
         let (area, cx) = setup(cx);
@@ -4036,7 +4036,7 @@ mod tests {
         });
         cx.update(|window, cx| {
             let tile = canvas.read(cx).tiles(cx)[0].clone();
-            assert!(tile.can_close());
+            assert!(tile.is_closable());
             tile.close(window, cx);
         });
         cx.run_until_parked();
@@ -4226,7 +4226,7 @@ mod tests {
         drag_bars.borrow_mut().clear();
         cx.update(|window, cx| {
             let tile = canvas.read(cx).tiles(cx)[0].clone();
-            assert!(tile.can_zoom());
+            assert!(tile.is_zoomable());
             tile.toggle_zoom(window, cx);
         });
         cx.run_until_parked();

--- a/crates/base/src/dock/tab_group.rs
+++ b/crates/base/src/dock/tab_group.rs
@@ -128,7 +128,7 @@ impl TabGroupConstraints {
         self.collapsed
     }
 
-    pub fn can_close(&self) -> bool {
+    pub fn is_closable(&self) -> bool {
         self.closable
     }
 }
@@ -220,8 +220,8 @@ impl TabGroup {
     /// Mirrors the old `TabPanel::closable`: the container must permit it, the
     /// group must have somewhere to go, and the displayed panel must itself be
     /// closable.
-    pub fn can_close(&self, cx: &App) -> bool {
-        self.constraints.can_close()
+    pub fn is_closable(&self, cx: &App) -> bool {
+        self.constraints.is_closable()
             && self.draggable(cx)
             && self
                 .active_panel(cx)
@@ -244,7 +244,7 @@ impl TabGroup {
     /// Ask the container to close `panel`. Nothing happens for a panel that is
     /// not in this group, or when either the group or the panel refuses.
     pub fn close_panel(&mut self, panel: PanelId, cx: &mut Context<Self>) {
-        if !self.constraints.can_close() {
+        if !self.constraints.is_closable() {
             return;
         }
         // A dock's last group has nowhere to go and must stay.
@@ -279,7 +279,7 @@ impl TabGroup {
             active_ix: self.active_ix,
             zoomed: self.zoomed,
             collapsed: self.constraints.is_collapsed(),
-            can_close: self.can_close(cx),
+            closable: self.is_closable(cx),
             locked: self.is_locked(),
             draggable: self.draggable(cx),
             droppable: self.droppable(),
@@ -755,7 +755,7 @@ pub struct TabGroupContext {
     locked: bool,
     draggable: bool,
     droppable: bool,
-    can_close: bool,
+    closable: bool,
     drop_indicator: Option<DropIndicator>,
     on_select_tab: SelectTabHandler,
     on_close: ClosePanelHandler,
@@ -801,8 +801,8 @@ impl TabGroupContext {
 
     /// Whether closing the displayed panel is allowed at all, so a skin knows
     /// whether to offer a Close control.
-    pub fn can_close(&self) -> bool {
-        self.can_close
+    pub fn is_closable(&self) -> bool {
+        self.closable
     }
 
     pub fn is_locked(&self) -> bool {
@@ -1481,7 +1481,7 @@ mod tests {
         });
         cx.run_until_parked();
 
-        assert!(!cx.update(|_, cx| group.read(cx).context(cx).can_close()));
+        assert!(!cx.update(|_, cx| group.read(cx).context(cx).is_closable()));
         assert!(events.borrow().is_empty());
     }
 
@@ -1500,14 +1500,14 @@ mod tests {
                 group.set_constraints(TabGroupConstraints::in_split(true), window, cx)
             })
         });
-        let alone = cx.update(|_, cx| group.read(cx).context(cx).can_close());
+        let alone = cx.update(|_, cx| group.read(cx).context(cx).is_closable());
 
         cx.update(|window, cx| {
             group.update(cx, |group, cx| {
                 group.set_constraints(TabGroupConstraints::in_split(false), window, cx)
             })
         });
-        let beside_a_sibling = cx.update(|_, cx| group.read(cx).context(cx).can_close());
+        let beside_a_sibling = cx.update(|_, cx| group.read(cx).context(cx).is_closable());
 
         assert!(!alone);
         assert!(beside_a_sibling);

--- a/crates/base/src/dock/tiles_state.rs
+++ b/crates/base/src/dock/tiles_state.rs
@@ -686,7 +686,7 @@ impl TileContext {
         self.resizing
     }
 
-    pub fn can_close(&self) -> bool {
+    pub fn is_closable(&self) -> bool {
         self.closable
     }
 
@@ -702,7 +702,7 @@ impl TileContext {
     /// Whether this tile's panel allows zooming at all. Where the zoom
     /// control appears is the skin's decision; whether there is one to offer
     /// is not.
-    pub fn can_zoom(&self) -> bool {
+    pub fn is_zoomable(&self) -> bool {
         self.zoomable
     }
 
@@ -746,14 +746,14 @@ impl TileContext {
     /// Flip this tile between filling the whole dock and sitting at its
     /// stored bounds.
     ///
-    /// Zooming *in* is refused when [`Self::can_zoom`] is false, so a skin
+    /// Zooming *in* is refused when [`Self::is_zoomable`] is false, so a skin
     /// that offers a Zoom control should gate it on that. Zooming out is
     /// never refused.
     pub fn toggle_zoom(&self, window: &mut Window, cx: &mut App) {
         (self.on_toggle_zoom)(window, cx);
     }
 
-    /// Dismiss this tile. Refused when [`Self::can_close`] is false, so a
+    /// Dismiss this tile. Refused when [`Self::is_closable`] is false, so a
     /// skin that offers a Close control should gate it on that.
     pub fn close(&self, window: &mut Window, cx: &mut App) {
         (self.on_close)(window, cx);

--- a/crates/base/src/input/base/mod.rs
+++ b/crates/base/src/input/base/mod.rs
@@ -27,6 +27,7 @@ pub struct InputContextMenuCapabilities {
     readonly: bool,
     code_editor: bool,
     selection: bool,
+    masked: bool,
     go_to_definition: bool,
     code_actions: bool,
 }
@@ -54,6 +55,12 @@ impl InputContextMenuCapabilities {
     /// Set whether the input has a non-empty selection.
     pub fn selection(mut self, selection: bool) -> Self {
         self.selection = selection;
+        self
+    }
+
+    /// Set whether the input renders its value masked.
+    pub fn masked(mut self, masked: bool) -> Self {
+        self.masked = masked;
         self
     }
 
@@ -89,6 +96,18 @@ impl InputContextMenuCapabilities {
 
     pub fn has_selection(&self) -> bool {
         self.selection
+    }
+
+    pub fn is_masked(&self) -> bool {
+        self.masked
+    }
+
+    /// Returns true if the selection may leave the input as plain text.
+    ///
+    /// A masked input keeps its value out of the clipboard, so both Copy and
+    /// Cut are unavailable while the value is hidden.
+    pub fn can_copy(&self) -> bool {
+        self.selection && !self.masked
     }
 
     pub fn can_go_to_definition(&self) -> bool {

--- a/crates/base/src/input/base/mod.rs
+++ b/crates/base/src/input/base/mod.rs
@@ -102,15 +102,15 @@ impl InputContextMenuCapabilities {
         self.masked
     }
 
-    /// Returns true if the selection may leave the input as plain text.
+    /// Returns true if the user is allowed to copy the text out.
     ///
-    /// A masked input keeps its value out of the clipboard, so both Copy and
-    /// Cut are unavailable while the value is hidden.
-    pub fn can_copy(&self) -> bool {
+    /// A masked input keeps its value out of the clipboard, so Copy and Cut
+    /// are both unavailable while the value is hidden.
+    pub fn is_copyable(&self) -> bool {
         self.selection && !self.masked
     }
 
-    pub fn can_go_to_definition(&self) -> bool {
+    pub fn has_definition(&self) -> bool {
         self.go_to_definition
     }
 

--- a/crates/base/src/input/base/selection.rs
+++ b/crates/base/src/input/base/selection.rs
@@ -14,9 +14,8 @@ impl<M: InputModeKind> InputBaseState<M> {
     /// The offset is the UTF-8 offset.
     pub(super) fn select_word(&mut self, offset: usize, _: &mut Window, cx: &mut Context<Self>) {
         // A masked value renders as one unbroken run of mask characters, so it
-        // has no word boundaries to select by. Take all of it instead, the way
-        // `<input type="password">` does, rather than let the selection
-        // highlight reveal where the words are.
+        // has no word boundaries to select by. Take all of it instead, rather
+        // than let the selection highlight reveal where the words are.
         let range = if self.masked {
             0..self.text.len()
         } else {

--- a/crates/base/src/input/base/selection.rs
+++ b/crates/base/src/input/base/selection.rs
@@ -13,8 +13,17 @@ impl<M: InputModeKind> InputBaseState<M> {
     ///
     /// The offset is the UTF-8 offset.
     pub(super) fn select_word(&mut self, offset: usize, _: &mut Window, cx: &mut Context<Self>) {
-        let Some(range) = TextSelector::word_range(&self.text, offset) else {
-            return;
+        // A masked value renders as one unbroken run of mask characters, so it
+        // has no word boundaries to select by. Take all of it instead, the way
+        // `<input type="password">` does, rather than let the selection
+        // highlight reveal where the words are.
+        let range = if self.masked {
+            0..self.text.len()
+        } else {
+            let Some(range) = TextSelector::word_range(&self.text, offset) else {
+                return;
+            };
+            range
         };
 
         self.undo_manager.break_transaction_coalescing();

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -520,8 +520,7 @@ impl<M: InputModeKind> InputBaseState<M> {
 
     /// Whether the user is allowed to copy the selection out.
     ///
-    /// A masked input keeps its value out of the clipboard, the way
-    /// `NSSecureTextField` and `PasswordBox` do.
+    /// A masked input keeps its value out of the clipboard.
     pub fn is_copyable(&self) -> bool {
         !self.selected_range.is_empty() && !self.masked
     }
@@ -3941,7 +3940,7 @@ mod tests {
                     Some("sentinel".to_string())
                 );
 
-                // Cut neither copies nor deletes, matching Chrome and PasswordBox.
+                // Cut neither copies nor deletes.
                 state.cut(&Cut, window, cx);
                 assert_eq!(state.value(), "hunter2");
                 assert_eq!(

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -518,6 +518,15 @@ impl<M: InputModeKind> InputBaseState<M> {
         M::CODE_EDITOR
     }
 
+    /// Whether the selection may leave the input as plain text.
+    ///
+    /// A masked input keeps its value out of the clipboard, the way
+    /// `NSSecureTextField`, `PasswordBox`, `QLineEdit` and
+    /// `<input type="password">` all do.
+    pub fn can_copy(&self) -> bool {
+        !self.selected_range.is_empty() && !self.masked
+    }
+
     pub fn context_menu_capabilities(&self) -> InputContextMenuCapabilities {
         let (go_to_definition, code_actions) = self.extras.context_menu_capabilities();
         InputContextMenuCapabilities::new()
@@ -525,6 +534,7 @@ impl<M: InputModeKind> InputBaseState<M> {
             .readonly(self.readonly)
             .code_editor(self.is_code_editor())
             .selection(!self.selected_range.is_empty())
+            .masked(self.masked)
             .go_to_definition(go_to_definition)
             .code_actions(code_actions)
     }
@@ -1280,6 +1290,13 @@ impl<M: InputModeKind> InputBaseState<M> {
 
     /// Return the start offset of the previous word.
     pub(super) fn previous_start_of_word(&mut self) -> usize {
+        if self.masked {
+            // The mask replaces every character, so the displayed text has no
+            // word boundaries to move or delete by. Collapse the word to the
+            // whole text, matching `<input type="password">` and `QLineEdit`.
+            return 0;
+        }
+
         let offset = self.selected_range.start;
         let offset = self.offset_from_utf16(self.offset_to_utf16(offset));
         // FIXME: Avoid to_string
@@ -1293,6 +1310,11 @@ impl<M: InputModeKind> InputBaseState<M> {
 
     /// Return the next end offset of the next word.
     pub(super) fn next_end_of_word(&mut self) -> usize {
+        if self.masked {
+            // See `previous_start_of_word`.
+            return self.text.len();
+        }
+
         let offset = self.cursor();
         let offset = self.offset_from_utf16(self.offset_to_utf16(offset));
         let right_part = self.text.slice(offset..self.text.len()).to_string();
@@ -1910,7 +1932,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     }
 
     pub(super) fn copy(&mut self, _: &Copy, _: &mut Window, cx: &mut Context<Self>) {
-        if self.selected_range.is_empty() {
+        if !self.can_copy() {
             return;
         }
 
@@ -1919,7 +1941,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     }
 
     pub(super) fn cut(&mut self, _: &Cut, window: &mut Window, cx: &mut Context<Self>) {
-        if self.selected_range.is_empty() {
+        if !self.can_copy() {
             return;
         }
 
@@ -3897,6 +3919,105 @@ mod tests {
                 );
                 state.undo(&Undo, window, cx);
                 assert_eq!(state.value(), "first line with punctuation!\n");
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_masked_input_keeps_its_value_out_of_the_clipboard(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("hunter2", window, cx);
+                state.set_masked(true, window, cx);
+                state.select_all(window, cx);
+                cx.write_to_clipboard(ClipboardItem::new_string("sentinel".into()));
+
+                state.copy(&Copy, window, cx);
+                assert_eq!(
+                    cx.read_from_clipboard().and_then(|item| item.text()),
+                    Some("sentinel".to_string())
+                );
+
+                // Cut neither copies nor deletes, matching Chrome and PasswordBox.
+                state.cut(&Cut, window, cx);
+                assert_eq!(state.value(), "hunter2");
+                assert_eq!(
+                    cx.read_from_clipboard().and_then(|item| item.text()),
+                    Some("sentinel".to_string())
+                );
+
+                // Revealing the value restores both.
+                state.set_masked(false, window, cx);
+                state.copy(&Copy, window, cx);
+                assert_eq!(
+                    cx.read_from_clipboard().and_then(|item| item.text()),
+                    Some("hunter2".to_string())
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_masked_input_collapses_word_boundaries(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("aaa bbb ccc", window, cx);
+                state.set_masked(true, window, cx);
+                state.set_selected_range(7..7, cx);
+
+                // The mask hides word boundaries, so a word delete takes
+                // everything before the caret and leaves the rest.
+                state.delete_previous_word(&DeleteToPreviousWordStart, window, cx);
+                assert_eq!(state.value(), " ccc");
+                assert_eq!(state.selected_range(), 0..0);
+
+                state.delete_next_word(&DeleteToNextWordEnd, window, cx);
+                assert_eq!(state.value(), "");
+
+                // A double click takes the whole value, not one word.
+                state.set_value("aaa bbb ccc", window, cx);
+                state.select_word(9, window, cx);
+                assert_eq!(state.selected_range(), 0..11);
+
+                // Unmasked, the same delete only takes one word.
+                state.set_masked(false, window, cx);
+                state.set_value("aaa bbb ccc", window, cx);
+                state.set_selected_range(11..11, cx);
+                state.delete_previous_word(&DeleteToPreviousWordStart, window, cx);
+                assert_eq!(state.value(), "aaa bbb ");
+
+                state.set_value("aaa bbb ccc", window, cx);
+                state.select_word(9, window, cx);
+                assert_eq!(state.selected_range(), 8..11);
+            });
+        });
+    }
+
+    #[gpui::test]
+    fn test_masked_input_disables_the_copy_context_menu_items(cx: &mut TestAppContext) {
+        let input_view = InputView::build(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value("hunter2", window, cx);
+                state.select_all(window, cx);
+                assert!(state.context_menu_capabilities().can_copy());
+
+                state.set_masked(true, window, cx);
+                let capabilities = state.context_menu_capabilities();
+                assert!(capabilities.is_masked());
+                assert!(capabilities.has_selection());
+                assert!(!capabilities.can_copy());
             });
         });
     }

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -518,12 +518,11 @@ impl<M: InputModeKind> InputBaseState<M> {
         M::CODE_EDITOR
     }
 
-    /// Whether the selection may leave the input as plain text.
+    /// Whether the user is allowed to copy the selection out.
     ///
     /// A masked input keeps its value out of the clipboard, the way
-    /// `NSSecureTextField`, `PasswordBox`, `QLineEdit` and
-    /// `<input type="password">` all do.
-    pub fn can_copy(&self) -> bool {
+    /// `NSSecureTextField` and `PasswordBox` do.
+    pub fn is_copyable(&self) -> bool {
         !self.selected_range.is_empty() && !self.masked
     }
 
@@ -1293,7 +1292,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         if self.masked {
             // The mask replaces every character, so the displayed text has no
             // word boundaries to move or delete by. Collapse the word to the
-            // whole text, matching `<input type="password">` and `QLineEdit`.
+            // whole text.
             return 0;
         }
 
@@ -1932,7 +1931,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     }
 
     pub(super) fn copy(&mut self, _: &Copy, _: &mut Window, cx: &mut Context<Self>) {
-        if !self.can_copy() {
+        if !self.is_copyable() {
             return;
         }
 
@@ -1941,7 +1940,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     }
 
     pub(super) fn cut(&mut self, _: &Cut, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.can_copy() {
+        if !self.is_copyable() {
             return;
         }
 
@@ -4011,13 +4010,13 @@ mod tests {
             input.update(cx, |state, cx| {
                 state.set_value("hunter2", window, cx);
                 state.select_all(window, cx);
-                assert!(state.context_menu_capabilities().can_copy());
+                assert!(state.context_menu_capabilities().is_copyable());
 
                 state.set_masked(true, window, cx);
                 let capabilities = state.context_menu_capabilities();
                 assert!(capabilities.is_masked());
                 assert!(capabilities.has_selection());
-                assert!(!capabilities.can_copy());
+                assert!(!capabilities.is_copyable());
             });
         });
     }

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -283,7 +283,7 @@ impl TabGroupSkin {
         let control = zoom_control(group, cx);
         let toolbar_zoom = control.is_some_and(|control| control.toolbar_visible());
         let menu_zoom = control.is_some_and(|control| control.menu_visible());
-        let closable = group.can_close();
+        let closable = group.is_closable();
         let buttons = handle.and_then(|handle| handle.toolbar_buttons(window, cx));
         let panel = handle.map(|handle| handle.panel());
 

--- a/crates/ui/src/dock/tiles.rs
+++ b/crates/ui/src/dock/tiles.rs
@@ -117,9 +117,9 @@ impl TilesSkin {
         let control = handle.and_then(|handle| handle.zoom_control(cx));
         let zoomed = tile.is_zoomed();
         let toolbar_zoom =
-            tile.can_zoom() && control.is_some_and(|control| control.toolbar_visible());
-        let menu_zoom = tile.can_zoom() && control.is_some_and(|control| control.menu_visible());
-        let closable = tile.can_close();
+            tile.is_zoomable() && control.is_some_and(|control| control.toolbar_visible());
+        let menu_zoom = tile.is_zoomable() && control.is_some_and(|control| control.menu_visible());
+        let closable = tile.is_closable();
         let buttons = handle.and_then(|handle| handle.toolbar_buttons(window, cx));
         let panel = handle.map(|handle| handle.panel());
 

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -439,7 +439,7 @@ impl RenderOnce for Input {
                         menu = menu
                             .menu_with_disabled(
                                 t!("Input.Go to Definition"),
-                                !(enabled && capabilities.can_go_to_definition()),
+                                !(enabled && capabilities.has_definition()),
                                 Box::new(gpui_base::input::GoToDefinition),
                             )
                             .menu_with_disabled(
@@ -451,12 +451,12 @@ impl RenderOnce for Input {
                     }
                     menu.menu_with_disabled(
                         t!("Input.Cut"),
-                        !(editable && capabilities.can_copy()),
+                        !(editable && capabilities.is_copyable()),
                         Box::new(gpui_base::input::Cut),
                     )
                     .menu_with_disabled(
                         t!("Input.Copy"),
-                        !capabilities.can_copy(),
+                        !capabilities.is_copyable(),
                         Box::new(gpui_base::input::Copy),
                     )
                     .menu_with_disabled(

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -451,12 +451,12 @@ impl RenderOnce for Input {
                     }
                     menu.menu_with_disabled(
                         t!("Input.Cut"),
-                        !(editable && capabilities.has_selection()),
+                        !(editable && capabilities.can_copy()),
                         Box::new(gpui_base::input::Cut),
                     )
                     .menu_with_disabled(
                         t!("Input.Copy"),
-                        !capabilities.has_selection(),
+                        !capabilities.can_copy(),
                         Box::new(gpui_base::input::Copy),
                     )
                     .menu_with_disabled(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -209,8 +209,8 @@ The shape to use instead:
 Setters and readers must not collide, which decides the naming:
 
 - a type whose fields are all boolean names its setters after the field and its
-  readers `is_`/`has_`/`can_`, matching how elements read — `CalendarItemState`,
-  `InputContextMenuCapabilities`;
+  readers `is_<adjective>`/`has_<noun>`, never `can_`, matching how elements
+  read — `CalendarItemState`, `InputContextMenuCapabilities`;
 - a type carrying non-boolean fields prefixes every setter with `with_`, so the
   readers keep the plain field name — `RenderOptions::with_item_ix` against
   `RenderOptions::item_ix`. This follows `Sizable::with_size`.

--- a/skills/gpui-component/references/coding-guides.md
+++ b/skills/gpui-component/references/coding-guides.md
@@ -580,8 +580,7 @@ For reusable components:
   modifiers or pointer details are meaningful;
 - evolvable behavioral seams use private fields, builders for construction,
   and readers for inspection;
-- boolean readers use `is_`, `has_`, or `can_` where a same-named builder
-  exists;
+- boolean readers use `is_` or `has_` where a same-named builder exists;
 - non-boolean setters use `with_` when readers need the plain field name;
 - explicit compound parts are preferable to inspecting arbitrary descendants;
 - adding reusable behavior must not force a product-level visual choice.
@@ -648,7 +647,7 @@ make ordinary prose sound technical.
 | Fluent property | noun/adjective | `label`, `disabled`, `selected`, `placement` |
 | General non-boolean replacement builder | `with_<field>` | `with_size`, `with_mode` |
 | In-place mutation | `set_<field>` | `set_items`, `set_selected_index` |
-| Boolean reader | `is_` / `has_` / `can_` | `is_open`, `has_selection` |
+| Boolean reader | `is_<adjective>` / `has_<noun>` | `is_open`, `is_closable`, `has_selection` |
 | Plain value reader | field noun | `placement`, `selected_value` |
 | Callback registration | `on_<event or intent>` | `on_click`, `on_open_change` |
 | Rendering a named region | `render_<region>` | `render_toolbar`, `render_content` |
@@ -657,6 +656,13 @@ For new APIs, fluent builders omit `set_` because they consume and return
 `Self`; mutation through `&mut self` uses `set_`. Preserve established public
 names when changing them would cause needless churn. Existing builder names
 such as `set_position` are compatibility exceptions, not patterns for new APIs.
+
+A boolean reader is either `has_<noun>`, when the value holds something, or
+`is_<adjective>`, when it describes a state or a permission. Reach for the
+adjective whenever the action has one: `is_closable` over `can_close`,
+`is_zoomable` over `can_zoom`, `is_copyable` over `can_copy`. When the action
+is a verb phrase with no adjective form, name the thing it needs instead:
+`has_definition`, not `can_go_to_definition`. Do not add new `can_` readers.
 
 Boolean builders may use the field name (`disabled(bool)`) while their readers
 use `is_disabled()`. For a public seam struct containing non-boolean fields,

--- a/website/docs/coding-guides.md
+++ b/website/docs/coding-guides.md
@@ -580,8 +580,7 @@ For reusable components:
   modifiers or pointer details are meaningful;
 - evolvable behavioral seams use private fields, builders for construction,
   and readers for inspection;
-- boolean readers use `is_`, `has_`, or `can_` where a same-named builder
-  exists;
+- boolean readers use `is_` or `has_` where a same-named builder exists;
 - non-boolean setters use `with_` when readers need the plain field name;
 - explicit compound parts are preferable to inspecting arbitrary descendants;
 - adding reusable behavior must not force a product-level visual choice.
@@ -648,7 +647,7 @@ make ordinary prose sound technical.
 | Fluent property | noun/adjective | `label`, `disabled`, `selected`, `placement` |
 | General non-boolean replacement builder | `with_<field>` | `with_size`, `with_mode` |
 | In-place mutation | `set_<field>` | `set_items`, `set_selected_index` |
-| Boolean reader | `is_` / `has_` / `can_` | `is_open`, `has_selection` |
+| Boolean reader | `is_<adjective>` / `has_<noun>` | `is_open`, `is_closable`, `has_selection` |
 | Plain value reader | field noun | `placement`, `selected_value` |
 | Callback registration | `on_<event or intent>` | `on_click`, `on_open_change` |
 | Rendering a named region | `render_<region>` | `render_toolbar`, `render_content` |
@@ -657,6 +656,13 @@ For new APIs, fluent builders omit `set_` because they consume and return
 `Self`; mutation through `&mut self` uses `set_`. Preserve established public
 names when changing them would cause needless churn. Existing builder names
 such as `set_position` are compatibility exceptions, not patterns for new APIs.
+
+A boolean reader is either `has_<noun>`, when the value holds something, or
+`is_<adjective>`, when it describes a state or a permission. Reach for the
+adjective whenever the action has one: `is_closable` over `can_close`,
+`is_zoomable` over `can_zoom`, `is_copyable` over `can_copy`. When the action
+is a verb phrase with no adjective form, name the thing it needs instead:
+`has_definition`, not `can_go_to_definition`. Do not add new `can_` readers.
 
 Boolean builders may use the field name (`disabled(bool)`) while their readers
 use `is_disabled()`. For a public seam struct containing non-boolean fields,

--- a/website/docs/components/input.md
+++ b/website/docs/components/input.md
@@ -95,9 +95,8 @@ Input::new(&input)
 While the value is masked, the input keeps it out of the clipboard and out of
 the selection: Copy and Cut do nothing (and are disabled in the context menu),
 a word-wise delete takes everything before the caret, and a double click
-selects the whole value instead of one word. This matches `NSSecureTextField`,
-`PasswordBox`, `QLineEdit` and `<input type="password">`. Paste and Select All
-keep working, and revealing the value with `mask_toggle` restores all of them.
+selects the whole value instead of one word. Paste and Select All keep working,
+and revealing the value with `mask_toggle` restores all of them.
 
 ### Input Sizes
 

--- a/website/docs/components/input.md
+++ b/website/docs/components/input.md
@@ -92,6 +92,13 @@ Input::new(&input)
     .mask_toggle() // Shows toggle button to reveal password
 ```
 
+While the value is masked, the input keeps it out of the clipboard and out of
+the selection: Copy and Cut do nothing (and are disabled in the context menu),
+a word-wise delete takes everything before the caret, and a double click
+selects the whole value instead of one word. This matches `NSSecureTextField`,
+`PasswordBox`, `QLineEdit` and `<input type="password">`. Paste and Select All
+keep working, and revealing the value with `mask_toggle` restores all of them.
+
 ### Input Sizes
 
 ```rust

--- a/website/zh-CN/docs/coding-guides.md
+++ b/website/zh-CN/docs/coding-guides.md
@@ -364,7 +364,7 @@ Reusable component 应遵守：
 - builder 消费并返回 `Self`，使用 domain 词汇；
 - callback 描述 requested change；只有 pointer modifier/detail 有意义时才带 pointer event；
 - 需要持续演进的行为接口使用私有字段、构造方法与读取方法；
-- boolean reader 在同名 builder 存在时使用 `is_` / `has_` / `can_`；
+- boolean reader 在同名 builder 存在时使用 `is_` / `has_`；
 - reader 需要 plain field name 时，non-boolean setter 使用 `with_`；
 - explicit compound part 优于检查 arbitrary descendant；
 - reusable behavior 不能强制 product-level visual choice。
@@ -405,12 +405,14 @@ Platform branch 即使 presentation 不同，也必须保留 semantic contract�
 | Fluent property | 名词或形容词 | `label`, `disabled`, `selected`, `placement` |
 | 通用 non-boolean builder | `with_<field>` | `with_size`, `with_mode` |
 | In-place mutation | `set_<field>` | `set_items`, `set_selected_index` |
-| Boolean reader | `is_` / `has_` / `can_` | `is_open`, `has_selection` |
+| Boolean reader | `is_<形容词>` / `has_<名词>` | `is_open`, `is_closable`, `has_selection` |
 | Plain value reader | field noun | `placement`, `selected_value` |
 | Callback registration | `on_<event/intent>` | `on_click`, `on_open_change` |
 | Named region renderer | `render_<region>` | `render_toolbar`, `render_content` |
 
 新 API 中，消费并返回 `Self` 的链式构造方法不加 `set_`；通过 `&mut self` 修改状态时使用`set_`。已经公开的名称应保持兼容，现有的 `set_position` 等链式方法属于兼容例外，不作为新 API 的命名范例。
+
+Boolean reader 只有两种：值持有某物时用 `has_<名词>`，描述状态或许可时用 `is_<形容词>`。只要动作有对应的形容词形式就用形容词：`is_closable` 而非 `can_close`，`is_zoomable` 而非 `can_zoom`，`is_copyable` 而非 `can_copy`。动作是没有形容词形式的动词短语时，改为命名它所需要的东西：用 `has_definition`，不用 `can_go_to_definition`。不再新增 `can_` reader。
 
 Boolean builder 可叫 `disabled(bool)`，reader 叫 `is_disabled()`。含 non-boolean field 的公开接口中的非布尔字段使用 `with_item_ix(...)` 构造、`item_ix()` 读取，避免冲突。新的局部或内部零起始索引优先使用 `_ix`，现有公开名称如 `selected_index` 保持不变，不再引入 `_idx`。调用方从不构造的快照，不要为了对称而发布构造方法。
 

--- a/website/zh-CN/docs/components/input.md
+++ b/website/zh-CN/docs/components/input.md
@@ -87,6 +87,12 @@ Input::new(&input)
     .mask_toggle()
 ```
 
+掩码状态下，输入框不会让明文进入剪贴板，也不会通过选区暴露内容：Copy 和 Cut
+不执行任何操作（上下文菜单中同样置灰），按词删除会删掉光标之前的全部内容，双击
+则选中整个值而不是其中一个词。这与 `NSSecureTextField`、`PasswordBox`、
+`QLineEdit` 和 `<input type="password">` 的行为一致。Paste 和 Select All 不受
+影响，通过 `mask_toggle` 显示明文后，上述操作全部恢复。
+
 ### 尺寸
 
 ```rust

--- a/website/zh-CN/docs/components/input.md
+++ b/website/zh-CN/docs/components/input.md
@@ -89,9 +89,8 @@ Input::new(&input)
 
 掩码状态下，输入框不会让明文进入剪贴板，也不会通过选区暴露内容：Copy 和 Cut
 不执行任何操作（上下文菜单中同样置灰），按词删除会删掉光标之前的全部内容，双击
-则选中整个值而不是其中一个词。这与 `NSSecureTextField`、`PasswordBox`、
-`QLineEdit` 和 `<input type="password">` 的行为一致。Paste 和 Select All 不受
-影响，通过 `mask_toggle` 显示明文后，上述操作全部恢复。
+则选中整个值而不是其中一个词。Paste 和 Select All 不受影响，通过 `mask_toggle`
+显示明文后，上述操作全部恢复。
 
 ### 尺寸
 


### PR DESCRIPTION
## Summary

Refs #2669. Two parts: the masked-input fix, and the naming rule its new reader forced a decision on.

### 1. A masked `Input` leaked its plain text

`copy` and `cut` read `self.text` without looking at `masked`, so a password went to the system clipboard verbatim. Word-wise movement, word-wise delete, and double-click word selection each ran their boundary search over the real text too — so the number of mask characters that disappeared on a word delete, and the width of the highlight after a double click, told an onlooker where the word boundaries in the password were.

This treats `masked` as the single switch for all of it, rather than adding a per-action flag like the `.disable_copy(bool)` the issue proposed. A second switch would allow "masked but copyable", which no other implementation offers, and `mask_toggle` already gives the user a way to reveal the value when they do want to copy it.

- **Copy / Cut** return early while masked, and the context menu reads the same answer through a new `InputContextMenuCapabilities::is_copyable`, so a menu item is never enabled for an action that would silently do nothing. Cut does not delete either — matching Chrome and `PasswordBox` rather than Qt, whose `cut()` deletes without copying as a side effect of its implementation.
- **Word boundaries** collapse to the whole value, which is what the mask actually renders — one unbroken run of mask characters. A word delete takes everything before the caret; a double click takes all of it.
- **Paste and Select All** are untouched, and clearing the mask restores everything.

`masked` is only exposed on the single-line `impl InputBaseState<InputMode>`, so `select_line` and Home/End already span the whole value and needed no change.

#### Prior art

Every implementation I checked refuses to let the plain text out:

| | Copy while masked |
|---|---|
| `NSSecureTextField` | disabled in the class itself, not configurable |
| WPF / WinUI `PasswordBox` | by design, only Paste is supported |
| Qt `QLineEdit` | `copy()` documented to act only when `echoMode` is `Normal` |
| GTK4 `GtkText` | copies the invisible char, not the text |
| Chrome `<input type="password">` | blocked |

The browser row I verified directly, back-to-back on one page, since [w3c/clipboard-apis#5](https://github.com/w3c/clipboard-apis/issues/5) was never resolved:

```
plain    input: queryCommandEnabled('copy')=true,  copy event fires,       clipboard <- "PLAINTEXT_CONTROL"
password input: queryCommandEnabled('copy')=false, copy event never fires, clipboard unchanged
```

`cut` is likewise disabled and `selectAll` stays enabled. The word-collapse behaviour is Chrome's too — with the caret at offset 7 of `aaa bbb ccc`, a word delete leaves `" ccc"` in the password field but only removes `ccc` in the plain field, and a double click selects `0..11` rather than one word.

Qt reaches the same place by a different route: only `MoveToPreviousWord` checks `echoMode` (falling back to `home()`), but `cursorWordBackward` runs on `m_textLayout`, and `updateDisplayText` fills that layout with `m_passwordCharacter` — a run of mask characters has no word boundaries to skip to.

### 2. Boolean reader naming

The new reader sat next to `can_go_to_definition`, `can_zoom` and `can_close`, so the same question was being asked two different ways. The `can_` readers were the smaller group by a wide margin — 6 against 122 `is_` and 14 `has_` — and three of them read a field already spelled as an adjective (`closable`, `zoomable`), so the reader had drifted from the field, not the other way round.

The rule, now written into the Coding Guides, `CLAUDE.md` and `docs/ARCHITECTURE.md`:

> A boolean reader is either `has_<noun>`, when the value holds something, or `is_<adjective>`, when it describes a state or a permission. Reach for the adjective whenever the action has one. When the action is a verb phrase with no adjective form, name the thing it needs instead. Do not add new `can_` readers.

`can_go_to_definition` was reporting `lsp.definition_provider.is_some()` — exactly parallel to the `has_code_actions` beside it, which reports `!lsp.code_action_providers.is_empty()` — so it becomes `has_definition`.

## Test Plan

Three new tests in `crates/base/src/input/base/state.rs`:

- `test_masked_input_keeps_its_value_out_of_the_clipboard` — Copy leaves a clipboard sentinel intact, Cut neither copies nor deletes, and unmasking restores both.
- `test_masked_input_collapses_word_boundaries` — word delete and double click take the whole value while masked, and the same calls take one word once unmasked.
- `test_masked_input_disables_the_copy_context_menu_items` — `is_copyable()` is false while masked even with a selection.

`cargo test -p gpui-base --lib` (560 passed), `cargo test -p gpui-component --lib` (452 passed), `cargo test -p gpui-base --doc` (13 passed), `cargo check --workspace --all-targets`, `cargo clippy -p gpui-base -p gpui-component --all-targets`, and `typos` are all clean.

To check by hand: the Story gallery's Input page already has a masked example with `mask_toggle` (`crates/story/src/stories/input_story.rs`).

## Breaking Changes

Three boolean readers are renamed. `InputContextMenuCapabilities` also gains a field, but it is built through its builder and read through methods, so that part is not breaking.

```diff
- if capabilities.can_go_to_definition() { .. }
+ if capabilities.has_definition() { .. }

- if tile.can_zoom() { .. }
+ if tile.is_zoomable() { .. }

- if tile.can_close() { .. }
+ if tile.is_closable() { .. }

- if group.can_close(cx) { .. }
+ if group.is_closable(cx) { .. }
```

Affected types: `InputContextMenuCapabilities`, `TileState`, `TabGroupContext`, `TabGroupConstraints`, and `TabGroup`. `TabGroupContext`'s `can_close` field is renamed to `closable`, matching the spelling the other containers already use; it is private, so only the reader is visible to callers.

## AI Assistance

Prior-art research, browser verification, implementation, rename, and tests were done with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
