### PR TITLE
native_menu: Prevent CWD files from shadowing relative icons

### DIFF
--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -104,8 +104,8 @@ impl NativeMenu {
 
     /// Append an item showing `icon` next to its label.
     ///
-    /// Native platform menus render file-backed icons from their filesystem path
-    /// and asset-backed icons from memory. [`crate::IconName`] works across all backends.
+    /// Native platform menus load absolute paths from the filesystem and relative paths through
+    /// the application [`gpui::AssetSource`].
     /// - **macOS**: loaded into an `NSImage` as a template image, so it tints with the item
     /// text and assigned to the item ([`NSMenuItem::image`]).
     /// - **Windows**: loaded into an `HBITMAP` and set as the item's
@@ -228,8 +228,10 @@ pub(super) fn resolve_icon_image(
         return None;
     }
 
-    let bytes = if Path::new(path.as_ref()).is_file() {
-        std::fs::read(path.as_ref()).ok()?
+    let icon_path = Path::new(path.as_ref());
+    // Relative paths are asset identifiers and must not resolve against the process CWD.
+    let bytes = if icon_path.is_absolute() {
+        std::fs::read(icon_path).ok()?
     } else {
         asset_source
             .load(path.as_ref())
@@ -345,9 +347,52 @@ mod tests {
     use crate::IconName;
     use serde::Deserialize;
 
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    use std::{borrow::Cow, fs, path::PathBuf};
+
     #[derive(Action, Clone, PartialEq, Deserialize)]
     #[action(namespace = native_menu_tests, no_json)]
     struct TestAction;
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    struct TestAssetSource(Option<&'static [u8]>);
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    impl AssetSource for TestAssetSource {
+        fn load(&self, _path: &str) -> gpui::Result<Option<Cow<'static, [u8]>>> {
+            Ok(self.0.map(Cow::Borrowed))
+        }
+
+        fn list(&self, _path: &str) -> gpui::Result<Vec<SharedString>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    struct TestIconFile(PathBuf);
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    impl TestIconFile {
+        fn create(path: impl Into<PathBuf>, bytes: &[u8]) -> Self {
+            let path = path.into();
+            assert!(
+                !path.exists(),
+                "test file already exists: {}",
+                path.display()
+            );
+            fs::create_dir_all(path.parent().expect("test file should have a parent"))
+                .expect("test directory should be created");
+            fs::write(&path, bytes).expect("test file should be written");
+            Self(path)
+        }
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    impl Drop for TestIconFile {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.0);
+        }
+    }
 
     #[test]
     fn test_native_menu_builder_accepts_icon() {
@@ -369,7 +414,7 @@ mod tests {
         assert_eq!(label, "Github");
         assert!(!disabled);
         assert!(!checked);
-        assert!(icon.path_ref().ends_with("github.svg"));
+        assert_eq!(icon.path_ref().as_ref(), "icons/github.svg");
     }
 
     #[test]
@@ -408,5 +453,38 @@ mod tests {
 
         assert_eq!(image.format, ImageFormat::Svg);
         assert!(!image.bytes.is_empty());
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn test_relative_icon_path_only_uses_asset_source() {
+        const ASSET_SVG: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg"/>"#;
+        const FILE_SVG: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg"><path/></svg>"#;
+
+        let path: SharedString = "target/native-menu-relative-shadow-test.svg".into();
+        let _file = TestIconFile::create(path.as_ref(), FILE_SVG);
+
+        let image = resolve_icon_image(&path, &TestAssetSource(Some(ASSET_SVG)))
+            .expect("relative icon should resolve from the asset source");
+        assert_eq!(image.bytes, ASSET_SVG);
+
+        assert!(resolve_icon_image(&path, &TestAssetSource(None)).is_none());
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn test_absolute_icon_path_loads_from_filesystem() {
+        const ASSET_SVG: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg"/>"#;
+        const FILE_SVG: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg"><path/></svg>"#;
+
+        let path = std::env::current_dir()
+            .expect("test current directory should be available")
+            .join("target/native-menu-absolute-path-test.svg");
+        let _file = TestIconFile::create(&path, FILE_SVG);
+        let path: SharedString = path.to_string_lossy().into_owned().into();
+
+        let image = resolve_icon_image(&path, &TestAssetSource(Some(ASSET_SVG)))
+            .expect("absolute icon should resolve from the filesystem");
+        assert_eq!(image.bytes, FILE_SVG);
     }
 }

--- a/crates/ui/src/native_menu/mod.rs
+++ b/crates/ui/src/native_menu/mod.rs
@@ -104,8 +104,9 @@ impl NativeMenu {
 
     /// Append an item showing `icon` next to its label.
     ///
-    /// Native platform menus load absolute paths from the filesystem and relative paths through
-    /// the application [`gpui::AssetSource`].
+    /// Native platform menus load absolute paths ([`Path::is_absolute`]) from the filesystem,
+    /// and every other path through the application [`gpui::AssetSource`].
+    /// [`crate::IconName`] resolves as an asset and works across all backends.
     /// - **macOS**: loaded into an `NSImage` as a template image, so it tints with the item
     /// text and assigned to the item ([`NSMenuItem::image`]).
     /// - **Windows**: loaded into an `HBITMAP` and set as the item's
@@ -347,52 +348,9 @@ mod tests {
     use crate::IconName;
     use serde::Deserialize;
 
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    use std::{borrow::Cow, fs, path::PathBuf};
-
     #[derive(Action, Clone, PartialEq, Deserialize)]
     #[action(namespace = native_menu_tests, no_json)]
     struct TestAction;
-
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    struct TestAssetSource(Option<&'static [u8]>);
-
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    impl AssetSource for TestAssetSource {
-        fn load(&self, _path: &str) -> gpui::Result<Option<Cow<'static, [u8]>>> {
-            Ok(self.0.map(Cow::Borrowed))
-        }
-
-        fn list(&self, _path: &str) -> gpui::Result<Vec<SharedString>> {
-            Ok(Vec::new())
-        }
-    }
-
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    struct TestIconFile(PathBuf);
-
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    impl TestIconFile {
-        fn create(path: impl Into<PathBuf>, bytes: &[u8]) -> Self {
-            let path = path.into();
-            assert!(
-                !path.exists(),
-                "test file already exists: {}",
-                path.display()
-            );
-            fs::create_dir_all(path.parent().expect("test file should have a parent"))
-                .expect("test directory should be created");
-            fs::write(&path, bytes).expect("test file should be written");
-            Self(path)
-        }
-    }
-
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    impl Drop for TestIconFile {
-        fn drop(&mut self) {
-            let _ = fs::remove_file(&self.0);
-        }
-    }
 
     #[test]
     fn test_native_menu_builder_accepts_icon() {
@@ -444,47 +402,86 @@ mod tests {
         assert!(icon.path_ref().ends_with("inbox.svg"));
     }
 
+    /// Icon resolution is only compiled for the platforms with an OS-native menu.
     #[cfg(any(target_os = "macos", target_os = "windows"))]
-    #[test]
-    fn test_native_menu_icon_asset_resolves_to_bytes() {
-        let icon = Icon::new(IconName::Github);
-        let image = resolve_icon_image(icon.path_ref(), &gpui_component_assets::Assets)
-            .expect("icon asset should resolve");
+    mod icon_resolution {
+        use super::*;
+        use std::{borrow::Cow, fs, path::PathBuf};
 
-        assert_eq!(image.format, ImageFormat::Svg);
-        assert!(!image.bytes.is_empty());
-    }
-
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    #[test]
-    fn test_relative_icon_path_only_uses_asset_source() {
         const ASSET_SVG: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg"/>"#;
         const FILE_SVG: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg"><path/></svg>"#;
 
-        let path: SharedString = "target/native-menu-relative-shadow-test.svg".into();
-        let _file = TestIconFile::create(path.as_ref(), FILE_SVG);
+        struct TestAssetSource(Option<&'static [u8]>);
 
-        let image = resolve_icon_image(&path, &TestAssetSource(Some(ASSET_SVG)))
-            .expect("relative icon should resolve from the asset source");
-        assert_eq!(image.bytes, ASSET_SVG);
+        impl AssetSource for TestAssetSource {
+            fn load(&self, _path: &str) -> gpui::Result<Option<Cow<'static, [u8]>>> {
+                Ok(self.0.map(Cow::Borrowed))
+            }
 
-        assert!(resolve_icon_image(&path, &TestAssetSource(None)).is_none());
-    }
+            fn list(&self, _path: &str) -> gpui::Result<Vec<SharedString>> {
+                Ok(Vec::new())
+            }
+        }
 
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    #[test]
-    fn test_absolute_icon_path_loads_from_filesystem() {
-        const ASSET_SVG: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg"/>"#;
-        const FILE_SVG: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg"><path/></svg>"#;
+        /// A file written into the current directory for the duration of one test.
+        ///
+        /// The shadowing tests need a file the process would find by walking a *relative*
+        /// path, so it has to live in the current directory rather than a temporary one.
+        /// Nothing else is created alongside it, so dropping the file leaves no residue.
+        struct TestIconFile(PathBuf);
 
-        let path = std::env::current_dir()
-            .expect("test current directory should be available")
-            .join("target/native-menu-absolute-path-test.svg");
-        let _file = TestIconFile::create(&path, FILE_SVG);
-        let path: SharedString = path.to_string_lossy().into_owned().into();
+        impl TestIconFile {
+            fn create(path: impl Into<PathBuf>, bytes: &[u8]) -> Self {
+                let path = path.into();
+                assert!(
+                    !path.exists(),
+                    "leftover test file, delete it and re-run: {}",
+                    path.display()
+                );
+                fs::write(&path, bytes).expect("test file should be written");
+                Self(path)
+            }
+        }
 
-        let image = resolve_icon_image(&path, &TestAssetSource(Some(ASSET_SVG)))
-            .expect("absolute icon should resolve from the filesystem");
-        assert_eq!(image.bytes, FILE_SVG);
+        impl Drop for TestIconFile {
+            fn drop(&mut self) {
+                let _ = fs::remove_file(&self.0);
+            }
+        }
+
+        #[test]
+        fn test_native_menu_icon_asset_resolves_to_bytes() {
+            let icon = Icon::new(IconName::Github);
+            let image = resolve_icon_image(icon.path_ref(), &gpui_component_assets::Assets)
+                .expect("icon asset should resolve");
+
+            assert_eq!(image.format, ImageFormat::Svg);
+            assert!(!image.bytes.is_empty());
+        }
+
+        #[test]
+        fn test_relative_icon_path_only_uses_asset_source() {
+            let path: SharedString = "native-menu-relative-shadow-test.svg".into();
+            let _file = TestIconFile::create(path.as_ref(), FILE_SVG);
+
+            let image = resolve_icon_image(&path, &TestAssetSource(Some(ASSET_SVG)))
+                .expect("relative icon should resolve from the asset source");
+            assert_eq!(image.bytes, ASSET_SVG);
+
+            assert!(resolve_icon_image(&path, &TestAssetSource(None)).is_none());
+        }
+
+        #[test]
+        fn test_absolute_icon_path_loads_from_filesystem() {
+            let path = std::env::current_dir()
+                .expect("test current directory should be available")
+                .join("native-menu-absolute-path-test.svg");
+            let _file = TestIconFile::create(&path, FILE_SVG);
+            let path: SharedString = path.to_string_lossy().into_owned().into();
+
+            let image = resolve_icon_image(&path, &TestAssetSource(Some(ASSET_SVG)))
+                .expect("absolute icon should resolve from the filesystem");
+            assert_eq!(image.bytes, FILE_SVG);
+        }
     }
 }


### PR DESCRIPTION
Closes #2813

## Description

Built-in native-menu icons use relative asset paths such as `icons/close.svg`. On macOS and Windows, `resolve_icon_image` previously checked whether that relative path existed on the filesystem before consulting the application `AssetSource`. This allowed a matching file under the process current working directory to shadow a bundled icon.

This PR limits filesystem-backed native-menu icons to explicit absolute paths. Relative paths are now always resolved through `AssetSource`, while existing support for absolute custom icon files is preserved.

The change is intentionally scoped to the native-menu resolver and adds two target-gated regression tests covering three resolution properties:

- Relative paths resolve only through `AssetSource`, including when a matching CWD file exists or the asset is missing.
- An explicit absolute icon path still resolves from the filesystem.

## Screenshot

| Before | After |
| ------ | ----- |
| ![Before fix: matching CWD file wins](https://github.com/lurenjia534/gpui-component/releases/download/native-menu-icon-cwd-shadow-evidence-20260824/native-menu-icon-cwd-shadow-poc.png) | ![After fix: relative asset wins and no CWD fallback occurs](https://github.com/lurenjia534/gpui-component/releases/download/native-menu-icon-cwd-shadow-evidence-20260824/native-menu-icon-cwd-shadow-fix-verified.png) |

The before screenshot shows the attacker-controlled CWD file being selected. The after screenshot shows that the same shadow file exists but the embedded asset is selected instead.

The screenshots were captured from a Linux logic-level PoC because the native-menu image resolver is compiled only on macOS and Windows. The committed regression tests exercise the real resolver on those affected platforms in CI.

## How to Test

On macOS or Windows, run the native-menu tests:

```bash
cargo test -p gpui-component native_menu::tests::
```

The following relevant tests should pass:

```text
test_relative_icon_path_only_uses_asset_source
test_absolute_icon_path_loads_from_filesystem
```

Local Linux verification completed:

```bash
cargo clippy -p gpui-component --lib -- --deny warnings
cargo test -p gpui-component --lib
```

A separate post-fix logic PoC also confirmed that a matching CWD file was present while relative assets did not fall back to it and absolute file paths continued to work.

macOS and Windows native-menu execution was not available in the local Linux environment; the repository CI matrix runs the test suite on both affected platforms.

## AI Assistance

AI assistance was used to analyze the reported issue, minimize the supplied patch, adjust the documentation and regression tests, run local verification, and draft this PR description. The resulting code and claims were reviewed before submission.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (if any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific).

The Story test is not applicable to this resolver-only change. The changed module passes `rustfmt`; Linux Clippy and library tests passed locally. The new resolver tests are target-gated to macOS and Windows and are covered by CI.
