### PR TITLE
input: Clear a stale focused_input left by an input removed while focused

### DIFF
--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -997,4 +997,81 @@ mod tests {
             assert_eq!(cx.update(|window, cx| window.focused_input(cx)), None);
         }
     }
+
+    #[gpui::test]
+    fn focused_input_registry_ignores_input_removed_while_focused(cx: &mut gpui::TestAppContext) {
+        use crate::{Root, WindowExt as _};
+        use gpui::{AppContext as _, Render};
+
+        struct Probe {
+            input: Entity<InputState>,
+            show_input: bool,
+            other: gpui::FocusHandle,
+        }
+        impl Render for Probe {
+            fn render(&mut self, _: &mut Window, _: &mut gpui::Context<Self>) -> impl IntoElement {
+                let base = div().child(div().track_focus(&self.other));
+                if self.show_input {
+                    base.child(Input::new(&self.input))
+                } else {
+                    base
+                }
+            }
+        }
+
+        cx.update(crate::init);
+        let mut input = None;
+        let mut other_focus = None;
+        let mut probe_entity = None;
+        let window = cx.update(|cx| {
+            cx.open_window(Default::default(), |window, cx| {
+                let state = cx.new(|cx| InputState::new(window, cx));
+                input = Some(state.clone());
+                let other = cx.focus_handle();
+                other_focus = Some(other.clone());
+                let probe = cx.new(|_| Probe {
+                    input: state,
+                    show_input: true,
+                    other,
+                });
+                probe_entity = Some(probe.clone());
+                cx.new(|cx| Root::new(probe, window, cx))
+            })
+            .unwrap()
+        });
+        let input: AnyInputState = input.unwrap().into();
+        let other_focus = other_focus.unwrap();
+        let probe = probe_entity.unwrap();
+        let mut cx = gpui::VisualTestContext::from_window(window.into(), cx);
+
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        cx.update(|window, cx| input.focus_handle(cx).focus(window, cx));
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        assert_eq!(
+            cx.update(|window, cx| window.focused_input(cx)),
+            Some(input.clone())
+        );
+
+        // Remove the input from the tree while it holds focus and move focus
+        // elsewhere in the same update (e.g. closing a sidebar containing the
+        // input) — the input never re-renders to unregister itself.
+        cx.update(|window, cx| {
+            probe.update(cx, |probe, cx| {
+                probe.show_input = false;
+                cx.notify();
+            });
+            other_focus.focus(window, cx);
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        assert!(!cx.update(|window, cx| window.has_focused_input(cx)));
+        assert_eq!(cx.update(|window, cx| window.focused_input(cx)), None);
+    }
 }

--- a/crates/ui/src/window_ext.rs
+++ b/crates/ui/src/window_ext.rs
@@ -81,6 +81,8 @@ pub trait WindowExt: Sized {
     ///
     /// Covers `Input`, `Textarea`, `Editor` and `OtpInput`, use
     /// [`AnyInputState::as_input`] and friends to get the concrete state.
+    /// A registration whose focus handle is no longer focused (e.g. the input
+    /// was removed from the tree while focused) is treated as `None`.
     fn focused_input(&mut self, cx: &mut App) -> Option<AnyInputState>;
     /// Returns true if there is a focused Input entity.
     fn has_focused_input(&mut self, cx: &mut App) -> bool;
@@ -215,12 +217,24 @@ impl WindowExt for Window {
 
     #[inline]
     fn has_focused_input(&mut self, cx: &mut App) -> bool {
-        Root::read(self, cx).focused_input.is_some()
+        self.focused_input(cx).is_some()
     }
 
-    #[inline]
     fn focused_input(&mut self, cx: &mut App) -> Option<AnyInputState> {
-        Root::read(self, cx).focused_input.clone()
+        let state = Root::read(self, cx).focused_input.clone()?;
+        if state.focus_handle(cx).is_focused(self) {
+            return Some(state);
+        }
+
+        // An input removed from the tree while focused never re-renders to
+        // unregister itself; drop the stale registration lazily.
+        Root::try_update(self, cx, |root, _, cx| {
+            if root.focused_input.as_ref() == Some(&state) {
+                root.focused_input = None;
+                cx.notify();
+            }
+        });
+        None
     }
 
     #[inline]


### PR DESCRIPTION
## Summary

`Root.focused_input` is maintained from the input's render: `sync_focused_input_registry` records the state while its handle is focused, and unregisters it on the first render after focus moves away. An input removed from the tree while still focused never renders again, so the unregister branch never runs — the registration outlives the input, and `has_focused_input` answers true for the whole window until a dialog close happens to reset the field.

Validate the registration when it is read: `focused_input` now answers `None` — and lazily clears the field — once the registered handle is no longer the window's focus. `has_focused_input` goes through the same path. The identity guard leaves a registration made by another input in the meantime untouched.

No public API change, so no breaking changes.

## Test Plan

- `focused_input_registry_ignores_input_removed_while_focused` — new, failing before this change: focus an input, remove it from the tree and move focus elsewhere in the same update, then assert the window reports no focused input.
- `cargo test -p gpui-component` — full lib suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
