### PR TITLE
progress: Fix ProgressBar rounded border.

### DIFF
--- a/crates/ui/src/progress/progress.rs
+++ b/crates/ui/src/progress/progress.rs
@@ -119,7 +119,9 @@ impl RenderOnce for Progress {
                 ProgressTrack::new()
                     .absolute()
                     .size_full()
-                    .bg(bg.opacity(0.2)),
+                    .bg(bg.opacity(0.2))
+                    .rounded(radius)
+                    .refine_style(&inner_style),
             )
             .child(
                 ProgressIndicator::new()

--- a/crates/ui/src/progress/progress.rs
+++ b/crates/ui/src/progress/progress.rs
@@ -4,10 +4,10 @@ use gpui::{
     ParentElement, RenderOnce, StyleRefinement, Styled, Window, ease_in_out,
     prelude::FluentBuilder, px, relative,
 };
-use gpui_base::{Progress as BaseProgress, ProgressIndicator, ProgressTrack};
+use gpui_base::{
+    Progress as BaseProgress, ProgressIndicator, ProgressTrack, Transition, transition,
+};
 use instant::Duration;
-
-use super::ProgressState;
 
 /// A linear horizontal progress bar element.
 #[derive(IntoElement)]
@@ -78,6 +78,7 @@ impl RenderOnce for Progress {
             .unwrap_or(cx.theme().tokens.progress_bar.into());
         let value = self.value;
         let loading = self.loading;
+        let reduce_motion = cx.reduce_motion();
 
         let radius = self.style.corner_radii.clone();
         let mut inner_style = StyleRefinement::default();
@@ -98,9 +99,13 @@ impl RenderOnce for Progress {
             pill_radius
         };
 
-        let state = window.use_keyed_state(self.id.clone(), cx, |_, _| ProgressState::new(value));
-        let prev_target = state.read(cx).target();
-        let has_changed = prev_target != value;
+        let animated_value = transition(
+            (self.id.clone(), "indicator"),
+            value,
+            Transition::new(Duration::from_millis(180)),
+            window,
+            cx,
+        );
 
         BaseProgress::new(self.id)
             .value(value)
@@ -125,38 +130,8 @@ impl RenderOnce for Progress {
                     .bg(bg)
                     .rounded(radius)
                     .refine_style(&inner_style)
-                    .map(|this| match value {
-                        v if v >= 100. || loading => this,
-                        _ => this.rounded_r_none(),
-                    })
                     .map(|this| {
-                        if has_changed {
-                            let from = prev_target;
-                            state.read(cx).set_target(value);
-
-                            let duration = Duration::from_secs_f64(0.15);
-                            cx.spawn({
-                                let state = state.clone();
-                                async move |cx| {
-                                    cx.background_executor().timer(duration).await;
-                                    _ = state.update(cx, |this, _| {
-                                        this.value = this.target();
-                                    });
-                                }
-                            })
-                            .detach();
-
-                            this.with_animation(
-                                "progress-animation",
-                                Animation::new(duration),
-                                move |this, delta| {
-                                    let current_value = from + (value - from) * delta;
-                                    let w = relative((current_value / 100.).clamp(0., 1.));
-                                    this.w(w)
-                                },
-                            )
-                            .into_any_element()
-                        } else if loading {
+                        if loading && !reduce_motion {
                             this.with_animation(
                                 "progress-loading",
                                 Animation::new(Duration::from_secs(1)).repeat(),
@@ -168,8 +143,12 @@ impl RenderOnce for Progress {
                                 },
                             )
                             .into_any_element()
+                        } else if loading {
+                            this.left(relative(0.325))
+                                .right(relative(0.325))
+                                .into_any_element()
                         } else {
-                            this.w(relative((value / 100.).clamp(0., 1.)))
+                            this.w(relative((animated_value / 100.).clamp(0., 1.)))
                                 .into_any_element()
                         }
                     }),


### PR DESCRIPTION
## Summary

- preserve the trailing corner radius on determinate progress indicators
- use the shared keyed transition so rapid value updates continue from the visible position
- honor reduced motion for determinate and indeterminate progress states

## Test Plan

- `cargo test -p gpui-component --lib` (456 passed)
- `rustfmt --edition 2024 --check crates/ui/src/progress/progress.rs`
- `git diff --check`