### PR TITLE
motion: Add spring transitions and use them where a target changes mid-flight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1206,7 +1206,7 @@ dependencies = [
 [[package]]
 name = "collections"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "gpui_util",
  "indexmap",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "derive_refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2903,7 +2903,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.58.0",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2929,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "accesskit",
  "anyhow",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "gpui_apple"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "anyhow",
  "block",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "gpui_linux"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "accesskit",
  "accesskit_unix",
@@ -3315,7 +3315,7 @@ dependencies = [
 [[package]]
 name = "gpui_macos"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -3361,7 +3361,7 @@ dependencies = [
 [[package]]
 name = "gpui_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3372,7 +3372,7 @@ dependencies = [
 [[package]]
 name = "gpui_platform"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "console_error_panic_hook",
  "gpui",
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "gpui_shared_string"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "schemars",
  "serde",
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "gpui_util"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "anyhow",
  "log",
@@ -3405,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "gpui_web"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "gpui_wgpu"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3458,7 +3458,7 @@ dependencies = [
 [[package]]
 name = "gpui_windows"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "accesskit",
  "accesskit_windows",
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "http_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -3802,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "http_client_tls"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "rustls",
  "rustls-platform-verifier",
@@ -3883,7 +3883,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4847,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -5853,7 +5853,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "perf"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "collections",
  "serde",
@@ -6829,7 +6829,7 @@ dependencies = [
 [[package]]
 name = "refineable"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "derive_refineable",
 ]
@@ -6881,7 +6881,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 [[package]]
 name = "reqwest_client"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "scheduler"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "async-task",
  "backtrace",
@@ -7939,7 +7939,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sum_tree"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "heapless",
  "log",
@@ -9449,7 +9449,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 [[package]]
 name = "util_macros"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "perf",
  "quote",
@@ -11458,7 +11458,7 @@ dependencies = [
 [[package]]
 name = "zlog"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11475,7 +11475,7 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 [[package]]
 name = "ztracing"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 dependencies = [
  "tracing",
  "tracing-subscriber",
@@ -11486,7 +11486,7 @@ dependencies = [
 [[package]]
 name = "ztracing_macro"
 version = "0.1.0"
-source = "git+https://github.com/zed-industries/zed#e0931d5a9dbf4f781b336fdf448739e74a2ac0b5"
+source = "git+https://github.com/zed-industries/zed#8b1497dbd22fb06f5838a7c0b84a1e54fafa71bc"
 
 [[package]]
 name = "zune-core"

--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -111,7 +111,7 @@ pub use macos_accessibility::install_window_hit_test_forwarder;
 #[doc(hidden)]
 pub use measure::measurement_enabled;
 pub use measure::{Measure, measure, measure_if};
-pub use motion::{Interpolate, Transition, TransitionId, transition};
+pub use motion::{Interpolate, Spring, Transition, TransitionId, spring, transition};
 pub use number_input::{
     Decrement, Increment, NumberInput, NumberInputEvent, NumberInputText, NumberStep, StepAction,
     step_value,

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -204,6 +204,7 @@ where
 pub struct Spring {
     config: SpringConfig,
     epsilon: f32,
+    travel: bool,
 }
 
 impl Spring {
@@ -234,7 +235,20 @@ impl Spring {
         Self {
             config,
             epsilon: DEFAULT_SPRING_EPSILON,
+            travel: true,
         }
+    }
+
+    /// Sets whether the spring travels to its target or adopts it on the spot.
+    ///
+    /// A value the pointer is already moving — a panel being dragged by its
+    /// resize handle — must not lag behind the pointer, so the spring stops
+    /// travelling for as long as the drag lasts. Retained state stays pinned to
+    /// the target meanwhile, so travel resumes from the value the drag released
+    /// rather than from wherever the spring was when it began.
+    pub const fn with_travel(mut self, travel: bool) -> Self {
+        self.travel = travel;
+        self
     }
 
     /// Sets the settling tolerance, expressed in the target's own units.
@@ -256,6 +270,11 @@ impl Spring {
     /// Returns the settling tolerance.
     pub fn epsilon(&self) -> f32 {
         self.epsilon
+    }
+
+    /// Returns whether the spring travels to its target.
+    pub fn travel(&self) -> bool {
+        self.travel
     }
 }
 
@@ -307,7 +326,7 @@ where
         state.updated_at = now;
     };
 
-    if cx.reduce_motion() {
+    if cx.reduce_motion() || !policy.travel {
         if snapshot.state.position != target_position || snapshot.state.velocity != 0.0 {
             state.update(cx, |state, _| settle(state));
         }
@@ -550,6 +569,7 @@ mod tests {
     struct SpringView {
         target: Rc<Cell<f32>>,
         policy: Spring,
+        travel: Rc<Cell<bool>>,
         samples: Rc<RefCell<Vec<f32>>>,
     }
 
@@ -562,7 +582,7 @@ mod tests {
             self.samples.borrow_mut().push(spring(
                 ("spring-test", "value"),
                 self.target.get(),
-                self.policy,
+                self.policy.with_travel(self.travel.get()),
                 window,
                 cx,
             ));
@@ -573,19 +593,23 @@ mod tests {
     struct SpringFixture {
         window: WindowHandle<SpringView>,
         target: Rc<Cell<f32>>,
+        travel: Rc<Cell<bool>>,
         samples: Rc<RefCell<Vec<f32>>>,
     }
 
     impl SpringFixture {
         fn open(cx: &mut TestAppContext, policy: Spring) -> Self {
             let target = Rc::new(Cell::new(0.0));
+            let travel = Rc::new(Cell::new(true));
             let samples = Rc::new(RefCell::new(Vec::new()));
             let window = cx.open_window(size(px(100.), px(100.)), {
                 let target = target.clone();
+                let travel = travel.clone();
                 let samples = samples.clone();
                 move |_, _| SpringView {
                     target,
                     policy,
+                    travel,
                     samples,
                 }
             });
@@ -593,6 +617,7 @@ mod tests {
             Self {
                 window,
                 target,
+                travel,
                 samples,
             }
         }
@@ -683,6 +708,26 @@ mod tests {
         fixture.pending_frame(cx);
         cx.run_until_parked();
         assert_eq!(fixture.pending_frame(cx), 0);
+    }
+
+    #[gpui::test]
+    fn a_spring_that_is_not_travelling_adopts_its_target_on_the_spot(cx: &mut TestAppContext) {
+        let fixture = SpringFixture::open(cx, Spring::SMOOTH);
+        fixture.travel.set(false);
+
+        assert_eq!(fixture.render(cx, 1.0), 1.0);
+        assert_eq!(fixture.pending_frame(cx), 0);
+        assert_eq!(fixture.advance(cx, 100, 5.0), 5.0);
+
+        // Travel resumes from the value the pause left behind. A spring that
+        // had kept its pre-pause state would jump back to it here.
+        fixture.travel.set(true);
+        assert_eq!(fixture.render(cx, 6.0), 5.0);
+        let next = fixture.advance(cx, 50, 6.0);
+        assert!(
+            5.0 < next && next < 6.0,
+            "expected travel to resume from 5.0, got {next}"
+        );
     }
 
     #[gpui::test]

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -202,21 +202,25 @@ where
 /// snapping to a new curve's initial speed.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Spring {
-    response_seconds: f32,
+    response: Duration,
     damping_ratio: f32,
     epsilon: f32,
     travel: bool,
 }
 
 impl Spring {
-    /// Builds a spring that reaches its target in about `response_seconds`
-    /// without overshooting it.
+    /// Builds a spring that reaches its target in about `response` without
+    /// overshooting it.
     ///
-    /// `response_seconds` is the period one full oscillation would take without
-    /// damping; smaller values feel faster.
-    pub const fn new(response_seconds: f32) -> Self {
+    /// `response` is not a duration in the sense [`Transition::new`] means one.
+    /// A spring has no end to schedule: this is the period one full oscillation
+    /// would take without damping, which is the scale the motion is felt at
+    /// rather than the moment it stops. The remaining fraction of a percent
+    /// keeps settling past it, until it is within the tolerance
+    /// [`Self::with_epsilon`] sets.
+    pub const fn new(response: Duration) -> Self {
         Self {
-            response_seconds,
+            response,
             damping_ratio: 1.0,
             epsilon: DEFAULT_SPRING_EPSILON,
             travel: true,
@@ -236,11 +240,11 @@ impl Spring {
 
     /// The physical parameters GPUI integrates.
     ///
-    /// Derived on use rather than stored, so the builder stays `const`:
-    /// recovering a damping ratio from a built config needs a square root,
-    /// which a `const fn` cannot call.
+    /// Derived on use rather than stored, so the builders stay `const`: neither
+    /// `Duration::as_secs_f32` nor the square root that recovers a damping ratio
+    /// from a built config can be called from a `const fn`.
     fn config(&self) -> SpringConfig {
-        let frequency = std::f32::consts::TAU / self.response_seconds;
+        let frequency = std::f32::consts::TAU / self.response.as_secs_f32();
         SpringConfig::new(
             frequency * frequency,
             2.0 * self.damping_ratio * frequency,
@@ -637,13 +641,13 @@ mod tests {
 
     #[gpui::test]
     fn a_spring_adopts_its_first_target_immediately(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.3));
+        let fixture = SpringFixture::open(cx, Spring::new(Duration::from_millis(300)));
         assert_eq!(*fixture.samples.borrow().first().unwrap(), 0.0);
     }
 
     #[gpui::test]
     fn a_spring_travels_toward_its_target_over_time(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.3));
+        let fixture = SpringFixture::open(cx, Spring::new(Duration::from_millis(300)));
         assert_eq!(fixture.render(cx, 1.0), 0.0);
 
         let early = fixture.advance(cx, 50, 1.0);
@@ -656,7 +660,7 @@ mod tests {
 
     #[gpui::test]
     fn a_reversed_spring_keeps_its_momentum_before_turning_around(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.3));
+        let fixture = SpringFixture::open(cx, Spring::new(Duration::from_millis(300)));
         fixture.render(cx, 1.0);
         let reversed_at = fixture.advance(cx, 100, 1.0);
 
@@ -675,7 +679,10 @@ mod tests {
 
     #[gpui::test]
     fn a_bouncy_spring_overshoots_its_target(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.35).with_damping(0.7));
+        let fixture = SpringFixture::open(
+            cx,
+            Spring::new(Duration::from_millis(350)).with_damping(0.7),
+        );
         fixture.render(cx, 1.0);
         for _ in 0..30 {
             fixture.advance(cx, 16, 1.0);
@@ -692,7 +699,7 @@ mod tests {
 
     #[gpui::test]
     fn a_settled_spring_stops_requesting_frames(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.3));
+        let fixture = SpringFixture::open(cx, Spring::new(Duration::from_millis(300)));
         fixture.render(cx, 1.0);
         assert_eq!(fixture.pending_frame(cx), 1);
 
@@ -704,7 +711,7 @@ mod tests {
 
     #[gpui::test]
     fn a_spring_that_is_not_travelling_adopts_its_target_on_the_spot(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.3));
+        let fixture = SpringFixture::open(cx, Spring::new(Duration::from_millis(300)));
         fixture.travel.set(false);
 
         assert_eq!(fixture.render(cx, 1.0), 1.0);
@@ -725,7 +732,10 @@ mod tests {
     #[gpui::test]
     fn reduced_motion_adopts_the_spring_target_without_requesting_a_frame(cx: &mut TestAppContext) {
         cx.update(|cx| cx.set_reduce_motion(true));
-        let fixture = SpringFixture::open(cx, Spring::new(0.35).with_damping(0.7));
+        let fixture = SpringFixture::open(
+            cx,
+            Spring::new(Duration::from_millis(350)).with_damping(0.7),
+        );
         assert_eq!(fixture.render(cx, 1.0), 1.0);
         assert_eq!(fixture.pending_frame(cx), 0);
     }

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -208,13 +208,6 @@ pub struct Spring {
 }
 
 impl Spring {
-    /// A firm spring that settles without overshooting.
-    pub const SMOOTH: Self = Self::new(0.30, 1.0);
-    /// A quick spring with a slight overshoot.
-    pub const SNAPPY: Self = Self::new(0.25, 0.85);
-    /// A loose spring with a pronounced overshoot.
-    pub const BOUNCY: Self = Self::new(0.35, 0.7);
-
     /// Builds a spring from a perceptual response time and a damping ratio.
     ///
     /// `response_seconds` is the period one full oscillation would take without
@@ -223,17 +216,8 @@ impl Spring {
     /// above `1.0` to approach slowly.
     pub const fn new(response_seconds: f32, damping_ratio: f32) -> Self {
         let frequency = std::f32::consts::TAU / response_seconds;
-        Self::from_config(SpringConfig::new(
-            frequency * frequency,
-            2.0 * damping_ratio * frequency,
-            1.0,
-        ))
-    }
-
-    /// Builds a spring from stiffness, damping, and mass directly.
-    pub const fn from_config(config: SpringConfig) -> Self {
         Self {
-            config,
+            config: SpringConfig::new(frequency * frequency, 2.0 * damping_ratio * frequency, 1.0),
             epsilon: DEFAULT_SPRING_EPSILON,
             travel: true,
         }
@@ -260,21 +244,6 @@ impl Spring {
     pub const fn with_epsilon(mut self, epsilon: f32) -> Self {
         self.epsilon = epsilon;
         self
-    }
-
-    /// Returns the underlying physical parameters.
-    pub fn config(&self) -> SpringConfig {
-        self.config
-    }
-
-    /// Returns the settling tolerance.
-    pub fn epsilon(&self) -> f32 {
-        self.epsilon
-    }
-
-    /// Returns whether the spring travels to its target.
-    pub fn travel(&self) -> bool {
-        self.travel
     }
 }
 
@@ -645,13 +614,13 @@ mod tests {
 
     #[gpui::test]
     fn a_spring_adopts_its_first_target_immediately(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::SMOOTH);
+        let fixture = SpringFixture::open(cx, Spring::new(0.3, 1.0));
         assert_eq!(*fixture.samples.borrow().first().unwrap(), 0.0);
     }
 
     #[gpui::test]
     fn a_spring_travels_toward_its_target_over_time(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::SMOOTH);
+        let fixture = SpringFixture::open(cx, Spring::new(0.3, 1.0));
         assert_eq!(fixture.render(cx, 1.0), 0.0);
 
         let early = fixture.advance(cx, 50, 1.0);
@@ -664,7 +633,7 @@ mod tests {
 
     #[gpui::test]
     fn a_reversed_spring_keeps_its_momentum_before_turning_around(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::SMOOTH);
+        let fixture = SpringFixture::open(cx, Spring::new(0.3, 1.0));
         fixture.render(cx, 1.0);
         let reversed_at = fixture.advance(cx, 100, 1.0);
 
@@ -683,7 +652,7 @@ mod tests {
 
     #[gpui::test]
     fn a_bouncy_spring_overshoots_its_target(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::BOUNCY);
+        let fixture = SpringFixture::open(cx, Spring::new(0.35, 0.7));
         fixture.render(cx, 1.0);
         for _ in 0..30 {
             fixture.advance(cx, 16, 1.0);
@@ -700,7 +669,7 @@ mod tests {
 
     #[gpui::test]
     fn a_settled_spring_stops_requesting_frames(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::SMOOTH);
+        let fixture = SpringFixture::open(cx, Spring::new(0.3, 1.0));
         fixture.render(cx, 1.0);
         assert_eq!(fixture.pending_frame(cx), 1);
 
@@ -712,7 +681,7 @@ mod tests {
 
     #[gpui::test]
     fn a_spring_that_is_not_travelling_adopts_its_target_on_the_spot(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::SMOOTH);
+        let fixture = SpringFixture::open(cx, Spring::new(0.3, 1.0));
         fixture.travel.set(false);
 
         assert_eq!(fixture.render(cx, 1.0), 1.0);
@@ -733,7 +702,7 @@ mod tests {
     #[gpui::test]
     fn reduced_motion_adopts_the_spring_target_without_requesting_a_frame(cx: &mut TestAppContext) {
         cx.update(|cx| cx.set_reduce_motion(true));
-        let fixture = SpringFixture::open(cx, Spring::BOUNCY);
+        let fixture = SpringFixture::open(cx, Spring::new(0.35, 0.7));
         assert_eq!(fixture.render(cx, 1.0), 1.0);
         assert_eq!(fixture.pending_frame(cx), 0);
     }

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -200,12 +200,11 @@ where
 /// position but not in velocity. A spring carries velocity across the retarget,
 /// so a value reversed mid-flight decelerates and turns around instead of
 /// snapping to a new curve's initial speed.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy)]
 pub struct Spring {
     response: Duration,
     damping: f32,
     epsilon: f32,
-    travel: bool,
 }
 
 impl Spring {
@@ -218,12 +217,19 @@ impl Spring {
     /// rather than the moment it stops. The remaining fraction of a percent
     /// keeps settling past it, until it is within the tolerance
     /// [`Self::with_epsilon`] sets.
+    ///
+    /// A zero response adopts the target on the spot, as a zero duration does
+    /// for a transition — an infinitely stiff spring has nowhere to travel. Use
+    /// it for a value the pointer is already moving, such as a panel being
+    /// dragged by its resize handle, which must not lag behind the pointer:
+    /// retained state stays pinned to the target meanwhile, so travel resumes
+    /// from the value the drag released rather than from wherever the spring was
+    /// when it began.
     pub const fn new(response: Duration) -> Self {
         Self {
             response,
             damping: 1.0,
             epsilon: DEFAULT_SPRING_EPSILON,
-            travel: true,
         }
     }
 
@@ -241,18 +247,6 @@ impl Spring {
         self
     }
 
-    /// Sets whether the spring travels to its target or adopts it on the spot.
-    ///
-    /// A value the pointer is already moving — a panel being dragged by its
-    /// resize handle — must not lag behind the pointer, so the spring stops
-    /// travelling for as long as the drag lasts. Retained state stays pinned to
-    /// the target meanwhile, so travel resumes from the value the drag released
-    /// rather than from wherever the spring was when it began.
-    pub const fn with_travel(mut self, travel: bool) -> Self {
-        self.travel = travel;
-        self
-    }
-
     /// Sets the settling tolerance, expressed in the target's own units.
     ///
     /// The default suits targets that move within a normalized `0..1` range. A
@@ -264,7 +258,8 @@ impl Spring {
         self
     }
 
-    /// The physical parameters GPUI integrates.
+    /// The physical parameters GPUI integrates. The response must be non-zero;
+    /// [`spring`] adopts the target before reaching here when it is not.
     ///
     /// Derived on use rather than stored, so the builders stay `const`: neither
     /// `Duration::as_secs_f32` nor the square root that recovers a damping ratio
@@ -323,7 +318,7 @@ where
         state.updated_at = now;
     };
 
-    if cx.reduce_motion() || !policy.travel {
+    if cx.reduce_motion() || policy.response.is_zero() {
         if snapshot.state.position != target_position || snapshot.state.velocity != 0.0 {
             state.update(cx, |state, _| settle(state));
         }
@@ -569,8 +564,7 @@ mod tests {
 
     struct SpringView {
         target: Rc<Cell<f32>>,
-        policy: Spring,
-        travel: Rc<Cell<bool>>,
+        policy: Rc<Cell<Spring>>,
         samples: Rc<RefCell<Vec<f32>>>,
     }
 
@@ -583,7 +577,7 @@ mod tests {
             self.samples.borrow_mut().push(spring(
                 ("spring-test", "value"),
                 self.target.get(),
-                self.policy.with_travel(self.travel.get()),
+                self.policy.get(),
                 window,
                 cx,
             ));
@@ -594,23 +588,22 @@ mod tests {
     struct SpringFixture {
         window: WindowHandle<SpringView>,
         target: Rc<Cell<f32>>,
-        travel: Rc<Cell<bool>>,
+        policy: Rc<Cell<Spring>>,
         samples: Rc<RefCell<Vec<f32>>>,
     }
 
     impl SpringFixture {
         fn open(cx: &mut TestAppContext, policy: Spring) -> Self {
             let target = Rc::new(Cell::new(0.0));
-            let travel = Rc::new(Cell::new(true));
+            let policy = Rc::new(Cell::new(policy));
             let samples = Rc::new(RefCell::new(Vec::new()));
             let window = cx.open_window(size(px(100.), px(100.)), {
                 let target = target.clone();
-                let travel = travel.clone();
+                let policy = policy.clone();
                 let samples = samples.clone();
                 move |_, _| SpringView {
                     target,
                     policy,
-                    travel,
                     samples,
                 }
             });
@@ -618,7 +611,7 @@ mod tests {
             Self {
                 window,
                 target,
-                travel,
+                policy,
                 samples,
             }
         }
@@ -715,17 +708,17 @@ mod tests {
     }
 
     #[gpui::test]
-    fn a_spring_that_is_not_travelling_adopts_its_target_on_the_spot(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(Duration::from_millis(300)));
-        fixture.travel.set(false);
+    fn a_zero_response_spring_adopts_its_target_on_the_spot(cx: &mut TestAppContext) {
+        let travelling = Spring::new(Duration::from_millis(300));
+        let fixture = SpringFixture::open(cx, Spring::new(Duration::ZERO));
 
         assert_eq!(fixture.render(cx, 1.0), 1.0);
         assert_eq!(fixture.pending_frame(cx), 0);
         assert_eq!(fixture.advance(cx, 100, 5.0), 5.0);
 
-        // Travel resumes from the value the pause left behind. A spring that
-        // had kept its pre-pause state would jump back to it here.
-        fixture.travel.set(true);
+        // Travel resumes from the value the zero response left behind. A spring
+        // that had kept the state it held beforehand would jump back to it here.
+        fixture.policy.set(travelling);
         assert_eq!(fixture.render(cx, 6.0), 5.0);
         let next = fixture.advance(cx, 50, 6.0);
         assert!(

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -338,6 +338,12 @@ where
     let config = policy.config();
     let stepped = config.step(snapshot.state, snapshot.target, elapsed);
 
+    // A spring that is already exactly at rest on its target writes nothing, so
+    // `updated_at` goes stale for as long as it stays there. The next retarget
+    // then steps a zero displacement at zero velocity over that whole gap, which
+    // any elapsed time leaves where it is, so the stale clock cannot move the
+    // value — it only has to not produce a NaN, and every term the propagator
+    // scales is finite.
     if config.is_settled(stepped, target_position, policy.epsilon) {
         if snapshot.state.position != target_position || snapshot.state.velocity != 0.0 {
             state.update(cx, |state, _| settle(state));

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -205,6 +205,7 @@ pub struct Spring {
     response: Duration,
     damping: f32,
     epsilon: f32,
+    travel: bool,
 }
 
 impl Spring {
@@ -219,17 +220,15 @@ impl Spring {
     /// [`Self::with_epsilon`] sets.
     ///
     /// A zero response adopts the target on the spot, as a zero duration does
-    /// for a transition — an infinitely stiff spring has nowhere to travel. Use
-    /// it for a value the pointer is already moving, such as a panel being
-    /// dragged by its resize handle, which must not lag behind the pointer:
-    /// retained state stays pinned to the target meanwhile, so travel resumes
-    /// from the value the drag released rather than from wherever the spring was
-    /// when it began.
+    /// for a transition. Say that with [`Self::with_travel`] where it is what
+    /// you mean; a zero here is the degenerate case, defined so an infinitely
+    /// stiff spring resolves rather than dividing by its own period.
     pub const fn new(response: Duration) -> Self {
         Self {
             response,
             damping: 1.0,
             epsilon: DEFAULT_SPRING_EPSILON,
+            travel: true,
         }
     }
 
@@ -244,6 +243,23 @@ impl Spring {
     /// coefficient $c = 2 \zeta \omega_0$.
     pub const fn with_damping(mut self, ratio: f32) -> Self {
         self.damping = ratio;
+        self
+    }
+
+    /// Sets whether the spring travels to its target or adopts it on the spot.
+    ///
+    /// A value the pointer is already moving — a panel being dragged by its
+    /// resize handle — must not lag behind the pointer, so the spring stops
+    /// travelling for as long as the drag lasts. Retained state stays pinned to
+    /// the target meanwhile, so travel resumes from the value the drag released
+    /// rather than from wherever the spring was when it began.
+    ///
+    /// This says at the call that the motion is suspended, and it says it
+    /// without disturbing the response, damping or tolerance the spring is
+    /// configured with — which a policy swapped out for the length of the drag
+    /// would have to restate or discard.
+    pub const fn with_travel(mut self, travel: bool) -> Self {
+        self.travel = travel;
         self
     }
 
@@ -318,7 +334,7 @@ where
         state.updated_at = now;
     };
 
-    if cx.reduce_motion() || policy.response.is_zero() {
+    if cx.reduce_motion() || !policy.travel || policy.response.is_zero() {
         if snapshot.state.position != target_position || snapshot.state.velocity != 0.0 {
             state.update(cx, |state, _| settle(state));
         }
@@ -708,15 +724,15 @@ mod tests {
     }
 
     #[gpui::test]
-    fn a_zero_response_spring_adopts_its_target_on_the_spot(cx: &mut TestAppContext) {
+    fn a_spring_that_is_not_travelling_adopts_its_target_on_the_spot(cx: &mut TestAppContext) {
         let travelling = Spring::new(Duration::from_millis(300));
-        let fixture = SpringFixture::open(cx, Spring::new(Duration::ZERO));
+        let fixture = SpringFixture::open(cx, travelling.with_travel(false));
 
         assert_eq!(fixture.render(cx, 1.0), 1.0);
         assert_eq!(fixture.pending_frame(cx), 0);
         assert_eq!(fixture.advance(cx, 100, 5.0), 5.0);
 
-        // Travel resumes from the value the zero response left behind. A spring
+        // Travel resumes from the value the suspension left behind. A spring
         // that had kept the state it held beforehand would jump back to it here.
         fixture.policy.set(travelling);
         assert_eq!(fixture.render(cx, 6.0), 5.0);
@@ -725,6 +741,13 @@ mod tests {
             5.0 < next && next < 6.0,
             "expected travel to resume from 5.0, got {next}"
         );
+    }
+
+    #[gpui::test]
+    fn a_zero_response_spring_resolves_instead_of_dividing_by_its_period(cx: &mut TestAppContext) {
+        let fixture = SpringFixture::open(cx, Spring::new(Duration::ZERO));
+        assert_eq!(fixture.render(cx, 1.0), 1.0);
+        assert_eq!(fixture.pending_frame(cx), 0);
     }
 
     #[gpui::test]

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -241,16 +241,6 @@ impl Spring {
         self
     }
 
-    /// The physical parameters GPUI integrates.
-    ///
-    /// Derived on use rather than stored, so the builders stay `const`: neither
-    /// `Duration::as_secs_f32` nor the square root that recovers a damping ratio
-    /// from a built config can be called from a `const fn`.
-    fn config(&self) -> SpringConfig {
-        let frequency = std::f32::consts::TAU / self.response.as_secs_f32();
-        SpringConfig::new(frequency * frequency, 2.0 * self.damping * frequency, 1.0)
-    }
-
     /// Sets whether the spring travels to its target or adopts it on the spot.
     ///
     /// A value the pointer is already moving — a panel being dragged by its
@@ -272,6 +262,16 @@ impl Spring {
     pub const fn with_epsilon(mut self, epsilon: f32) -> Self {
         self.epsilon = epsilon;
         self
+    }
+
+    /// The physical parameters GPUI integrates.
+    ///
+    /// Derived on use rather than stored, so the builders stay `const`: neither
+    /// `Duration::as_secs_f32` nor the square root that recovers a damping ratio
+    /// from a built config can be called from a `const fn`.
+    fn config(&self) -> SpringConfig {
+        let frequency = std::f32::consts::TAU / self.response.as_secs_f32();
+        SpringConfig::new(frequency * frequency, 2.0 * self.damping * frequency, 1.0)
     }
 }
 

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -325,6 +325,23 @@ where
     });
 
     let snapshot = *state.read(cx);
+    let at_rest_on_target =
+        snapshot.state.position == target_position && snapshot.state.velocity == 0.0;
+
+    // The overwhelmingly common case: a spring nothing is currently moving. It
+    // has no state to advance and no frame to ask for, so it never builds a
+    // config or steps one — a settled spring costs a read and two comparisons.
+    // Every branch below would return this same value and write nothing.
+    //
+    // Resting writes nothing, so `updated_at` goes stale for as long as the rest
+    // lasts. The next retarget then steps a zero displacement at zero velocity
+    // over that whole gap, which any elapsed time leaves where it is, so the
+    // stale clock cannot move the value — it only has to not produce a NaN, and
+    // every term the propagator scales is finite.
+    if at_rest_on_target {
+        return target.resolve(target_position);
+    }
+
     let settle = |state: &mut SpringTransition| {
         state.state = SpringState {
             position: target_position,
@@ -335,9 +352,7 @@ where
     };
 
     if cx.reduce_motion() || !policy.travel || policy.response.is_zero() {
-        if snapshot.state.position != target_position || snapshot.state.velocity != 0.0 {
-            state.update(cx, |state, _| settle(state));
-        }
+        state.update(cx, |state, _| settle(state));
         return target.resolve(target_position);
     }
 
@@ -349,16 +364,8 @@ where
     let config = policy.config();
     let stepped = config.step(snapshot.state, snapshot.target, elapsed);
 
-    // A spring that is already exactly at rest on its target writes nothing, so
-    // `updated_at` goes stale for as long as it stays there. The next retarget
-    // then steps a zero displacement at zero velocity over that whole gap, which
-    // any elapsed time leaves where it is, so the stale clock cannot move the
-    // value — it only has to not produce a NaN, and every term the propagator
-    // scales is finite.
     if config.is_settled(stepped, target_position, policy.epsilon) {
-        if snapshot.state.position != target_position || snapshot.state.velocity != 0.0 {
-            state.update(cx, |state, _| settle(state));
-        }
+        state.update(cx, |state, _| settle(state));
         return target.resolve(target_position);
     }
 

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -203,7 +203,7 @@ where
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Spring {
     response: Duration,
-    damping_ratio: f32,
+    damping: f32,
     epsilon: f32,
     travel: bool,
 }
@@ -221,7 +221,7 @@ impl Spring {
     pub const fn new(response: Duration) -> Self {
         Self {
             response,
-            damping_ratio: 1.0,
+            damping: 1.0,
             epsilon: DEFAULT_SPRING_EPSILON,
             travel: true,
         }
@@ -236,8 +236,8 @@ impl Spring {
     ///
     /// This is $\zeta$, not GPUI's `SpringConfig::damping`, which is the
     /// coefficient $c = 2 \zeta \omega_0$.
-    pub const fn with_damping_ratio(mut self, ratio: f32) -> Self {
-        self.damping_ratio = ratio;
+    pub const fn with_damping(mut self, ratio: f32) -> Self {
+        self.damping = ratio;
         self
     }
 
@@ -248,11 +248,7 @@ impl Spring {
     /// from a built config can be called from a `const fn`.
     fn config(&self) -> SpringConfig {
         let frequency = std::f32::consts::TAU / self.response.as_secs_f32();
-        SpringConfig::new(
-            frequency * frequency,
-            2.0 * self.damping_ratio * frequency,
-            1.0,
-        )
+        SpringConfig::new(frequency * frequency, 2.0 * self.damping * frequency, 1.0)
     }
 
     /// Sets whether the spring travels to its target or adopts it on the spot.
@@ -684,7 +680,7 @@ mod tests {
     fn a_bouncy_spring_overshoots_its_target(cx: &mut TestAppContext) {
         let fixture = SpringFixture::open(
             cx,
-            Spring::new(Duration::from_millis(350)).with_damping_ratio(0.7),
+            Spring::new(Duration::from_millis(350)).with_damping(0.7),
         );
         fixture.render(cx, 1.0);
         for _ in 0..30 {
@@ -737,7 +733,7 @@ mod tests {
         cx.update(|cx| cx.set_reduce_motion(true));
         let fixture = SpringFixture::open(
             cx,
-            Spring::new(Duration::from_millis(350)).with_damping_ratio(0.7),
+            Spring::new(Duration::from_millis(350)).with_damping(0.7),
         );
         assert_eq!(fixture.render(cx, 1.0), 1.0);
         assert_eq!(fixture.pending_frame(cx), 0);

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -4,9 +4,12 @@ use std::{rc::Rc, time::Duration};
 #[cfg(target_family = "wasm")]
 use web_time::Instant;
 
-use gpui::{App, ElementId, SharedString, Window};
+use gpui::{App, ElementId, SharedString, SpringConfig, SpringState, SpringTarget, Window};
 
 use crate::animation::{Lerp, ease_out_cubic};
+
+/// Matches GPUI's own default spring settling tolerance.
+const DEFAULT_SPRING_EPSILON: f32 = 0.001;
 
 /// A value that can be interpolated between two application-owned targets.
 pub trait Interpolate: Clone {
@@ -187,6 +190,154 @@ where
         window.request_animation_frame();
     }
     value
+}
+
+/// A physical spring policy for [`spring`].
+///
+/// A spring is the counterpart to [`Transition`] for values that can be
+/// retargeted while they are still moving. A duration-based transition restarts
+/// its easing from the value sampled at that instant, which is continuous in
+/// position but not in velocity. A spring carries velocity across the retarget,
+/// so a value reversed mid-flight decelerates and turns around instead of
+/// snapping to a new curve's initial speed.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Spring {
+    config: SpringConfig,
+    epsilon: f32,
+}
+
+impl Spring {
+    /// A firm spring that settles without overshooting.
+    pub const SMOOTH: Self = Self::new(0.30, 1.0);
+    /// A quick spring with a slight overshoot.
+    pub const SNAPPY: Self = Self::new(0.25, 0.85);
+    /// A loose spring with a pronounced overshoot.
+    pub const BOUNCY: Self = Self::new(0.35, 0.7);
+
+    /// Builds a spring from a perceptual response time and a damping ratio.
+    ///
+    /// `response_seconds` is the period one full oscillation would take without
+    /// damping; smaller values feel faster. `damping_ratio` is `1.0` for a
+    /// spring that stops exactly at its target, below `1.0` to overshoot, and
+    /// above `1.0` to approach slowly.
+    pub const fn new(response_seconds: f32, damping_ratio: f32) -> Self {
+        let frequency = std::f32::consts::TAU / response_seconds;
+        Self::from_config(SpringConfig::new(
+            frequency * frequency,
+            2.0 * damping_ratio * frequency,
+            1.0,
+        ))
+    }
+
+    /// Builds a spring from stiffness, damping, and mass directly.
+    pub const fn from_config(config: SpringConfig) -> Self {
+        Self {
+            config,
+            epsilon: DEFAULT_SPRING_EPSILON,
+        }
+    }
+
+    /// Sets the settling tolerance, expressed in the target's own units.
+    ///
+    /// The default suits targets that move within a normalized `0..1` range. A
+    /// spring over pixels settles perceptibly sooner with a coarser tolerance,
+    /// which also ends the animation frames that the remaining sub-pixel motion
+    /// would otherwise request.
+    pub const fn with_epsilon(mut self, epsilon: f32) -> Self {
+        self.epsilon = epsilon;
+        self
+    }
+
+    /// Returns the underlying physical parameters.
+    pub fn config(&self) -> SpringConfig {
+        self.config
+    }
+
+    /// Returns the settling tolerance.
+    pub fn epsilon(&self) -> f32 {
+        self.epsilon
+    }
+}
+
+#[derive(Clone, Copy)]
+struct SpringTransition {
+    state: SpringState,
+    target: f32,
+    updated_at: Instant,
+}
+
+/// Returns the current value for a spring travelling toward `target`.
+///
+/// State is keyed by `id` exactly as [`transition`] keys its own. The first
+/// value is adopted immediately; later target changes preserve both the current
+/// position and the current velocity, so an interrupted spring is redirected
+/// rather than restarted.
+///
+/// Call this while rendering an element, where GPUI keyed element state is
+/// available. A channel id must identify one value within that element.
+pub fn spring<T>(
+    id: impl Into<TransitionId>,
+    target: T,
+    policy: Spring,
+    window: &mut Window,
+    cx: &mut App,
+) -> T::Output
+where
+    T: SpringTarget,
+{
+    let id: ElementId = id.into().into();
+    let now = cx.background_executor().now();
+    let target_position = target.target();
+    let state = window.use_keyed_state(id, cx, |_, _| SpringTransition {
+        state: SpringState {
+            position: target_position,
+            velocity: 0.0,
+        },
+        target: target_position,
+        updated_at: now,
+    });
+
+    let snapshot = *state.read(cx);
+    let settle = |state: &mut SpringTransition| {
+        state.state = SpringState {
+            position: target_position,
+            velocity: 0.0,
+        };
+        state.target = target_position;
+        state.updated_at = now;
+    };
+
+    if cx.reduce_motion() {
+        if snapshot.state.position != target_position || snapshot.state.velocity != 0.0 {
+            state.update(cx, |state, _| settle(state));
+        }
+        return target.resolve(target_position);
+    }
+
+    // Advance over the frame that just elapsed, which the previous target
+    // governed, before adopting the new one for the frame to come.
+    let elapsed = now
+        .saturating_duration_since(snapshot.updated_at)
+        .as_secs_f32();
+    let stepped = policy.config.step(snapshot.state, snapshot.target, elapsed);
+
+    if policy
+        .config
+        .is_settled(stepped, target_position, policy.epsilon)
+    {
+        if snapshot.state.position != target_position || snapshot.state.velocity != 0.0 {
+            state.update(cx, |state, _| settle(state));
+        }
+        return target.resolve(target_position);
+    }
+
+    state.update(cx, |state, _| {
+        state.state = stepped;
+        state.target = target_position;
+        state.updated_at = now;
+    });
+    window.request_animation_frame();
+    target.resolve(stepped.position)
 }
 
 #[cfg(test)]
@@ -392,6 +543,152 @@ mod tests {
         cx.update(|cx| cx.set_reduce_motion(true));
         let duration = Duration::from_millis(100);
         let fixture = Fixture::open(cx, duration);
+        assert_eq!(fixture.render(cx, 1.0), 1.0);
+        assert_eq!(fixture.pending_frame(cx), 0);
+    }
+
+    struct SpringView {
+        target: Rc<Cell<f32>>,
+        policy: Spring,
+        samples: Rc<RefCell<Vec<f32>>>,
+    }
+
+    impl Render for SpringView {
+        fn render(
+            &mut self,
+            window: &mut Window,
+            cx: &mut gpui::Context<Self>,
+        ) -> impl IntoElement {
+            self.samples.borrow_mut().push(spring(
+                ("spring-test", "value"),
+                self.target.get(),
+                self.policy,
+                window,
+                cx,
+            ));
+            Empty
+        }
+    }
+
+    struct SpringFixture {
+        window: WindowHandle<SpringView>,
+        target: Rc<Cell<f32>>,
+        samples: Rc<RefCell<Vec<f32>>>,
+    }
+
+    impl SpringFixture {
+        fn open(cx: &mut TestAppContext, policy: Spring) -> Self {
+            let target = Rc::new(Cell::new(0.0));
+            let samples = Rc::new(RefCell::new(Vec::new()));
+            let window = cx.open_window(size(px(100.), px(100.)), {
+                let target = target.clone();
+                let samples = samples.clone();
+                move |_, _| SpringView {
+                    target,
+                    policy,
+                    samples,
+                }
+            });
+            cx.run_until_parked();
+            Self {
+                window,
+                target,
+                samples,
+            }
+        }
+
+        fn render(&self, cx: &mut TestAppContext, target: f32) -> f32 {
+            self.target.set(target);
+            self.window
+                .update(cx, |_, window, _| window.refresh())
+                .unwrap();
+            cx.run_until_parked();
+            *self.samples.borrow().last().unwrap()
+        }
+
+        fn advance(&self, cx: &mut TestAppContext, millis: u64, target: f32) -> f32 {
+            cx.executor().advance_clock(Duration::from_millis(millis));
+            self.render(cx, target)
+        }
+
+        fn pending_frame(&self, cx: &mut TestAppContext) -> usize {
+            self.window
+                .update(cx, |_, window, cx| window.simulate_next_frame(cx))
+                .unwrap()
+        }
+    }
+
+    #[gpui::test]
+    fn a_spring_adopts_its_first_target_immediately(cx: &mut TestAppContext) {
+        let fixture = SpringFixture::open(cx, Spring::SMOOTH);
+        assert_eq!(*fixture.samples.borrow().first().unwrap(), 0.0);
+    }
+
+    #[gpui::test]
+    fn a_spring_travels_toward_its_target_over_time(cx: &mut TestAppContext) {
+        let fixture = SpringFixture::open(cx, Spring::SMOOTH);
+        assert_eq!(fixture.render(cx, 1.0), 0.0);
+
+        let early = fixture.advance(cx, 50, 1.0);
+        let late = fixture.advance(cx, 50, 1.0);
+        assert!(
+            0.0 < early && early < late && late < 1.0,
+            "expected monotonic approach, got {early} then {late}"
+        );
+    }
+
+    #[gpui::test]
+    fn a_reversed_spring_keeps_its_momentum_before_turning_around(cx: &mut TestAppContext) {
+        let fixture = SpringFixture::open(cx, Spring::SMOOTH);
+        fixture.render(cx, 1.0);
+        let reversed_at = fixture.advance(cx, 100, 1.0);
+
+        // Retarget mid-flight. A duration-based transition restarts its easing
+        // here and moves away from 1.0 on the very next frame.
+        assert_eq!(fixture.render(cx, 0.0), reversed_at);
+
+        let next = fixture.advance(cx, 16, 0.0);
+        assert!(
+            next > reversed_at,
+            "expected the spring to carry its velocity past {reversed_at}, got {next}"
+        );
+
+        assert_eq!(fixture.advance(cx, 1_000, 0.0), 0.0);
+    }
+
+    #[gpui::test]
+    fn a_bouncy_spring_overshoots_its_target(cx: &mut TestAppContext) {
+        let fixture = SpringFixture::open(cx, Spring::BOUNCY);
+        fixture.render(cx, 1.0);
+        for _ in 0..30 {
+            fixture.advance(cx, 16, 1.0);
+        }
+
+        let peak = fixture
+            .samples
+            .borrow()
+            .iter()
+            .copied()
+            .fold(f32::MIN, f32::max);
+        assert!(peak > 1.0, "expected an overshoot past 1.0, got {peak}");
+    }
+
+    #[gpui::test]
+    fn a_settled_spring_stops_requesting_frames(cx: &mut TestAppContext) {
+        let fixture = SpringFixture::open(cx, Spring::SMOOTH);
+        fixture.render(cx, 1.0);
+        assert_eq!(fixture.pending_frame(cx), 1);
+
+        assert_eq!(fixture.advance(cx, 2_000, 1.0), 1.0);
+        fixture.pending_frame(cx);
+        cx.run_until_parked();
+        assert_eq!(fixture.pending_frame(cx), 0);
+    }
+
+    #[gpui::test]
+    fn reduced_motion_adopts_the_spring_target_without_requesting_a_frame(cx: &mut TestAppContext) {
+        cx.update(|cx| cx.set_reduce_motion(true));
+        let fixture = SpringFixture::open(cx, Spring::BOUNCY);
         assert_eq!(fixture.render(cx, 1.0), 1.0);
         assert_eq!(fixture.pending_frame(cx), 0);
     }

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -202,25 +202,50 @@ where
 /// snapping to a new curve's initial speed.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Spring {
-    config: SpringConfig,
+    response_seconds: f32,
+    damping_ratio: f32,
     epsilon: f32,
     travel: bool,
 }
 
 impl Spring {
-    /// Builds a spring from a perceptual response time and a damping ratio.
+    /// Builds a spring that reaches its target in about `response_seconds`
+    /// without overshooting it.
     ///
     /// `response_seconds` is the period one full oscillation would take without
-    /// damping; smaller values feel faster. `damping_ratio` is `1.0` for a
-    /// spring that stops exactly at its target, below `1.0` to overshoot, and
-    /// above `1.0` to approach slowly.
-    pub const fn new(response_seconds: f32, damping_ratio: f32) -> Self {
-        let frequency = std::f32::consts::TAU / response_seconds;
+    /// damping; smaller values feel faster.
+    pub const fn new(response_seconds: f32) -> Self {
         Self {
-            config: SpringConfig::new(frequency * frequency, 2.0 * damping_ratio * frequency, 1.0),
+            response_seconds,
+            damping_ratio: 1.0,
             epsilon: DEFAULT_SPRING_EPSILON,
             travel: true,
         }
+    }
+
+    /// Sets the damping ratio, which is `1.0` — no overshoot — by default.
+    ///
+    /// Below `1.0` the spring passes its target and comes back; above `1.0` it
+    /// approaches slowly. Overshoot suits a value with room to pass its target
+    /// and nothing to collide with. A height, an opacity, or anything bounded by
+    /// the geometry around it should stay at the default.
+    pub const fn with_damping(mut self, damping_ratio: f32) -> Self {
+        self.damping_ratio = damping_ratio;
+        self
+    }
+
+    /// The physical parameters GPUI integrates.
+    ///
+    /// Derived on use rather than stored, so the builder stays `const`:
+    /// recovering a damping ratio from a built config needs a square root,
+    /// which a `const fn` cannot call.
+    fn config(&self) -> SpringConfig {
+        let frequency = std::f32::consts::TAU / self.response_seconds;
+        SpringConfig::new(
+            frequency * frequency,
+            2.0 * self.damping_ratio * frequency,
+            1.0,
+        )
     }
 
     /// Sets whether the spring travels to its target or adopts it on the spot.
@@ -307,12 +332,10 @@ where
     let elapsed = now
         .saturating_duration_since(snapshot.updated_at)
         .as_secs_f32();
-    let stepped = policy.config.step(snapshot.state, snapshot.target, elapsed);
+    let config = policy.config();
+    let stepped = config.step(snapshot.state, snapshot.target, elapsed);
 
-    if policy
-        .config
-        .is_settled(stepped, target_position, policy.epsilon)
-    {
+    if config.is_settled(stepped, target_position, policy.epsilon) {
         if snapshot.state.position != target_position || snapshot.state.velocity != 0.0 {
             state.update(cx, |state, _| settle(state));
         }
@@ -614,13 +637,13 @@ mod tests {
 
     #[gpui::test]
     fn a_spring_adopts_its_first_target_immediately(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.3, 1.0));
+        let fixture = SpringFixture::open(cx, Spring::new(0.3));
         assert_eq!(*fixture.samples.borrow().first().unwrap(), 0.0);
     }
 
     #[gpui::test]
     fn a_spring_travels_toward_its_target_over_time(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.3, 1.0));
+        let fixture = SpringFixture::open(cx, Spring::new(0.3));
         assert_eq!(fixture.render(cx, 1.0), 0.0);
 
         let early = fixture.advance(cx, 50, 1.0);
@@ -633,7 +656,7 @@ mod tests {
 
     #[gpui::test]
     fn a_reversed_spring_keeps_its_momentum_before_turning_around(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.3, 1.0));
+        let fixture = SpringFixture::open(cx, Spring::new(0.3));
         fixture.render(cx, 1.0);
         let reversed_at = fixture.advance(cx, 100, 1.0);
 
@@ -652,7 +675,7 @@ mod tests {
 
     #[gpui::test]
     fn a_bouncy_spring_overshoots_its_target(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.35, 0.7));
+        let fixture = SpringFixture::open(cx, Spring::new(0.35).with_damping(0.7));
         fixture.render(cx, 1.0);
         for _ in 0..30 {
             fixture.advance(cx, 16, 1.0);
@@ -669,7 +692,7 @@ mod tests {
 
     #[gpui::test]
     fn a_settled_spring_stops_requesting_frames(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.3, 1.0));
+        let fixture = SpringFixture::open(cx, Spring::new(0.3));
         fixture.render(cx, 1.0);
         assert_eq!(fixture.pending_frame(cx), 1);
 
@@ -681,7 +704,7 @@ mod tests {
 
     #[gpui::test]
     fn a_spring_that_is_not_travelling_adopts_its_target_on_the_spot(cx: &mut TestAppContext) {
-        let fixture = SpringFixture::open(cx, Spring::new(0.3, 1.0));
+        let fixture = SpringFixture::open(cx, Spring::new(0.3));
         fixture.travel.set(false);
 
         assert_eq!(fixture.render(cx, 1.0), 1.0);
@@ -702,7 +725,7 @@ mod tests {
     #[gpui::test]
     fn reduced_motion_adopts_the_spring_target_without_requesting_a_frame(cx: &mut TestAppContext) {
         cx.update(|cx| cx.set_reduce_motion(true));
-        let fixture = SpringFixture::open(cx, Spring::new(0.35, 0.7));
+        let fixture = SpringFixture::open(cx, Spring::new(0.35).with_damping(0.7));
         assert_eq!(fixture.render(cx, 1.0), 1.0);
         assert_eq!(fixture.pending_frame(cx), 0);
     }

--- a/crates/base/src/motion.rs
+++ b/crates/base/src/motion.rs
@@ -233,8 +233,11 @@ impl Spring {
     /// approaches slowly. Overshoot suits a value with room to pass its target
     /// and nothing to collide with. A height, an opacity, or anything bounded by
     /// the geometry around it should stay at the default.
-    pub const fn with_damping(mut self, damping_ratio: f32) -> Self {
-        self.damping_ratio = damping_ratio;
+    ///
+    /// This is $\zeta$, not GPUI's `SpringConfig::damping`, which is the
+    /// coefficient $c = 2 \zeta \omega_0$.
+    pub const fn with_damping_ratio(mut self, ratio: f32) -> Self {
+        self.damping_ratio = ratio;
         self
     }
 
@@ -681,7 +684,7 @@ mod tests {
     fn a_bouncy_spring_overshoots_its_target(cx: &mut TestAppContext) {
         let fixture = SpringFixture::open(
             cx,
-            Spring::new(Duration::from_millis(350)).with_damping(0.7),
+            Spring::new(Duration::from_millis(350)).with_damping_ratio(0.7),
         );
         fixture.render(cx, 1.0);
         for _ in 0..30 {
@@ -734,7 +737,7 @@ mod tests {
         cx.update(|cx| cx.set_reduce_motion(true));
         let fixture = SpringFixture::open(
             cx,
-            Spring::new(Duration::from_millis(350)).with_damping(0.7),
+            Spring::new(Duration::from_millis(350)).with_damping_ratio(0.7),
         );
         assert_eq!(fixture.render(cx, 1.0), 1.0);
         assert_eq!(fixture.pending_frame(cx), 0);

--- a/crates/base/src/toast.rs
+++ b/crates/base/src/toast.rs
@@ -19,7 +19,14 @@ use crate::{
 /// Motion tokens used by an unstyled toast stack.
 #[derive(Clone, Copy, Debug)]
 pub struct ToastMotion {
-    /// Duration of stack expansion and collapse.
+    /// Time scale of the stack's motion.
+    ///
+    /// This is read as two different quantities, because the stack sequences
+    /// one thing and interpolates another. [`ToastManager`] treats it as a
+    /// deadline: a toast is present once it has elapsed. The layout treats it
+    /// as a spring response, which is the scale the reflow is felt at rather
+    /// than the moment it stops — a toast arriving still nudges the stack for
+    /// a little longer than this.
     pub duration: Duration,
     /// Duration before an ending toast is unmounted.
     pub exit_duration: Duration,

--- a/crates/base/src/toast.rs
+++ b/crates/base/src/toast.rs
@@ -13,8 +13,7 @@ use gpui::{
 
 use crate::{
     ElementExt as _, StyledExt as _,
-    animation::cubic_bezier,
-    motion::{Transition, transition},
+    motion::{Spring, spring},
 };
 
 /// Motion tokens used by an unstyled toast stack.
@@ -422,7 +421,6 @@ impl RenderOnce for ToastStack {
             .map(|id| measured_by_id.get(id).copied().unwrap_or(px(0.)))
             .collect::<Vec<_>>();
         let measured = self.state.heights.clone();
-        let duration = self.motion.duration;
         let peek = self.motion.collapsed_peek;
         let gap = self.motion.expanded_gap;
         let scale_step = self.motion.collapsed_scale_step;
@@ -439,15 +437,22 @@ impl RenderOnce for ToastStack {
             peek,
             anchored_bottom,
         );
-        let policy = || Transition::new(duration).ease(cubic_bezier(0.25, 0.1, 0.25, 1.));
-        let stack_height = transition(
+        // The whole stack reflows every time a toast arrives or leaves, so each
+        // layer is sprung: one retargeted mid-move carries its velocity into the
+        // new layout instead of restarting. Critically damped, because a height
+        // or an opacity that overshoots its target reads as a glitch. Geometry
+        // settles in pixels, so its tolerance is coarser than the fade's.
+        let response = self.motion.duration.as_secs_f32();
+        let geometry = Spring::new(response, 1.).with_epsilon(0.1);
+        let fade = Spring::new(response, 1.);
+        let stack_height = spring(
             (self.id.clone(), "height"),
             if expanded {
                 expanded_height
             } else {
                 collapsed_height
             },
-            policy(),
+            geometry,
             window,
             cx,
         );
@@ -466,10 +471,10 @@ impl RenderOnce for ToastStack {
                 } else {
                     collapsed_offset
                 };
-                let offset = transition(
+                let offset = spring(
                     (item_id.clone(), "offset"),
                     target_offset,
-                    policy(),
+                    geometry,
                     window,
                     cx,
                 );
@@ -478,21 +483,21 @@ impl RenderOnce for ToastStack {
                 } else {
                     stack_width * (scale_step * rank.min(collapsed_visible - 1) as f32 / 2.)
                 };
-                let inset = transition(
+                let inset = spring(
                     (item_id.clone(), "inset"),
                     target_inset,
-                    policy(),
+                    geometry,
                     window,
                     cx,
                 );
-                let opacity = transition(
+                let opacity = spring(
                     (item_id.clone(), "visibility"),
                     if expanded || rank < collapsed_visible {
                         1.
                     } else {
                         0.
                     },
-                    policy(),
+                    fade,
                     window,
                     cx,
                 );
@@ -943,7 +948,12 @@ mod tests {
             window.draw(cx).clear(cx);
             window.draw(cx).clear(cx);
         });
-        cx.executor().advance_clock(ToastMotion::sonner().duration);
+        // A bottom-anchored item's position is composed from two springs — the
+        // stack height and the item's own offset — and the stack height only
+        // acquires its real target once the toast has been measured in prepaint.
+        // Both the baseline and the final reading are taken settled, so neither
+        // carries the fraction of a pixel that separates them mid-flight.
+        cx.executor().advance_clock(Duration::from_secs(1));
         cx.update(|window, cx| window.draw(cx).clear(cx));
         let initial_y = cx.debug_bounds("bottom-first-toast").unwrap().origin.y;
 
@@ -966,7 +976,7 @@ mod tests {
             "middle={middle_y:?}, initial={initial_y:?}"
         );
 
-        cx.executor().advance_clock(Duration::from_millis(200));
+        cx.executor().advance_clock(Duration::from_secs(1));
         cx.update(|window, cx| window.draw(cx).clear(cx));
         assert_eq!(
             cx.debug_bounds("bottom-first-toast").unwrap().origin.y,

--- a/crates/base/src/toast.rs
+++ b/crates/base/src/toast.rs
@@ -442,9 +442,8 @@ impl RenderOnce for ToastStack {
         // new layout instead of restarting. Critically damped, because a height
         // or an opacity that overshoots its target reads as a glitch. Geometry
         // settles in pixels, so its tolerance is coarser than the fade's.
-        let response = self.motion.duration.as_secs_f32();
-        let geometry = Spring::new(response).with_epsilon(0.1);
-        let fade = Spring::new(response);
+        let geometry = Spring::new(self.motion.duration).with_epsilon(0.1);
+        let fade = Spring::new(self.motion.duration);
         let stack_height = spring(
             (self.id.clone(), "height"),
             if expanded {

--- a/crates/base/src/toast.rs
+++ b/crates/base/src/toast.rs
@@ -443,8 +443,8 @@ impl RenderOnce for ToastStack {
         // or an opacity that overshoots its target reads as a glitch. Geometry
         // settles in pixels, so its tolerance is coarser than the fade's.
         let response = self.motion.duration.as_secs_f32();
-        let geometry = Spring::new(response, 1.).with_epsilon(0.1);
-        let fade = Spring::new(response, 1.);
+        let geometry = Spring::new(response).with_epsilon(0.1);
+        let fade = Spring::new(response);
         let stack_height = spring(
             (self.id.clone(), "height"),
             if expanded {

--- a/crates/base/src/toast.rs
+++ b/crates/base/src/toast.rs
@@ -449,6 +449,15 @@ impl RenderOnce for ToastStack {
         // new layout instead of restarting. Critically damped, because a height
         // or an opacity that overshoots its target reads as a glitch. Geometry
         // settles in pixels, so its tolerance is coarser than the fade's.
+        //
+        // A bottom-anchored item's position is composed from two of these — the
+        // stack height and the item's own offset — and the stack height only
+        // acquires its real target once the new toast has been measured in
+        // prepaint, a frame after the offsets know theirs. Two springs sharing a
+        // config stay proportional to each other only while they also share a
+        // start, so that one frame of skew lets the composed position pass its
+        // settled value by a fraction of a pixel before arriving. Both springs
+        // snap on settling, so it is a transient, not a resting error.
         let geometry = Spring::new(self.motion.duration).with_epsilon(0.1);
         let fade = Spring::new(self.motion.duration);
         let stack_height = spring(

--- a/crates/ui/src/accordion.rs
+++ b/crates/ui/src/accordion.rs
@@ -19,7 +19,7 @@ use gpui_base::{
 /// Critically damped, so the panel height never overshoots the measured content
 /// height. A panel toggled again mid-flight reverses from its current velocity
 /// instead of restarting.
-const PANEL_SPRING: Spring = Spring::new(0.2, 1.0);
+const PANEL_SPRING: Spring = Spring::new(0.2);
 
 /// Accordion element.
 #[derive(IntoElement)]

--- a/crates/ui/src/accordion.rs
+++ b/crates/ui/src/accordion.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
+use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc, time::Duration};
 
 use gpui::{
     AnyElement, App, AvailableSpace, Bounds, ContentMask, Element, ElementId, GlobalElementId,
@@ -19,7 +19,7 @@ use gpui_base::{
 /// Critically damped, so the panel height never overshoots the measured content
 /// height. A panel toggled again mid-flight reverses from its current velocity
 /// instead of restarting.
-const PANEL_SPRING: Spring = Spring::new(0.2);
+const PANEL_SPRING: Spring = Spring::new(Duration::from_millis(200));
 
 /// Accordion element.
 #[derive(IntoElement)]

--- a/crates/ui/src/accordion.rs
+++ b/crates/ui/src/accordion.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc, time::Duration};
+use std::{cell::RefCell, collections::HashSet, rc::Rc, sync::Arc};
 
 use gpui::{
     AnyElement, App, AvailableSpace, Bounds, ContentMask, Element, ElementId, GlobalElementId,
@@ -7,18 +7,19 @@ use gpui::{
     Window, div, percentage, prelude::FluentBuilder as _, px, relative, rems, size,
 };
 
-use crate::{
-    ActiveTheme as _, Icon, IconName, Sizable, Size, StyledExt as _, animation::ease_out_cubic,
-    h_flex,
-};
+use crate::{ActiveTheme as _, Icon, IconName, Sizable, Size, StyledExt as _, h_flex};
 use gpui_base::{
     Accordion as BaseAccordion, AccordionHeader as BaseAccordionHeader,
     AccordionItem as BaseAccordionItem, AccordionPanel as BaseAccordionPanel, AccordionTrigger,
-    Transition, transition,
+    Spring, spring,
 };
 
-/// Duration of the expand/collapse animation.
-const ANIMATION_DURATION: Duration = Duration::from_millis(200);
+/// Expand and collapse motion.
+///
+/// Critically damped, so the panel height never overshoots the measured content
+/// height. A panel toggled again mid-flight reverses from its current velocity
+/// instead of restarting.
+const PANEL_SPRING: Spring = Spring::new(0.2, 1.0);
 
 /// Accordion element.
 #[derive(IntoElement)]
@@ -416,10 +417,10 @@ impl RenderOnce for AccordionItem {
             Size::Large => rems(1.0),
             _ => rems(0.875),
         };
-        let progress = transition(
+        let progress = spring(
             (self.index, "accordion-panel"),
             if self.open { 1. } else { 0. },
-            Transition::new(ANIMATION_DURATION).ease(ease_out_cubic),
+            PANEL_SPRING,
             window,
             cx,
         );

--- a/crates/ui/src/checkbox.rs
+++ b/crates/ui/src/checkbox.rs
@@ -1,4 +1,4 @@
-use std::{rc::Rc, time::Duration};
+use std::rc::Rc;
 
 use crate::{
     ActiveTheme, Disableable, IconName, RoleOverride, Selectable, Sizable, Size, icon::IconNamed,
@@ -6,11 +6,17 @@ use crate::{
 };
 use crate::{StyledExt as _, ThemeStyled as _};
 use gpui::{
-    Animation, AnimationExt, AnyElement, App, ElementId, InteractiveElement, IntoElement,
-    MouseButton, ParentElement, RenderOnce, SharedString, StatefulInteractiveElement,
-    StyleRefinement, Styled, Window, div, prelude::FluentBuilder as _, px, relative, rems, svg,
+    AnyElement, App, ElementId, InteractiveElement, IntoElement, MouseButton, ParentElement,
+    RenderOnce, SharedString, StatefulInteractiveElement, StyleRefinement, Styled, Window, div,
+    prelude::FluentBuilder as _, px, relative, rems, svg,
 };
-use gpui_base::CheckboxIndicator;
+use gpui_base::{CheckboxIndicator, Spring, spring};
+
+/// Check-mark fade motion.
+///
+/// Critically damped, because an opacity that overshoots would clip at 1 and
+/// come back — a flicker rather than a flourish.
+const MARK_SPRING: Spring = Spring::new(0.2, 1.);
 
 /// A Checkbox element.
 #[derive(IntoElement)]
@@ -161,7 +167,16 @@ pub(crate) fn checkbox_check_icon(
     window: &mut Window,
     cx: &mut App,
 ) -> impl IntoElement {
-    let toggle_state = window.use_keyed_state(id, cx, |_, _| checked);
+    // The mark keeps its path while the spring is still fading it out. Guarding
+    // the path on `checked` alone unmounted the glyph the moment the box was
+    // cleared, so only the fade-in was ever visible.
+    let opacity = spring(
+        (id, "mark"),
+        if checked { 1. } else { 0. },
+        MARK_SPRING,
+        window,
+        cx,
+    );
     let color = if disabled {
         cx.theme().primary_foreground.opacity(0.5)
     } else {
@@ -180,33 +195,8 @@ pub(crate) fn checkbox_check_icon(
             _ => this.size_3(),
         })
         .text_color(color)
-        .map(|this| match checked {
-            true => this.path(IconName::Check.path()),
-            _ => this,
-        })
-        .map(|this| {
-            if !disabled && checked != *toggle_state.read(cx) {
-                let duration = Duration::from_secs_f64(0.25);
-                cx.spawn({
-                    let toggle_state = toggle_state.clone();
-                    async move |cx| {
-                        cx.background_executor().timer(duration).await;
-                        _ = toggle_state.update(cx, |this, _| *this = checked);
-                    }
-                })
-                .detach();
-
-                this.with_animation(
-                    ElementId::NamedInteger("toggle".into(), checked as u64),
-                    Animation::new(Duration::from_secs_f64(0.25)),
-                    move |this, delta| {
-                        this.opacity(if checked { 1.0 * delta } else { 1.0 - delta })
-                    },
-                )
-                .into_any_element()
-            } else {
-                this.into_any_element()
-            }
+        .when(opacity > 0., |this| {
+            this.path(IconName::Check.path()).opacity(opacity)
         })
 }
 

--- a/crates/ui/src/checkbox.rs
+++ b/crates/ui/src/checkbox.rs
@@ -16,7 +16,7 @@ use gpui_base::{CheckboxIndicator, Spring, spring};
 ///
 /// Critically damped, because an opacity that overshoots would clip at 1 and
 /// come back — a flicker rather than a flourish.
-const MARK_SPRING: Spring = Spring::new(0.2, 1.);
+const MARK_SPRING: Spring = Spring::new(0.2);
 
 /// A Checkbox element.
 #[derive(IntoElement)]

--- a/crates/ui/src/checkbox.rs
+++ b/crates/ui/src/checkbox.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{rc::Rc, time::Duration};
 
 use crate::{
     ActiveTheme, Disableable, IconName, RoleOverride, Selectable, Sizable, Size, icon::IconNamed,
@@ -16,7 +16,7 @@ use gpui_base::{CheckboxIndicator, Spring, spring};
 ///
 /// Critically damped, because an opacity that overshoots would clip at 1 and
 /// come back — a flicker rather than a flourish.
-const MARK_SPRING: Spring = Spring::new(0.2);
+const MARK_SPRING: Spring = Spring::new(Duration::from_millis(200));
 
 /// A Checkbox element.
 #[derive(IntoElement)]

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -1,7 +1,7 @@
 //! The gpui-component appearance for the dock area: the outer frame, the
 //! split frames, and one dock's chrome.
 
-use std::{ops::Deref as _, rc::Rc, sync::Arc};
+use std::{ops::Deref as _, rc::Rc, sync::Arc, time::Duration};
 
 use gpui::{
     AnyElement, App, AppContext as _, Axis, Context, Div, Element, Empty, InteractiveElement as _,
@@ -35,7 +35,7 @@ const CLOSED_BOTTOM_STRIP: Pixels = px(29.);
 /// window edge and pull it back. The tolerance is coarse because the value is a
 /// layout width — every frame of it re-lays out the whole dock subtree, and
 /// half a pixel of travel is not worth that.
-const DOCK_SPRING: Spring = Spring::new(0.28).with_epsilon(0.5);
+const DOCK_SPRING: Spring = Spring::new(Duration::from_millis(280)).with_epsilon(0.5);
 
 /// The transition channel naming one dock within its area.
 fn placement_channel(placement: DockPlacement) -> &'static str {

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -114,10 +114,9 @@ impl DockAreaRenderer for DockSkin {
         };
 
         // Opening and closing a dock is sprung, so the panel slides instead of
-        // appearing and vanishing. A drag drives the same value from the pointer
-        // and the handle is drawn at the dock's edge, so for the length of one
-        // the spring gives up its response and takes the size as it comes —
-        // otherwise the handle would trail the cursor.
+        // appearing and vanishing. The resize handle drives the same value from
+        // the pointer and is drawn at the dock's edge, so travel is suspended
+        // for the length of a drag or the handle would trail the cursor.
         let resizing = self.shared().resizing_dock().get() == Some(placement);
         let size = spring(
             (
@@ -125,11 +124,7 @@ impl DockAreaRenderer for DockSkin {
                 placement_channel(placement),
             ),
             target,
-            if resizing {
-                Spring::new(Duration::ZERO)
-            } else {
-                DOCK_SPRING
-            },
+            DOCK_SPRING.with_travel(!resizing),
             window,
             cx,
         );

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -35,7 +35,7 @@ const CLOSED_BOTTOM_STRIP: Pixels = px(29.);
 /// window edge and pull it back. The tolerance is coarse because the value is a
 /// layout width — every frame of it re-lays out the whole dock subtree, and
 /// half a pixel of travel is not worth that.
-const DOCK_SPRING: Spring = Spring::new(0.28, 1.).with_epsilon(0.5);
+const DOCK_SPRING: Spring = Spring::new(0.28).with_epsilon(0.5);
 
 /// The transition channel naming one dock within its area.
 fn placement_channel(placement: DockPlacement) -> &'static str {

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -8,9 +8,13 @@ use gpui::{
     IntoElement, MouseMoveEvent, MouseUpEvent, ParentElement as _, Pixels, Render, Stateful, Style,
     Styled as _, Window, div, prelude::FluentBuilder as _, px,
 };
-use gpui_base::dock::{
-    DockAreaRenderer, DockContext, DockEvent, DockPlacement, NodeId, PanelState, PanelView,
-    TabGroupRenderer, TilesRenderer,
+use gpui_base::{
+    Spring,
+    dock::{
+        DockAreaRenderer, DockContext, DockEvent, DockPlacement, NodeId, PanelState, PanelView,
+        TabGroupRenderer, TilesRenderer,
+    },
+    spring,
 };
 
 use crate::{
@@ -21,6 +25,27 @@ use crate::{
     },
     resize_handle,
 };
+
+/// The height a closed bottom dock keeps, so its tab bar stays clickable.
+const CLOSED_BOTTOM_STRIP: Pixels = px(29.);
+
+/// Open and close motion for a dock.
+///
+/// Critically damped: a dock that overshot would push the centre area past the
+/// window edge and pull it back. The tolerance is coarse because the value is a
+/// layout width — every frame of it re-lays out the whole dock subtree, and
+/// half a pixel of travel is not worth that.
+const DOCK_SPRING: Spring = Spring::new(0.28, 1.).with_epsilon(0.5);
+
+/// The transition channel naming one dock within its area.
+fn placement_channel(placement: DockPlacement) -> &'static str {
+    match placement {
+        DockPlacement::Left => "left",
+        DockPlacement::Right => "right",
+        DockPlacement::Bottom => "bottom",
+        DockPlacement::Center => "center",
+    }
+}
 
 /// The payload a dock's resize handle drags. It draws nothing: the handle
 /// itself is the affordance.
@@ -79,11 +104,32 @@ impl DockAreaRenderer for DockSkin {
         cx: &mut App,
     ) -> AnyElement {
         let placement = dock.placement();
-        let open = dock.is_open();
 
         // A closed left or right dock takes no space at all; a closed bottom
         // dock keeps a strip so its tab bar stays clickable.
-        if !open && !placement.is_bottom() {
+        let target = match (dock.is_open(), placement) {
+            (true, _) => dock.size(),
+            (false, DockPlacement::Bottom) => CLOSED_BOTTOM_STRIP,
+            (false, _) => px(0.),
+        };
+
+        // Opening and closing a dock is sprung, so the panel slides instead of
+        // appearing and vanishing. The resize handle drives the same value from
+        // the pointer and is drawn at the dock's edge, so travel is suspended
+        // for the length of a drag or the handle would trail the cursor.
+        let resizing = self.shared().resizing_dock().get() == Some(placement);
+        let size = spring(
+            (
+                ("dock-size", self.shared().area().entity_id()),
+                placement_channel(placement),
+            ),
+            target,
+            DOCK_SPRING.with_travel(!resizing),
+            window,
+            cx,
+        );
+
+        if size <= px(0.) {
             return div().into_any_element();
         }
 
@@ -93,12 +139,11 @@ impl DockAreaRenderer for DockSkin {
             .relative()
             .overflow_hidden()
             .map(|this| match placement {
-                DockPlacement::Left | DockPlacement::Right => this.h_flex().h_full().w(dock.size()),
-                DockPlacement::Bottom => this.w_full().h(dock.size()),
+                DockPlacement::Left | DockPlacement::Right => this.h_flex().h_full().w(size),
+                DockPlacement::Bottom => this.w_full().h(size),
                 // Base never builds a dock for the centre.
                 DockPlacement::Center => this,
             })
-            .when(!open && placement.is_bottom(), |this| this.h(px(29.)))
             .child(content)
             .child(self.render_resize_handle(dock, window, cx))
             .child(DockResizeTracker {

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -32,10 +32,11 @@ const CLOSED_BOTTOM_STRIP: Pixels = px(29.);
 /// Open and close motion for a dock.
 ///
 /// Critically damped: a dock that overshot would push the centre area past the
-/// window edge and pull it back. The tolerance is coarse because the value is a
-/// layout width — every frame of it re-lays out the whole dock subtree, and
-/// half a pixel of travel is not worth that.
-const DOCK_SPRING: Spring = Spring::new(Duration::from_millis(280)).with_epsilon(0.5);
+/// window edge and pull it back. The tolerance is a whole pixel, coarser than
+/// anywhere else here, because this is the most expensive value in the set — it
+/// is a layout width, so every frame of it re-lays out the entire dock subtree,
+/// and the last pixel of a slide hundreds wide is not worth one of those.
+const DOCK_SPRING: Spring = Spring::new(Duration::from_millis(280)).with_epsilon(1.);
 
 /// The transition channel naming one dock within its area.
 fn placement_channel(placement: DockPlacement) -> &'static str {

--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -114,9 +114,10 @@ impl DockAreaRenderer for DockSkin {
         };
 
         // Opening and closing a dock is sprung, so the panel slides instead of
-        // appearing and vanishing. The resize handle drives the same value from
-        // the pointer and is drawn at the dock's edge, so travel is suspended
-        // for the length of a drag or the handle would trail the cursor.
+        // appearing and vanishing. A drag drives the same value from the pointer
+        // and the handle is drawn at the dock's edge, so for the length of one
+        // the spring gives up its response and takes the size as it comes —
+        // otherwise the handle would trail the cursor.
         let resizing = self.shared().resizing_dock().get() == Some(placement);
         let size = spring(
             (
@@ -124,7 +125,11 @@ impl DockAreaRenderer for DockSkin {
                 placement_channel(placement),
             ),
             target,
-            DOCK_SPRING.with_travel(!resizing),
+            if resizing {
+                Spring::new(Duration::ZERO)
+            } else {
+                DOCK_SPRING
+            },
             window,
             cx,
         );

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -10,6 +10,7 @@ use std::{
     collections::HashSet,
     rc::Rc,
     sync::Arc,
+    time::Duration,
 };
 
 use gpui::{
@@ -51,7 +52,7 @@ const DRAG_PREVIEW_SIZE: gpui::Size<gpui::Pixels> = gpui::size(px(96.), px(30.))
 /// Critically damped, so the placeholder never reads as covering a region the
 /// drop would not take. The tolerance is coarse: this runs during a drag, where
 /// a frame spent on half a pixel competes with the drag itself.
-const PLACEHOLDER_SPRING: Spring = Spring::new(0.2).with_epsilon(0.5);
+const PLACEHOLDER_SPRING: Spring = Spring::new(Duration::from_millis(200)).with_epsilon(0.5);
 
 /// The preview that follows the cursor while a panel is dragged.
 ///

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -10,24 +10,26 @@ use std::{
     collections::HashSet,
     rc::Rc,
     sync::Arc,
-    time::Duration,
 };
 
 use gpui::{
-    Anchor, Animation, AnimationExt as _, AnyElement, AnyView, App, AppContext as _, Context, Div,
-    Empty, InteractiveElement as _, IntoElement, ParentElement as _, Point, Render, ScrollHandle,
-    SharedString, Stateful, StatefulInteractiveElement as _, StyleRefinement, Styled as _, Window,
-    div, prelude::FluentBuilder as _, px,
+    Anchor, AnyElement, AnyView, App, AppContext as _, Context, Div, Empty,
+    InteractiveElement as _, IntoElement, ParentElement as _, Render, ScrollHandle, SharedString,
+    Stateful, StatefulInteractiveElement as _, StyleRefinement, Styled as _, Window, div,
+    prelude::FluentBuilder as _, px,
 };
-use gpui_base::dock::{
-    AnyDrag, DockPlacement, DragPanel, DropIndicator, NodeId, PaneNode, PaneRef, PanelId,
-    TabGroupContext, TabGroupRenderer,
+use gpui_base::{
+    Spring,
+    dock::{
+        AnyDrag, DockPlacement, DragPanel, DropIndicator, NodeId, PaneNode, PaneRef, PanelId,
+        TabGroupContext, TabGroupRenderer,
+    },
+    spring,
 };
 use rust_i18n::t;
 
 use crate::{
     ActiveTheme as _, IconName, Selectable as _, Sizable as _,
-    animation::{Lerp as _, ease_out_cubic},
     button::{Button, ButtonVariants as _},
     dock::{ClosePanel, PanelControl, PanelHandle, PanelStyle, SkinShared, ToggleZoom},
     h_flex,
@@ -43,6 +45,13 @@ const ZOOM_CONTROL_SELECTOR: &str = "dock-tab-bar-zoom-control";
 /// The size the styled drag preview occupies, reported to base so a drop
 /// placeholder knows where to fly in from.
 const DRAG_PREVIEW_SIZE: gpui::Size<gpui::Pixels> = gpui::size(px(96.), px(30.));
+
+/// Motion for the drop placeholder as it follows the drop that would land.
+///
+/// Critically damped, so the placeholder never reads as covering a region the
+/// drop would not take. The tolerance is coarse: this runs during a drag, where
+/// a frame spent on half a pixel competes with the drag itself.
+const PLACEHOLDER_SPRING: Spring = Spring::new(0.2, 1.).with_epsilon(0.5);
 
 /// The preview that follows the cursor while a panel is dragged.
 ///
@@ -743,40 +752,41 @@ impl TabGroupRenderer for TabGroupSkin {
     fn render_drop_indicator(
         &self,
         indicator: DropIndicator,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut App,
     ) -> Option<AnyElement> {
-        let (from, to) = (indicator.from(), indicator.to());
-        // The placeholder animates from wherever it was to where the drop
-        // would land, so its own element is positioned at the destination and
-        // the animation only has to walk the difference back to zero.
-        let offset = from.origin() - to.origin();
+        let to = indicator.to();
+        // The placeholder chases the drop it would land in. Its rect was
+        // previously replayed from the drag source on every epoch, so crossing
+        // several drop zones in one drag restarted the walk at each one; the
+        // springs carry it through instead, and the element no longer needs an
+        // outer frame to hold the destination while an inner one walks to it.
+        let id = "drop-placeholder";
+        let left = spring((id, "left"), to.origin().x, PLACEHOLDER_SPRING, window, cx);
+        let top = spring((id, "top"), to.origin().y, PLACEHOLDER_SPRING, window, cx);
+        let width = spring(
+            (id, "width"),
+            to.size().width,
+            PLACEHOLDER_SPRING,
+            window,
+            cx,
+        );
+        let height = spring(
+            (id, "height"),
+            to.size().height,
+            PLACEHOLDER_SPRING,
+            window,
+            cx,
+        );
 
         Some(
             div()
                 .absolute()
-                .left(to.origin().x)
-                .top(to.origin().y)
-                .w(to.size().width)
-                .h(to.size().height)
-                .child(
-                    div()
-                        .absolute()
-                        .bg(cx.theme().tokens.drop_target)
-                        .with_animation(
-                            gpui::ElementId::NamedInteger(
-                                "drop-placeholder".into(),
-                                indicator.epoch(),
-                            ),
-                            Animation::new(Duration::from_millis(150)).with_easing(ease_out_cubic),
-                            move |this, delta| {
-                                let origin = offset.lerp(&Point::default(), delta);
-                                let width = from.size().width.lerp(&to.size().width, delta);
-                                let height = from.size().height.lerp(&to.size().height, delta);
-                                this.left(origin.x).top(origin.y).w(width).h(height)
-                            },
-                        ),
-                )
+                .bg(cx.theme().tokens.drop_target)
+                .left(left)
+                .top(top)
+                .w(width)
+                .h(height)
                 .into_any_element(),
         )
     }

--- a/crates/ui/src/dock/tab_panel.rs
+++ b/crates/ui/src/dock/tab_panel.rs
@@ -51,7 +51,7 @@ const DRAG_PREVIEW_SIZE: gpui::Size<gpui::Pixels> = gpui::size(px(96.), px(30.))
 /// Critically damped, so the placeholder never reads as covering a region the
 /// drop would not take. The tolerance is coarse: this runs during a drag, where
 /// a frame spent on half a pixel competes with the drag itself.
-const PLACEHOLDER_SPRING: Spring = Spring::new(0.2, 1.).with_epsilon(0.5);
+const PLACEHOLDER_SPRING: Spring = Spring::new(0.2).with_epsilon(0.5);
 
 /// The preview that follows the cursor while a panel is dragged.
 ///

--- a/crates/ui/src/slider.rs
+++ b/crates/ui/src/slider.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crate::{ActiveTheme, AxisExt, StyledExt, ThemeStyled as _};
 pub use gpui_base::slider::{SliderEvent, SliderScale, SliderState, SliderValue};
@@ -20,7 +20,7 @@ const THUMB_RING_OPACITY: f32 = 0.5;
 /// A click presses and releases faster than the ring finishes growing, so the
 /// ring is sprung to decelerate through the reversal. Critically damped, so it
 /// never grows past the ring width the thumb reserves for it.
-const THUMB_RING_SPRING: Spring = Spring::new(0.15);
+const THUMB_RING_SPRING: Spring = Spring::new(Duration::from_millis(150));
 
 /// The animated hover ring of one thumb.
 struct ThumbRing {

--- a/crates/ui/src/slider.rs
+++ b/crates/ui/src/slider.rs
@@ -1,10 +1,8 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use crate::{ActiveTheme, AxisExt, StyledExt, ThemeStyled as _, animation::ease_out_cubic};
+use crate::{ActiveTheme, AxisExt, StyledExt, ThemeStyled as _};
 pub use gpui_base::slider::{SliderEvent, SliderScale, SliderState, SliderValue};
-use gpui_base::{
-    Slider as BaseSlider, SliderIndicator, SliderThumb, SliderTrack, Transition, transition,
-};
+use gpui_base::{Slider as BaseSlider, SliderIndicator, SliderThumb, SliderTrack, Spring, spring};
 
 use gpui::{
     App, Axis, Background, Corners, DefiniteLength, ElementId, Entity, EntityId, Hsla,
@@ -17,8 +15,12 @@ use gpui::{
 const THUMB_RING_WIDTH: Pixels = px(3.);
 /// Opacity of the fully grown thumb ring.
 const THUMB_RING_OPACITY: f32 = 0.5;
-/// Duration of the thumb ring grow/shrink animation.
-const THUMB_RING_DURATION: Duration = Duration::from_millis(150);
+/// Thumb ring grow and shrink motion.
+///
+/// A click presses and releases faster than the ring finishes growing, so the
+/// ring is sprung to decelerate through the reversal. Critically damped, so it
+/// never grows past the ring width the thumb reserves for it.
+const THUMB_RING_SPRING: Spring = Spring::new(0.15, 1.);
 
 /// The animated hover ring of one thumb.
 struct ThumbRing {
@@ -53,14 +55,14 @@ impl ThumbRing {
             cx,
             |_, _| ThumbInteraction::default(),
         );
-        let progress = transition(
+        let progress = spring(
             (("slider-thumb-ring", id), channel),
             if interaction.read(cx).is_active() {
                 1.
             } else {
                 0.
             },
-            Transition::new(THUMB_RING_DURATION).ease(ease_out_cubic),
+            THUMB_RING_SPRING,
             window,
             cx,
         );

--- a/crates/ui/src/slider.rs
+++ b/crates/ui/src/slider.rs
@@ -20,7 +20,7 @@ const THUMB_RING_OPACITY: f32 = 0.5;
 /// A click presses and releases faster than the ring finishes growing, so the
 /// ring is sprung to decelerate through the reversal. Critically damped, so it
 /// never grows past the ring width the thumb reserves for it.
-const THUMB_RING_SPRING: Spring = Spring::new(0.15, 1.);
+const THUMB_RING_SPRING: Spring = Spring::new(0.15);
 
 /// The animated hover ring of one thumb.
 struct ThumbRing {

--- a/crates/ui/src/switch.rs
+++ b/crates/ui/src/switch.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 ///
 /// Critically damped: the thumb slides inside a track it must not leave, so an
 /// overshoot would push it through the border.
-const THUMB_SPRING: Spring = Spring::new(0.18, 1.).with_epsilon(0.1);
+const THUMB_SPRING: Spring = Spring::new(0.18).with_epsilon(0.1);
 
 /// A Switch element that can be toggled on or off.
 #[derive(IntoElement)]

--- a/crates/ui/src/switch.rs
+++ b/crates/ui/src/switch.rs
@@ -2,12 +2,18 @@ use crate::{
     ActiveTheme, Disableable, Side, Sizable, Size, StyledExt, text::Text, tooltip::ComponentTooltip,
 };
 use gpui::{
-    Animation, AnimationExt as _, App, Background, ElementId, Hsla, InteractiveElement,
-    IntoElement, ParentElement as _, RenderOnce, SharedString, StyleRefinement, Styled, Window,
-    div, prelude::FluentBuilder as _, px,
+    App, Background, ElementId, Hsla, InteractiveElement, IntoElement, ParentElement as _,
+    RenderOnce, SharedString, StyleRefinement, Styled, Window, div, prelude::FluentBuilder as _,
+    px,
 };
-use gpui_base::{Switch as BaseSwitch, SwitchThumb, SwitchTrack};
-use std::{rc::Rc, time::Duration};
+use gpui_base::{Spring, Switch as BaseSwitch, SwitchThumb, SwitchTrack, spring};
+use std::rc::Rc;
+
+/// Thumb travel motion.
+///
+/// Critically damped: the thumb slides inside a track it must not leave, so an
+/// overshoot would push it through the border.
+const THUMB_SPRING: Spring = Spring::new(0.18, 1.).with_epsilon(0.1);
 
 /// A Switch element that can be toggled on or off.
 #[derive(IntoElement)]
@@ -101,7 +107,6 @@ impl RenderOnce for Switch {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let checked = self.checked;
         let on_click = self.on_click.clone();
-        let toggle_state = window.use_keyed_state(self.id.clone(), cx, |_, _| checked);
 
         let checked_bg = self
             .color
@@ -126,6 +131,23 @@ impl RenderOnce for Switch {
             cx.theme().radius
         };
 
+        // The thumb's position is geometry, not a semantic state style: a
+        // `checked` style setting `left` outranks the instance style by the
+        // documented precedence, which left the travel visible in one direction
+        // only. The spring owns it end to end and reverses from wherever the
+        // thumb is when the switch is toggled again mid-travel.
+        let thumb_x = spring(
+            (self.id.clone(), "thumb"),
+            if checked {
+                bg_width - bar_width - inset * 2
+            } else {
+                px(0.)
+            },
+            THUMB_SPRING,
+            window,
+            cx,
+        );
+
         div().refine_style(&self.style).child(
             BaseSwitch::new(self.id.clone())
                 .checked(checked)
@@ -135,11 +157,7 @@ impl RenderOnce for Switch {
                     |this, label| this.accessibility_label(label),
                 )
                 .when_some(on_click, |this, on_click| {
-                    let toggle_state = toggle_state.clone();
-                    this.on_change(move |next, _, window, cx| {
-                        _ = toggle_state.update(cx, |this, _| *this = checked);
-                        on_click(&next, window, cx);
-                    })
+                    this.on_change(move |next, _, window, cx| on_click(&next, window, cx))
                 })
                 .h_flex()
                 .gap_2()
@@ -175,48 +193,11 @@ impl RenderOnce for Switch {
                                 .disabled(self.disabled)
                                 .rounded(radius)
                                 .size(bar_width)
-                                .when(!checked, |this| this.left(px(0.)))
+                                .left(thumb_x)
                                 .when(!self.disabled, |this| this.bg(toggle_bg))
                                 .styles(|styles| {
                                     styles
-                                        .checked(|style| {
-                                            style.left(bg_width - bar_width - inset * 2)
-                                        })
                                         .disabled(|style| style.bg(toggle_bg.clone().opacity(0.35)))
-                                })
-                                .map(|this| {
-                                    let prev_checked = toggle_state.read(cx);
-                                    if !self.disabled && *prev_checked != checked {
-                                        let duration = Duration::from_secs_f64(0.15);
-                                        cx.spawn({
-                                            let toggle_state = toggle_state.clone();
-                                            async move |cx| {
-                                                cx.background_executor().timer(duration).await;
-                                                _ = toggle_state
-                                                    .update(cx, |this, _| *this = checked);
-                                            }
-                                        })
-                                        .detach();
-
-                                        this.with_animation(
-                                            ElementId::NamedInteger("move".into(), checked as u64),
-                                            Animation::new(duration),
-                                            move |this, delta| {
-                                                let max_x = bg_width - bar_width - inset * 2;
-                                                let x = if checked {
-                                                    max_x * delta
-                                                } else {
-                                                    max_x - max_x * delta
-                                                };
-                                                this.left(x)
-                                            },
-                                        )
-                                        .into_any_element()
-                                    } else {
-                                        let max_x = bg_width - bar_width - inset * 2;
-                                        let x = if checked { max_x } else { px(0.) };
-                                        this.left(x).into_any_element()
-                                    }
                                 }),
                         ),
                 )

--- a/crates/ui/src/switch.rs
+++ b/crates/ui/src/switch.rs
@@ -7,13 +7,13 @@ use gpui::{
     px,
 };
 use gpui_base::{Spring, Switch as BaseSwitch, SwitchThumb, SwitchTrack, spring};
-use std::rc::Rc;
+use std::{rc::Rc, time::Duration};
 
 /// Thumb travel motion.
 ///
 /// Critically damped: the thumb slides inside a track it must not leave, so an
 /// overshoot would push it through the border.
-const THUMB_SPRING: Spring = Spring::new(0.18).with_epsilon(0.1);
+const THUMB_SPRING: Spring = Spring::new(Duration::from_millis(180)).with_epsilon(0.1);
 
 /// A Switch element that can be toggled on or off.
 #[derive(IntoElement)]

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -24,7 +24,7 @@ use crate::{
 /// coarsened from the normalized default to end the animation once the
 /// remaining travel is sub-pixel.
 const INDICATOR_SPRING: Spring = Spring::new(Duration::from_millis(250))
-    .with_damping_ratio(0.85)
+    .with_damping(0.85)
     .with_epsilon(0.1);
 
 struct TabIndicatorBounds {

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -24,7 +24,7 @@ use crate::{
 /// coarsened from the normalized default to end the animation once the
 /// remaining travel is sub-pixel.
 const INDICATOR_SPRING: Spring = Spring::new(Duration::from_millis(250))
-    .with_damping(0.85)
+    .with_damping_ratio(0.85)
     .with_epsilon(0.1);
 
 struct TabIndicatorBounds {

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -1,22 +1,28 @@
-use std::{cell::RefCell, rc::Rc, time::Duration};
+use std::{cell::RefCell, rc::Rc};
 
 use gpui::{
-    Anchor, Animation, AnimationExt as _, AnyElement, App, Background, Bounds, Edges, ElementId,
-    InteractiveElement, IntoElement, ParentElement, Pixels, RenderOnce, ScrollHandle, SharedString,
-    StatefulInteractiveElement as _, StyleRefinement, Styled, Window, div,
-    prelude::FluentBuilder as _, px,
+    Anchor, AnyElement, App, Background, Bounds, Edges, ElementId, InteractiveElement, IntoElement,
+    ParentElement, Pixels, RenderOnce, ScrollHandle, SharedString, StatefulInteractiveElement as _,
+    StyleRefinement, Styled, Window, div, prelude::FluentBuilder as _, px,
 };
+use gpui_base::{Spring, spring};
 use rust_i18n::t;
 use smallvec::SmallVec;
 
 use super::{Tab, TabVariant};
-use crate::animation::{Lerp, ease_in_out_cubic};
 use crate::button::{Button, ButtonVariants as _};
 use crate::menu::{DropdownMenu as _, PopupMenuItem};
 use crate::{
     ActiveTheme, ElementExt, Icon, InteractiveElementExt as _, Selectable, Sizable, Size,
     StyledExt, h_flex,
 };
+
+/// Slide motion for the selected-tab indicator.
+///
+/// Settling is measured in pixels, so the tolerance is coarsened from the
+/// normalized default to end the animation once the remaining travel is
+/// sub-pixel.
+const INDICATOR_SPRING: Spring = Spring::SNAPPY.with_epsilon(0.1);
 
 struct TabIndicatorBounds {
     container: Bounds<Pixels>,
@@ -202,9 +208,8 @@ impl TabBar {
         let init_key = format!("{}-tab-init", self.id);
 
         let prev_selected = window.use_keyed_state(prev_key, cx, |_, _| selected_ix);
-        // (from_left, from_width, to_left, to_width, epoch)
-        let anim_params =
-            window.use_keyed_state(anim_key, cx, |_, _| (px(0.), px(0.), px(0.), px(0.), 0u64));
+        // (to_left, to_width, epoch)
+        let anim_params = window.use_keyed_state(anim_key, cx, |_, _| (px(0.), px(0.), 0u64));
         let initialized = window.use_keyed_state(init_key, cx, |_, _| false);
 
         // First frame: trigger re-render to capture bounds via on_prepaint
@@ -214,10 +219,29 @@ impl TabBar {
 
         self.update_anim_params(selected_ix, bounds_rc, &prev_selected, &anim_params, cx);
 
-        let (from_left, from_width, to_left, to_width, epoch) = *anim_params.read(cx);
+        let (to_left, to_width, epoch) = *anim_params.read(cx);
         if to_width <= px(0.) {
             return None;
         }
+
+        // The springs hold the indicator's own position and velocity, so a tab
+        // switched again mid-slide is redirected from where the indicator
+        // actually is rather than restarted from the tab it left.
+        let indicator_key = format!("{}-tab-indicator", self.id);
+        let left = spring(
+            (indicator_key.clone(), "left"),
+            to_left,
+            INDICATOR_SPRING,
+            window,
+            cx,
+        );
+        let width = spring(
+            (indicator_key, "width"),
+            to_width,
+            INDICATOR_SPRING,
+            window,
+            cx,
+        );
 
         let variant = self.variant;
         let size = self.size;
@@ -228,6 +252,8 @@ impl TabBar {
             .absolute()
             .top_0()
             .bottom_0()
+            .left(left)
+            .w(width)
             .map(|el| match variant {
                 TabVariant::Segmented => el.flex().items_center().child(
                     div()
@@ -253,16 +279,7 @@ impl TabBar {
                         .bg(cx.theme().tokens.primary),
                 ),
                 _ => el,
-            })
-            .with_animation(
-                ElementId::NamedInteger("tab-ind".into(), epoch),
-                Animation::new(Duration::from_millis(200)).with_easing(ease_in_out_cubic),
-                move |el, delta| {
-                    let left = Lerp::lerp(&from_left, &to_left, delta);
-                    let width = Lerp::lerp(&from_width, &to_width, delta);
-                    el.left(left).w(width)
-                },
-            );
+            });
 
         Some((indicator.into_any_element(), epoch))
     }
@@ -273,7 +290,7 @@ impl TabBar {
         selected_ix: usize,
         bounds_rc: &Option<Rc<RefCell<TabIndicatorBounds>>>,
         prev_selected: &gpui::Entity<usize>,
-        anim_params: &gpui::Entity<(Pixels, Pixels, Pixels, Pixels, u64)>,
+        anim_params: &gpui::Entity<(Pixels, Pixels, u64)>,
         cx: &mut App,
     ) {
         let rc = match bounds_rc {
@@ -293,25 +310,17 @@ impl TabBar {
         }
 
         if prev_ix != selected_ix {
-            let from_b = bounds.tabs.get(prev_ix);
-            let to_b = bounds.tabs.get(selected_ix);
-            match (from_b, to_b) {
-                (Some(from_b), Some(to_b)) => {
-                    let from_left = from_b.origin.x - container.origin.x;
-                    let from_width = from_b.size.width;
-                    let to_left = to_b.origin.x - container.origin.x;
-                    let to_width = to_b.size.width;
-                    let epoch = anim_params.read(cx).4 + 1;
-                    anim_params.update(cx, |v, _| {
-                        *v = (from_left, from_width, to_left, to_width, epoch)
-                    });
-                }
-                (None, Some(to_b)) => {
-                    let left = to_b.origin.x - container.origin.x;
-                    let width = to_b.size.width;
-                    anim_params.update(cx, |v, _| *v = (left, width, left, width, v.4));
-                }
-                _ => {}
+            if let Some(to_b) = bounds.tabs.get(selected_ix) {
+                let left = to_b.origin.x - container.origin.x;
+                let width = to_b.size.width;
+                // Only a switch away from a tab that still exists restarts the
+                // tabs' own epoch-keyed transitions.
+                let epoch = anim_params.read(cx).2;
+                let epoch = match bounds.tabs.get(prev_ix) {
+                    Some(_) => epoch + 1,
+                    None => epoch,
+                };
+                anim_params.update(cx, |v, _| *v = (left, width, epoch));
             }
             drop(bounds);
             prev_selected.update(cx, |v, _| *v = selected_ix);
@@ -321,15 +330,10 @@ impl TabBar {
         if let Some(to_b) = bounds.tabs.get(selected_ix) {
             let left = to_b.origin.x - container.origin.x;
             let width = to_b.size.width;
-            let (_, _, to_left, to_width, epoch) = *anim_params.read(cx);
-
-            if to_width == px(0.) {
-                anim_params.update(cx, |v, _| *v = (left, width, left, width, epoch));
-                return;
-            }
+            let (to_left, to_width, epoch) = *anim_params.read(cx);
 
             if left != to_left || width != to_width {
-                anim_params.update(cx, |v, _| *v = (left, width, left, width, epoch));
+                anim_params.update(cx, |v, _| *v = (left, width, epoch));
             }
         }
     }

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -23,7 +23,7 @@ use crate::{
 /// than stopping dead. Settling is measured in pixels, so the tolerance is
 /// coarsened from the normalized default to end the animation once the
 /// remaining travel is sub-pixel.
-const INDICATOR_SPRING: Spring = Spring::new(0.25, 0.85).with_epsilon(0.1);
+const INDICATOR_SPRING: Spring = Spring::new(0.25).with_damping(0.85).with_epsilon(0.1);
 
 struct TabIndicatorBounds {
     container: Bounds<Pixels>,

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, rc::Rc, time::Duration};
 
 use gpui::{
     Anchor, AnyElement, App, Background, Bounds, Edges, ElementId, InteractiveElement, IntoElement,
@@ -23,7 +23,9 @@ use crate::{
 /// than stopping dead. Settling is measured in pixels, so the tolerance is
 /// coarsened from the normalized default to end the animation once the
 /// remaining travel is sub-pixel.
-const INDICATOR_SPRING: Spring = Spring::new(0.25).with_damping(0.85).with_epsilon(0.1);
+const INDICATOR_SPRING: Spring = Spring::new(Duration::from_millis(250))
+    .with_damping(0.85)
+    .with_epsilon(0.1);
 
 struct TabIndicatorBounds {
     container: Bounds<Pixels>,

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -19,10 +19,11 @@ use crate::{
 
 /// Slide motion for the selected-tab indicator.
 ///
-/// Settling is measured in pixels, so the tolerance is coarsened from the
-/// normalized default to end the animation once the remaining travel is
-/// sub-pixel.
-const INDICATOR_SPRING: Spring = Spring::SNAPPY.with_epsilon(0.1);
+/// Slightly underdamped, so the indicator arrives with a hint of weight rather
+/// than stopping dead. Settling is measured in pixels, so the tolerance is
+/// coarsened from the normalized default to end the animation once the
+/// remaining travel is sub-pixel.
+const INDICATOR_SPRING: Spring = Spring::new(0.25, 0.85).with_epsilon(0.1);
 
 struct TabIndicatorBounds {
     container: Bounds<Pixels>,

--- a/docs/STYLING-AND-MOTION.md
+++ b/docs/STYLING-AND-MOTION.md
@@ -224,7 +224,7 @@ let left = gpui_base::spring(
     ("tab-indicator", "left"),
     selected_tab_left,
     gpui_base::Spring::new(Duration::from_millis(250))
-        .with_damping(0.85)
+        .with_damping_ratio(0.85)
         .with_epsilon(0.1),
     window,
     cx,
@@ -253,7 +253,7 @@ let size = spring(id, target, DOCK_SPRING.with_travel(!resizing), window, cx);
 `Spring::new(response)` builds one that reaches its target in about that long
 without overshooting it, which is what almost every value wants: a spring
 driving an opacity, a measured height, or anything bounded by the geometry
-around it has nowhere to overshoot to. `with_damping` opts a value out where
+around it has nowhere to overshoot to. `with_damping_ratio` opts a value out where
 passing the target and coming back is the intended effect.
 
 A response is not a duration in the sense `Transition::new` means one. A spring

--- a/docs/STYLING-AND-MOTION.md
+++ b/docs/STYLING-AND-MOTION.md
@@ -223,7 +223,7 @@ spring instead:
 let left = gpui_base::spring(
     ("tab-indicator", "left"),
     selected_tab_left,
-    gpui_base::Spring::SNAPPY.with_epsilon(0.1),
+    gpui_base::Spring::new(0.25, 0.85).with_epsilon(0.1),
     window,
     cx,
 );
@@ -249,7 +249,7 @@ let size = spring(id, target, DOCK_SPRING.with_travel(!resizing), window, cx);
 ```
 
 `Spring::new(response_seconds, damping_ratio)` builds one from perceptual
-parameters, with `SMOOTH`, `SNAPPY`, and `BOUNCY` as named starting points. A
+parameters. A
 damping ratio below `1.0` overshoots, so a spring driving a value with a
 meaningful ceiling — an opacity, a measured height — must be critically damped.
 The settling tolerance is expressed in the target's own units and defaults to a

--- a/docs/STYLING-AND-MOTION.md
+++ b/docs/STYLING-AND-MOTION.md
@@ -223,7 +223,9 @@ spring instead:
 let left = gpui_base::spring(
     ("tab-indicator", "left"),
     selected_tab_left,
-    gpui_base::Spring::new(0.25).with_damping(0.85).with_epsilon(0.1),
+    gpui_base::Spring::new(Duration::from_millis(250))
+        .with_damping(0.85)
+        .with_epsilon(0.1),
     window,
     cx,
 );
@@ -248,11 +250,16 @@ drag released it:
 let size = spring(id, target, DOCK_SPRING.with_travel(!resizing), window, cx);
 ```
 
-`Spring::new(response_seconds)` builds one that reaches its target in about that
-long without overshooting it, which is what almost every value wants: a spring
+`Spring::new(response)` builds one that reaches its target in about that long
+without overshooting it, which is what almost every value wants: a spring
 driving an opacity, a measured height, or anything bounded by the geometry
 around it has nowhere to overshoot to. `with_damping` opts a value out where
 passing the target and coming back is the intended effect.
+
+A response is not a duration in the sense `Transition::new` means one. A spring
+has no end to schedule, so this is the scale the motion is felt at rather than
+the moment it stops: the last fraction of a percent keeps settling past it,
+until it is inside the tolerance below.
 
 The settling tolerance is expressed in the target's own units and defaults to a
 normalized `0..1` range; a spring over pixels should coarsen it so the animation

--- a/docs/STYLING-AND-MOTION.md
+++ b/docs/STYLING-AND-MOTION.md
@@ -241,13 +241,14 @@ chasing rapid selection changes, a panel toggled again mid-slide — and a
 transition where the target is set once and runs to completion.
 
 A value that the pointer is already moving must not be sprung while the drag
-lasts, or it trails the cursor. `Spring::with_travel(false)` suspends travel and
-keeps the retained state pinned to the target, so the same call site can hand
-the value straight through during a drag and resume springing from where the
-drag released it:
+lasts, or it trails the cursor. A zero response adopts the target on the spot,
+exactly as a zero duration does for a transition, and keeps the retained state
+pinned to it — so one call site can hand the value straight through during a
+drag and resume springing from where the drag released it:
 
 ```rust,ignore
-let size = spring(id, target, DOCK_SPRING.with_travel(!resizing), window, cx);
+let policy = if resizing { Spring::new(Duration::ZERO) } else { DOCK_SPRING };
+let size = spring(id, target, policy, window, cx);
 ```
 
 `Spring::new(response)` builds one that reaches its target in about that long

--- a/docs/STYLING-AND-MOTION.md
+++ b/docs/STYLING-AND-MOTION.md
@@ -223,7 +223,7 @@ spring instead:
 let left = gpui_base::spring(
     ("tab-indicator", "left"),
     selected_tab_left,
-    gpui_base::Spring::new(0.25, 0.85).with_epsilon(0.1),
+    gpui_base::Spring::new(0.25).with_damping(0.85).with_epsilon(0.1),
     window,
     cx,
 );
@@ -248,10 +248,12 @@ drag released it:
 let size = spring(id, target, DOCK_SPRING.with_travel(!resizing), window, cx);
 ```
 
-`Spring::new(response_seconds, damping_ratio)` builds one from perceptual
-parameters. A
-damping ratio below `1.0` overshoots, so a spring driving a value with a
-meaningful ceiling — an opacity, a measured height — must be critically damped.
+`Spring::new(response_seconds)` builds one that reaches its target in about that
+long without overshooting it, which is what almost every value wants: a spring
+driving an opacity, a measured height, or anything bounded by the geometry
+around it has nowhere to overshoot to. `with_damping` opts a value out where
+passing the target and coming back is the intended effect.
+
 The settling tolerance is expressed in the target's own units and defaults to a
 normalized `0..1` range; a spring over pixels should coarsen it so the animation
 ends when the remaining travel is sub-pixel rather than running frames that

--- a/docs/STYLING-AND-MOTION.md
+++ b/docs/STYLING-AND-MOTION.md
@@ -224,7 +224,7 @@ let left = gpui_base::spring(
     ("tab-indicator", "left"),
     selected_tab_left,
     gpui_base::Spring::new(Duration::from_millis(250))
-        .with_damping_ratio(0.85)
+        .with_damping(0.85)
         .with_epsilon(0.1),
     window,
     cx,
@@ -253,7 +253,7 @@ let size = spring(id, target, DOCK_SPRING.with_travel(!resizing), window, cx);
 `Spring::new(response)` builds one that reaches its target in about that long
 without overshooting it, which is what almost every value wants: a spring
 driving an opacity, a measured height, or anything bounded by the geometry
-around it has nowhere to overshoot to. `with_damping_ratio` opts a value out where
+around it has nowhere to overshoot to. `with_damping` opts a value out where
 passing the target and coming back is the intended effect.
 
 A response is not a duration in the sense `Transition::new` means one. A spring

--- a/docs/STYLING-AND-MOTION.md
+++ b/docs/STYLING-AND-MOTION.md
@@ -15,7 +15,7 @@ GPUI
 gpui-base
   defines semantic component states
   resolves semantic-state style precedence
-  provides generic value-transition lifecycle
+  provides generic value-transition and spring lifecycle
 
 application or gpui-component
   owns all target styles
@@ -216,6 +216,37 @@ The transition owns lifecycle mechanics only:
 The caller chooses what the value means and applies it to opacity, color,
 geometry, or another interpolatable property.
 
+For a value that can be retargeted while it is still moving, base provides a
+spring instead:
+
+```rust,ignore
+let left = gpui_base::spring(
+    ("tab-indicator", "left"),
+    selected_tab_left,
+    gpui_base::Spring::SNAPPY.with_epsilon(0.1),
+    window,
+    cx,
+);
+```
+
+A spring is keyed, reduced-motion aware, and frame-rate independent in the same
+way a transition is. It differs in what it carries across a target change: a
+transition restarts its easing from the value sampled at that instant, which is
+continuous in position but not in velocity, while a spring preserves velocity
+and turns the value around. Prefer a spring where the target changes faster than
+the motion completes — a toast stack that reflows as toasts arrive, an indicator
+chasing rapid selection changes, a panel toggled again mid-slide — and a
+transition where the target is set once and runs to completion.
+
+`Spring::new(response_seconds, damping_ratio)` builds one from perceptual
+parameters, with `SMOOTH`, `SNAPPY`, and `BOUNCY` as named starting points. A
+damping ratio below `1.0` overshoots, so a spring driving a value with a
+meaningful ceiling — an opacity, a measured height — must be critically damped.
+The settling tolerance is expressed in the target's own units and defaults to a
+normalized `0..1` range; a spring over pixels should coarsen it so the animation
+ends when the remaining travel is sub-pixel rather than running frames that
+change nothing visible.
+
 Deep behavior modules may own configurable motion when it is required to keep
 their internal layout lifecycle coherent. `ToastStack`, for example, combines
 measurement, overlap, expansion, and collapse through `ToastMotion`. This does
@@ -254,6 +285,11 @@ On the first render, the target is adopted immediately. When reduced motion is
 enabled or duration is zero, the target is returned immediately and retained
 transition state is synchronized with it.
 
+A spring resolves the same three moments differently. A target change keeps both
+the current position and the current velocity, so the value decelerates through
+the reversal instead of restarting. The first render adopts the target at rest.
+Reduced motion snaps to the target and clears the stored velocity.
+
 ## Supported Values
 
 `transition` accepts values implementing `Interpolate`, `Clone`, and
@@ -262,6 +298,13 @@ transition state is synchronized with it.
 
 Applications may implement `Interpolate` for their own value types when the
 interpolation is meaningful and deterministic.
+
+`spring` accepts values implementing GPUI's `SpringTarget`, which projects a
+value onto the single scalar coordinate the spring integrates and back again.
+GPUI implements it for `f32`, `Pixels`, `Rems`, and `bool`, the last resolving
+to an `AnimationPhase` that interpolates between two endpoint values. A value
+that needs more than one coordinate — a position, a pair of bounds — uses one
+spring per channel rather than one spring over the composite.
 
 ## Legacy Element Animation
 
@@ -284,5 +327,5 @@ may continue to use its module-qualified API.
 6. Disabled is the last semantic layer.
 7. Part styling is explicit and typed; base does not traverse arbitrary child
    trees to apply styles.
-8. Reduced-motion preferences are honored by generic transitions.
+8. Reduced-motion preferences are honored by generic transitions and springs.
 9. Corner radius is derived from the theme, never written as a literal.

--- a/docs/STYLING-AND-MOTION.md
+++ b/docs/STYLING-AND-MOTION.md
@@ -241,15 +241,21 @@ chasing rapid selection changes, a panel toggled again mid-slide — and a
 transition where the target is set once and runs to completion.
 
 A value that the pointer is already moving must not be sprung while the drag
-lasts, or it trails the cursor. A zero response adopts the target on the spot,
-exactly as a zero duration does for a transition, and keeps the retained state
-pinned to it — so one call site can hand the value straight through during a
-drag and resume springing from where the drag released it:
+lasts, or it trails the cursor. `Spring::with_travel(false)` suspends travel and
+keeps the retained state pinned to the target, so the same call site can hand the
+value straight through during a drag and resume springing from where the drag
+released it:
 
 ```rust,ignore
-let policy = if resizing { Spring::new(Duration::ZERO) } else { DOCK_SPRING };
-let size = spring(id, target, policy, window, cx);
+let size = spring(id, target, DOCK_SPRING.with_travel(!resizing), window, cx);
 ```
+
+Suspending travel says so where the reader is, and says it without disturbing the
+response, damping or tolerance the spring is configured with. A zero response
+resolves the same way — as a zero duration does for a transition — but it is the
+degenerate case rather than the way to express this, and a policy swapped out for
+the length of a drag has to restate or discard everything else the original one
+carried.
 
 `Spring::new(response)` builds one that reaches its target in about that long
 without overshooting it, which is what almost every value wants: a spring

--- a/docs/STYLING-AND-MOTION.md
+++ b/docs/STYLING-AND-MOTION.md
@@ -238,6 +238,16 @@ the motion completes — a toast stack that reflows as toasts arrive, an indicat
 chasing rapid selection changes, a panel toggled again mid-slide — and a
 transition where the target is set once and runs to completion.
 
+A value that the pointer is already moving must not be sprung while the drag
+lasts, or it trails the cursor. `Spring::with_travel(false)` suspends travel and
+keeps the retained state pinned to the target, so the same call site can hand
+the value straight through during a drag and resume springing from where the
+drag released it:
+
+```rust,ignore
+let size = spring(id, target, DOCK_SPRING.with_travel(!resizing), window, cx);
+```
+
 `Spring::new(response_seconds, damping_ratio)` builds one from perceptual
 parameters, with `SMOOTH`, `SNAPPY`, and `BOUNCY` as named starting points. A
 damping ratio below `1.0` overshoots, so a spring driving a value with a

--- a/skills/gpui-component/references/coding-guides.md
+++ b/skills/gpui-component/references/coding-guides.md
@@ -666,6 +666,23 @@ zero-based indices, preserve established public terms such as `selected_index`,
 and do not introduce `_idx`. If callers never construct the seam value, do not
 publish a builder merely for symmetry.
 
+### Let the enclosing name carry the context
+
+A name is read inside something. A field is read inside its type and a parameter
+inside its method, so neither repeats what encloses it: `with_item_ix(ix)`, not
+`with_item_ix(item_ix)`.
+
+Keep one type's fields at the same level of abbreviation. A single field spelled
+out in full becomes the odd one out, and a reader goes looking for the
+distinction that made it different. Because a builder is named `with_<field>`,
+shortening a field shortens its builder with it and the pair stays matched.
+
+Shorten only where the enclosing name really does disambiguate. When a short
+form is also the established term for a *different* quantity elsewhere in the
+ecosystem, say which one you mean in the doc comment rather than lengthening the
+identifier — the doc is read at the call, and it can explain what a longer name
+could only hint at.
+
 ### Use precise domain words
 
 - **selected** is persistent membership or the active item; **focused** is the

--- a/website/docs/coding-guides.md
+++ b/website/docs/coding-guides.md
@@ -666,6 +666,23 @@ zero-based indices, preserve established public terms such as `selected_index`,
 and do not introduce `_idx`. If callers never construct the seam value, do not
 publish a builder merely for symmetry.
 
+### Let the enclosing name carry the context
+
+A name is read inside something. A field is read inside its type and a parameter
+inside its method, so neither repeats what encloses it: `with_item_ix(ix)`, not
+`with_item_ix(item_ix)`.
+
+Keep one type's fields at the same level of abbreviation. A single field spelled
+out in full becomes the odd one out, and a reader goes looking for the
+distinction that made it different. Because a builder is named `with_<field>`,
+shortening a field shortens its builder with it and the pair stays matched.
+
+Shorten only where the enclosing name really does disambiguate. When a short
+form is also the established term for a *different* quantity elsewhere in the
+ecosystem, say which one you mean in the doc comment rather than lengthening the
+identifier — the doc is read at the call, and it can explain what a longer name
+could only hint at.
+
 ### Use precise domain words
 
 - **selected** is persistent membership or the active item; **focused** is the

--- a/website/zh-CN/docs/coding-guides.md
+++ b/website/zh-CN/docs/coding-guides.md
@@ -414,6 +414,20 @@ Platform branch 即使 presentation 不同，也必须保留 semantic contract�
 
 Boolean builder 可叫 `disabled(bool)`，reader 叫 `is_disabled()`。含 non-boolean field 的公开接口中的非布尔字段使用 `with_item_ix(...)` 构造、`item_ix()` 读取，避免冲突。新的局部或内部零起始索引优先使用 `_ix`，现有公开名称如 `selected_index` 保持不变，不再引入 `_idx`。调用方从不构造的快照，不要为了对称而发布构造方法。
 
+### 让外层名字承担上下文
+
+名字总是在某个东西内部被阅读。字段在它的类型内部被读到，参数在它的方法签名内部
+被读到，所以两者都不重复外层已经说过的话：`with_item_ix(ix)`，而不是
+`with_item_ix(item_ix)`。
+
+同一个类型的字段保持相同的缩写程度。其中若有一个写全了，它就成了异类，读者会去
+找那个让它与众不同的区别。又因为 builder 按 `with_<field>` 命名，缩短字段会同时
+缩短它的 builder，两者始终配对。
+
+只在外层名字确实能消除歧义时才缩短。当短形式在生态的别处同时是*另一个量*的既有
+术语时，在 doc comment 里说明你指的是哪一个，而不是把标识符加长 —— doc 是在调用处
+被读到的，它能解释清楚一个更长的名字只能暗示的东西。
+
 ### 精确区分领域词汇
 
 - **selected** 是持久 membership/active item；**focused** 是 keyboard target；**hovered** 是 pointer presence；**confirmed** 是 activation result，不能混用。


### PR DESCRIPTION
GPUI gained spring animations in zed-industries/zed#62778, twelve hours after
the commit this repo pinned. This bumps gpui and builds a `spring()` counterpart
to `gpui_base::transition()` on top of it, then applies it where it earns its
keep.

## Why a spring

`transition()` already owns keyed state, reduced-motion handling, and reversal
from the currently sampled value. The one thing it cannot do is carry *velocity*
across a target change: it restarts its easing from the value sampled at that
instant, so a value reversed mid-flight jumps to the new curve's initial speed.
A spring turns it around instead.

So the rule applied throughout: **spring where the target changes faster than
the motion completes, transition where the target is set once and runs to
completion.** One-shot enters — dialog, sheet, popover — are deliberately left
as they are.

## What moved

| | Before | After |
|---|---|---|
| Tab indicator | keyed on an epoch that incremented per switch, so every switch replayed a full 200ms slide from the tab it left | two springs hold the indicator's own position |
| Toast stack | four fixed-duration transitions, retargeted on every arrival and dismissal | sprung; `ToastMotion::duration` now sets the response, so the existing knob still works and no public field is added |
| Drop placeholder | keyed on the drop epoch, so crossing several zones in one drag replayed the walk from the drag source at each one | the rect chases the drop continuously |
| Dock open/close | a closed left/right dock returned an empty element, so the centre snapped across the width it had held | the dock's size is sprung, so it slides |
| Accordion panel | 200ms ease-out | reverses from its current height when toggled mid-flight |
| Slider press ring | 150ms ease-out, and a click reverses it mid-grow | sprung |

## Two of these were not visible at all

- **Switch**: `SwitchThumb`'s `checked` style set `left`, which outranks the
  instance style the animation wrote by the documented precedence — so only the
  travel back to the *off* position ever played. Position is geometry, so the
  spring owns it outright now and the semantic style keeps only colour.
- **Checkbox**: the mark's path was mounted on `checked`, so clearing the box
  unmounted the glyph before the fade could run. The path now stays while the
  spring is still fading it out.

Both also retire a per-toggle spawned timer that existed only to drive the
previous animation's keyed restart.

## `Spring::with_travel`

The dock's resize handle drives the dock's size from the pointer and is drawn at
the dock's own edge, so springing it during a drag would leave the handle
trailing the cursor. `with_travel(false)` suspends travel and pins the retained
state to the target, so the value passes straight through for the length of the
drag and travel resumes from where the drag released it.

A zero response resolves the same way, as a zero duration does for a transition,
and is defined so the degenerate input does not divide by its own period. It is
not the way to say this, though: a policy swapped out for the length of a drag
has to restate or discard the response, damping and tolerance the original one
carried, and it trades a fluent builder for a branch at the call.

## Deliberately not done

- **Slider thumb** stays unsprung: it must track the pointer exactly, and
  removing a dragged target's lag needs `SpringConfig::step_ramp`, which takes a
  target velocity this API does not carry.
- **The base resize handle's active colour** and **`ResizablePanel::visible`**
  are painted in `gpui-base`, and `crates/ui` re-exports `ResizablePanel`
  unchanged, so there is no skin seam to put motion in. Giving either one motion
  means the `ScrollbarMotion` treatment — a zero default with the styled layer
  projecting timing — which is a design decision, not a swap.
- **Dock zoom** swaps whole subtrees rather than moving a value, so it needs a
  crossfade rather than a spring.
- The drop placeholder no longer flies in from the dragged tab on its first
  appearance, because a spring adopts its first target at rest. Restoring it
  needs an origin entry point (gpui spells it `SpringAnimation::from`).

## What a resting spring costs

A read and two comparisons. `spring` returns before it builds a `SpringConfig`
when the value is already at rest on its target, which is the state almost every
spring is in on almost every frame.

It did not, at first, and that showed up as drag lag somewhere else entirely: a
drag re-renders whole subtrees, so every checkbox, switch and slider ring inside
a resizing panel was integrating a spring — two square roots, an exponential and
a sin_cos — on every frame of the drag, to be told it had not moved. The symptom
was a stuttering resize; the cost was in leaves that had nothing to do with it.

## Notes

## API surface

Nothing existing is removed or changed. `Transition`, `transition()`,
`Interpolate`, `TransitionId` and every component's builder are untouched, so
this is additive for consumers.

The additions are held to what shipped code calls — five items in `gpui-base`,
plus the re-export line:

```rust
pub struct Spring;                                        // opaque; no public fields
impl Spring {
    pub const fn new(response: Duration) -> Self;         // critically damped
    pub const fn with_damping(mut self, ratio: f32) -> Self;
    pub const fn with_epsilon(mut self, epsilon: f32) -> Self;
    pub const fn with_travel(mut self, travel: bool) -> Self;
}
pub fn spring<T: SpringTarget>(id, target: T, policy: Spring, window, cx) -> T::Output;
```

Two earlier revisions carried more. `from_config`, the `config` / `epsilon` /
`travel` readers, and `SMOOTH` / `SNAPPY` / `BOUNCY` had no caller outside this
module's own tests, and `from_config` was the only thing exposing GPUI's
`SpringConfig` — a public-field struct — across the seam; all are gone, and the
config is now derived on use rather than stored.

`new` also took a damping ratio that eight of nine call sites answered `1.0`, so
it defaults to critical damping and `with_damping` carries the exception. The
ratio stays configurable rather than fixed: `Transition::ease` accepts any easing
curve including an overshooting one, so a critically-damped-only spring would be
the less expressive of the two, and it would be base deciding a motion character
that belongs to the layer above it.

`new` took the response as `response_seconds: f32`, spelling the unit in the
name because the type could not carry it, while every other time value here —
`Transition::new`, `ToastMotion` — is a `Duration`. It is a `Duration` now. The
name stays `response` rather than `duration`: a spring has no end to schedule,
so `Spring::new(Duration::from_millis(200))` is at about 98.6% of the way there
at 200ms and settles the rest inside its tolerance.

The names went a round of their own. `response_seconds: f32` spelled its unit
because the type could not carry it; a `Duration` carries it, which is what
`Transition::new` and `ToastMotion` already use. The damping field was then the
one name spelled out in full next to three short ones, and shortening it
shortened its `with_<field>` builder along with it. That is now written into the
Coding Guides as **Let the enclosing name carry the context**: a field is read
inside its type and a parameter inside its method, so neither repeats what
encloses it — with the limit that `damping` means the ratio in a `Spring` and the
coefficient in GPUI's `SpringConfig`, which the doc comment settles at the call
rather than a longer identifier hinting at it.
- The gpui bump is `Cargo.lock` only, pinned to the spring merge commit
  (`8b1497d`) rather than tracking HEAD. `cargo check --workspace --all-targets`
  is clean with no new warnings.
- `bottom_stack_reflow_moves_up_without_an_opposite_direction_jump` took its
  baseline 400ms after mount, when the stack-height spring was still half a pixel
  short of the height measured in prepaint. It now reads baseline and result
  settled.
- Reduced motion is honoured by `spring()` the same way `transition()` honours
  it.
- `docs/STYLING-AND-MOTION.md` documents when to reach for which, `SpringTarget`,
  and `with_travel`.

This PR was written with Claude Code; every hunk is AI-generated and
human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
