### PR TITLE
combobox: Stop an active search from deciding which values can be selected

### DIFF
--- a/crates/ui/src/combobox.rs
+++ b/crates/ui/src/combobox.rs
@@ -317,6 +317,8 @@ where
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.state.clear_query(window, cx);
+
         let selected_indices = {
             let list = self.state.list.read(cx);
             let delegate = &list.delegate().delegate;
@@ -1278,6 +1280,44 @@ mod tests {
                         .delegate()
                         .selection_snapshot
                         .is_empty()
+                );
+            });
+        });
+    }
+
+    /// A value projected in from outside is not a position in the filtered view,
+    /// so an active search must not decide which values can be selected.
+    #[gpui::test]
+    fn test_combo_box_set_selected_values_keeps_values_hidden_by_the_search(
+        cx: &mut TestAppContext,
+    ) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let items = SearchableVec::new(vec!["React", "Vue", "Angular"]);
+            let state = cx.new(|cx| ComboboxState::new(items, vec![], window, cx).multiple(true));
+
+            state.update(cx, |state, cx| {
+                state.set_selected_values(&["React", "Vue"], window, cx);
+                state.state.list.update(cx, |list, cx| {
+                    list.set_query("Angular", window, cx);
+                });
+
+                state.set_selected_values(&["React", "Vue", "Angular"], window, cx);
+
+                assert_eq!(
+                    state.selected_values(),
+                    vec!["React", "Vue", "Angular"],
+                    "a value the search had hidden must survive being reapplied"
+                );
+                assert_eq!(
+                    state
+                        .selection()
+                        .iter()
+                        .map(|(index, _)| *index)
+                        .collect::<Vec<_>>(),
+                    vec![IndexPath::new(0), IndexPath::new(1), IndexPath::new(2)],
+                    "clearing the query puts every selected item back in view"
                 );
             });
         });

--- a/crates/ui/src/searchable_list/state.rs
+++ b/crates/ui/src/searchable_list/state.rs
@@ -150,6 +150,27 @@ where
         &self.focus_handle
     }
 
+    /// Drop the search query, if there is one, so that a value lookup resolves
+    /// against every item rather than the filtered view.
+    ///
+    /// A delegate's `position` answers for the list as it is currently
+    /// displayed, which is what a click or a keyboard cursor needs. Projecting
+    /// an authoritative value in from outside is not a position in that view:
+    /// the value's item may be filtered out, and dropping it would let whatever
+    /// the user last typed decide which values can be selected at all.
+    ///
+    /// Search runs synchronously for a delegate holding its own items, so a
+    /// lookup right after this call sees the full set. One that fetches its
+    /// items cannot answer for a value it has not fetched, and this cannot make
+    /// it.
+    pub(crate) fn clear_query(&mut self, window: &mut Window, cx: &mut App) {
+        self.list.update(cx, |list, cx| {
+            if !list.query_input.read(cx).value().is_empty() {
+                list.set_query("", window, cx);
+            }
+        });
+    }
+
     // MARK: Mutation (no cx — callers emit events and notify)
 
     /// Add an index+item pair to the selection; no-op if already present.

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -307,11 +307,7 @@ where
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.state.list.update(cx, |list, cx| {
-            if !list.query_input.read(cx).value().is_empty() {
-                list.set_query("", window, cx);
-            }
-        });
+        self.state.clear_query(window, cx);
 
         let selected_index = self
             .state

--- a/website/docs/components/combobox.md
+++ b/website/docs/components/combobox.md
@@ -238,6 +238,11 @@ cx.subscribe_in(&state, window, |view, _, event, window, cx| {
 
 Values are resolved through the current delegate. Values that cannot be found are ignored.
 
+`set_selected_values` clears the search query first, so an active search never decides which
+values can be selected. Index paths address the list as it is currently displayed, so
+`set_selected_indices`, `add_selected_index` and `remove_selected_index` act on the visible rows
+and leave the query alone.
+
 ```rust
 // Replace the entire selection by value
 state.update(cx, |s, cx| {

--- a/website/zh-CN/docs/components/combobox.md
+++ b/website/zh-CN/docs/components/combobox.md
@@ -238,6 +238,10 @@ cx.subscribe_in(&state, window, |view, _, event, window, cx| {
 
 值会通过当前 delegate 解析，无法找到的值会被忽略。
 
+`set_selected_values` 会先清除搜索关键词，因此正在进行的搜索不会决定哪些值可以被选中。
+index path 定位的是列表当前显示的内容，所以 `set_selected_indices`、`add_selected_index`
+和 `remove_selected_index` 作用于可见行，不会改动搜索关键词。
+
 ```rust
 // 按值替换整个选中集合
 state.update(cx, |s, cx| {


### PR DESCRIPTION
Fixes #2652

## The bug

`ComboboxState::set_selected_values` resolved each value through the delegate's
`position`, which answers for the list **as it is currently displayed**. For
`SearchableVec` that is `matched_items`, so a value the search had hidden
resolved to nothing and was dropped before the whole selection was replaced:

```rust
// query matches only "Angular"
state.set_selected_values(&["React", "Vue", "Angular"], window, cx);
state.selected_values();  // ["Angular"]
```

## The fix

`Select::set_selected_value` already had the answer — drop the query first, then
resolve. `set_selected_values` now does the same. Search runs synchronously for a
delegate holding its own items (`perform_search` fills `matched_items` and returns
`Task::ready`), so the lookup that follows sees every item.

The logic moved to `SearchableListState::clear_query` rather than being restated,
so `Select` now shares it instead of carrying its own copy.

## Index paths keep meaning what they meant

`set_selected_indices`, `add_selected_index` and `remove_selected_index` address
the visible rows and leave the query alone — a click and a keyboard cursor *are*
positions in the current view, and an index path is the right way to name one.
Only projecting a value in from outside, which is not a position in that view,
clears the filter.

## Known limit

A delegate that fetches its items cannot answer for a value it has not fetched.
Clearing the query starts that fetch but cannot complete it synchronously, so
such a delegate keeps dropping unfetched values. Resolving that needs the
selection to hold values rather than resolved items, which is a design change
well past this fix.

## Notes

- No API change. Nothing existing is removed, renamed or re-typed, and no new
  trait method or generic bound is introduced. `clear_query` is `pub(crate)`.
- `+71 −5`, of which 38 lines are the test.
- Test: `test_combo_box_set_selected_values_keeps_values_hidden_by_the_search`
  follows the issue's repro — select `[React, Vue]`, search `Angular`, reapply
  `[React, Vue, Angular]`, assert all three survive with valid index paths.
- `cargo test -p gpui-component --lib` 453 pass, `-p gpui-base --lib` 557 pass;
  clippy and typos clean.
- Docs updated in both locales.

Supersedes the approach in #2653, which fixed the same issue by migrating
selection storage from `Vec<(IndexPath, Item)>` to `Vec<Item>`. That is a large
breaking change across `is_item_checked`, `on_will_change`, `on_confirm`,
`selection()` and `ComboboxTriggerContext`, and it does not remove the failure
mode: its `set_selected_values` still `filter_map`s over an `item_by_value` whose
default implementation searches the filtered view, so every delegate that does not
override it keeps the original bug.

This PR was written with Claude Code; every hunk is AI-generated and
human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)