### PR TITLE
button: Give Button a neutral default line height

### DIFF
--- a/crates/base/src/button.rs
+++ b/crates/base/src/button.rs
@@ -4,7 +4,7 @@ use gpui::{
     AnyElement, App, ClickEvent, Div, ElementId, FocusHandle, InteractiveElement, Interactivity,
     IntoElement, MouseButton, ParentElement, Refineable as _, RenderOnce, Role, SharedString,
     Stateful, StatefulInteractiveElement, StyleRefinement, Styled, Window, div,
-    prelude::FluentBuilder as _,
+    prelude::FluentBuilder as _, relative,
 };
 use smallvec::SmallVec;
 
@@ -212,6 +212,13 @@ impl RenderOnce for Button {
         let on_click = self.on_click;
 
         self.base
+            // A neutral line height is geometry, not visual policy: with the
+            // inherited value the text box is taller than the glyphs, so the
+            // caller's padding no longer determines the control's height and a
+            // button cannot be sized precisely. `relative(1.)` makes the text
+            // box exactly the font size; anything the caller sets refines over
+            // it, so a product that wants looser text still can.
+            .line_height(relative(1.))
             .when_some(self.role.resolve(|| Role::Button), |this, role| {
                 this.role(role)
             })


### PR DESCRIPTION
`Button` inherits its line height from the surrounding text style, which makes the text box taller than the glyphs it contains. The caller's padding then no longer determines the control height, so a button cannot be sized precisely — a `h(28).py(6)` button ends up taller than 28px, and vertical centering drifts with the ambient font.

Setting `line_height(relative(1.))` makes the text box exactly the font size, so padding is the only thing deciding the height.

This is geometry rather than visual policy, which is why it belongs in Base: it does not pick a look, it removes an ambient value that stops the presentation layer from controlling its own sizing. It is applied before `refine_style`, so anything the caller sets still wins.

```rust
Button::new("save").line_height(relative(1.4)) // still yours
```

**Note for review:** this changes the rendered height of every existing unstyled Button whose caller relied on the inherited line height, including `gpui-component`'s styled buttons. `cargo test -p gpui-base` (568 tests) passes, but the story gallery is worth a look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
