### PR TITLE
dock: Give each dock resize handle a unique element id

### DIFF
--- a/crates/ui/src/dock/dock.rs
+++ b/crates/ui/src/dock/dock.rs
@@ -143,7 +143,18 @@ impl DockSkin {
         let placement = dock.placement();
         let shared = self.shared().clone();
 
-        resize_handle("resize-handle", placement.axis())
+        // One id per placement: the docks all render under the same stateful
+        // ancestor, so a shared literal would collapse the handles into one
+        // GlobalElementId and GPUI would silently share their element state —
+        // a press on the left handle then starts the right handle's drag.
+        let id = match placement {
+            DockPlacement::Left => "resize-handle-left",
+            DockPlacement::Right => "resize-handle-right",
+            DockPlacement::Bottom => "resize-handle-bottom",
+            DockPlacement::Center => "resize-handle-center",
+        };
+
+        resize_handle(id, placement.axis())
             .when(placement.is_left(), |this| this.placement(Side::Left))
             .on_drag(ResizePanel, move |info, _, _, cx| {
                 cx.stop_propagation();
@@ -255,5 +266,98 @@ impl Element for DockResizeTracker {
                     .update(cx, |_, cx| cx.emit(DockEvent::LayoutChanged));
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+
+    use gpui::{
+        Entity, Modifiers, MouseButton, TestAppContext, VisualTestContext, point, px, size,
+    };
+
+    use crate::dock::{DockArea, DockLayout, DockPlacement, DockSkin, test_support::MeasuredProbe};
+
+    fn area_with_side_docks(cx: &mut TestAppContext) -> (Entity<DockArea>, &mut VisualTestContext) {
+        cx.update(|cx| crate::init(cx));
+        let (area, cx) = cx.add_window_view(|window, cx| {
+            DockArea::new("test", None, window, cx).with_renderer(DockSkin::new(cx))
+        });
+        cx.simulate_resize(size(px(800.), px(600.)));
+        cx.update(|window, cx| {
+            area.update(cx, |area, cx| {
+                area.set_center(
+                    DockLayout::tabs().panel(MeasuredProbe::new(Rc::default(), cx)),
+                    window,
+                    cx,
+                );
+                area.set_dock(
+                    DockPlacement::Left,
+                    DockLayout::tabs().panel(MeasuredProbe::new(Rc::default(), cx)),
+                    window,
+                    cx,
+                );
+                area.set_dock(
+                    DockPlacement::Right,
+                    DockLayout::tabs().panel(MeasuredProbe::new(Rc::default(), cx)),
+                    window,
+                    cx,
+                );
+            });
+        });
+        cx.run_until_parked();
+        (area, cx)
+    }
+
+    /// Every dock's handle once shared the literal element id
+    /// `"resize-handle"`, so GPUI silently handed them one element state —
+    /// including the pending-mouse-down that starts a drag. Pressing the left
+    /// handle then let the right dock's drag listener (painted later, so
+    /// dispatched first) claim the drag, and one pixel of movement threw the
+    /// right dock to nearly the full area width.
+    #[gpui::test]
+    fn dragging_the_left_handle_resizes_only_the_left_dock(cx: &mut TestAppContext) {
+        let (area, cx) = area_with_side_docks(cx);
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+
+        // The left dock is 200px wide, so its handle sits at x ∈ [198, 199).
+        cx.simulate_mouse_down(
+            point(px(198.5), px(300.)),
+            MouseButton::Left,
+            Modifiers::none(),
+        );
+        // Past the drag threshold: the drag starts and claims a dock.
+        cx.simulate_mouse_move(
+            point(px(204.), px(300.)),
+            MouseButton::Left,
+            Modifiers::none(),
+        );
+        // The move the claimed dock resizes to.
+        cx.simulate_mouse_move(
+            point(px(240.), px(300.)),
+            MouseButton::Left,
+            Modifiers::none(),
+        );
+        cx.simulate_mouse_up(
+            point(px(240.), px(300.)),
+            MouseButton::Left,
+            Modifiers::none(),
+        );
+        cx.run_until_parked();
+
+        let (left, right) = cx.update(|_, cx| {
+            let area = area.read(cx);
+            (
+                area.dock_size(DockPlacement::Left),
+                area.dock_size(DockPlacement::Right),
+            )
+        });
+        assert_eq!(
+            right,
+            Some(px(200.)),
+            "the right dock must not move when the left handle is dragged"
+        );
+        assert_eq!(left, Some(px(240.)), "the left dock follows the pointer");
     }
 }


### PR DESCRIPTION
## Summary

Dragging the left dock's resize handle by a single pixel threw the right dock to nearly the full area width, expanding over the center — and the left dock never moved at all.

Every dock built its handle as `resize_handle("resize-handle", …)`. The docks all render under the same stateful ancestor and the per-dock wrapper carries no id, so the left and right handles resolve to the **same `GlobalElementId`**. GPUI keys element state by that id and shares it silently rather than panicking — including the `pending_mouse_down` that arms a drag.

Three dispatch facts turn the collision into a misroute. Only the mouse-down is hitbox-gated, and it writes into the shared state. The drag-start listener checks nothing but that shared state and the 2px threshold. And bubble listeners run in reverse paint order, so the right dock's handle — painted last — claims the drag first, calls `stop_propagation`, and sets `resizing_dock` to `Right`. Every following move then resizes the right dock to `area.right() - pointer.x`, which with the pointer at the left dock's edge is nearly the whole area, clamped only at `area.width - PANEL_MIN_SIZE - left_size`. The mouse-up emits `LayoutChanged`, so the bogus width was persisted too. The same sharing made both handles paint their active highlight together.

This is a regression from #2772. Each dock used to be its own `Entity<Dock>`, and the view's `ElementId::View(entity_id)` kept the identical literals apart; inlining the docks into `DockArea::render` removed that namespace. The bottom dock escapes by rendering inside `#dock-area-center`, and base's split handles were already keyed as `("resizable-handle", ix)` — this was the one handle left unkeyed.

The handle id now names its placement: `resize-handle-left` / `-right` / `-bottom`.

The new test builds an 800px area with a 200px dock on each side and drags the left handle to x = 240. Before the fix the right dock jumped from 200px to exactly its 500px clamp ceiling while the left dock stayed at 200px; with it, the left dock follows the pointer to 240px and the right dock does not move.

## Test plan

- [x] `cargo test -p gpui-component --lib` — 453 passed
- [x] `cargo test -p gpui-base --lib` — 560 passed
- [x] `cargo clippy -p gpui-component -p gpui-base --all-targets -- --deny warnings` — clean
- [x] `cargo fmt --check` — clean for the changed file
- [x] Reverting the id change makes `dragging_the_left_handle_resizes_only_the_left_dock` fail with the right dock at 500px

## AI Assistance

Diagnosis, fix, and test were written with Claude Code; every hunk is AI-generated and human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
