### PR TITLE
fps: Enable gpui/profiler on the crate that uses it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ gpui-component-assets = { path = "crates/assets", version = "0.5.1" }
 gpui-fps = { path = "crates/fps", version = "0.1.0" }
 story = { path = "crates/story" }
 
-gpui = { version = "0.2.2", git = "https://github.com/zed-industries/zed", features = ["profiler"] }
+gpui = { version = "0.2.2", git = "https://github.com/zed-industries/zed" }
 gpui_platform = { git = "https://github.com/zed-industries/zed", features = ["font-kit", "x11", "wayland", "runtime_shaders"] }
 gpui_web = { git = "https://github.com/zed-industries/zed" }
 gpui_macros = { version = "0.1.0", git = "https://github.com/zed-industries/zed" }

--- a/crates/fps/Cargo.toml
+++ b/crates/fps/Cargo.toml
@@ -15,7 +15,9 @@ version = "0.1.0"
 doctest = false
 
 [dependencies]
-gpui.workspace = true
+# `gpui/profiler` belongs here, not on the workspace dependency: this is the
+# only crate that uses it, and cargo unifies features across the graph.
+gpui = { workspace = true, features = ["profiler"] }
 instant.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]


### PR DESCRIPTION
`gpui/profiler` is enabled on the workspace `gpui` dependency, so every crate
in the workspace gets it. Only `gpui-fps` uses the feature — `gpui::profiler`
appears in `crates/fps/src/lib.rs` and `crates/fps/src/sampler.rs` and nowhere
else. `crates/base` has no reference to it at all.

Because cargo unifies features across the dependency graph, that workspace-level
enablement reaches every downstream consumer too. A project that depends only on
`gpui-base` still compiles gpui's profiler, and cannot turn it off from its own
manifest — `default-features = false` on the consumer side does not help,
because the feature is requested here.

That is currently a hard build failure on `wasm32-unknown-unknown`. Against zed
`6e2fae61` (main at time of writing), gpui's profiler module does not compile for
wasm32 — it mixes `std::time::Instant` with `web_time::Instant`:

```
error[E0308]: mismatched types
  --> crates/gpui/src/profiler/hang.rs:315
error[E0308]: `match` arms have incompatible types
  --> crates/gpui/src/profiler/journal.rs:87
  --> crates/gpui/src/profiler/journal.rs:99
error[E0308]: mismatched types
  --> crates/gpui/src/profiler.rs:1002
  --> crates/gpui/src/profiler.rs:1003
error: could not compile `gpui` (lib) due to 5 previous errors
```

The underlying gpui bug is zed's to fix, but a wasm consumer of `gpui-base` has
no way to route around it while the feature is enabled workspace-wide. Moving the
feature to the one crate that needs it makes the browser build work today, and is
the right ownership regardless.

## Change

Drop `features = ["profiler"]` from the workspace `gpui` dependency and set it on
`gpui-fps`, the only crate that uses it.

## Verification

Resolved feature sets, via `cargo tree -e features`:

| | `gpui-base` (wasm32) | `gpui-fps` |
|---|---|---|
| before | profiler **on** | on |
| after  | profiler **off** | **on** |

So the HUD is unaffected, and `story` still gets the feature transitively through
its `gpui-fps` dependency.

Not verified: I did not run the full test suite or a complete workspace build.
The change is limited to feature placement in two manifests, with no source
changes and no public API change, so there is no `Breaking Changes` section.

The one behavioural change for downstream users: anyone who was relying on
`gpui/profiler` being enabled transitively via `gpui-base` or `gpui-component`
will now need to enable it themselves, or depend on `gpui-fps`.

---

Parts of this PR were drafted with AI assistance (Claude). The diagnosis, the
feature-resolution comparison, and the wording were reviewed by me.
