### PR TITLE
webview: Add an owned handle for raw Wry access

### DIFF
--- a/crates/webview/src/lib.rs
+++ b/crates/webview/src/lib.rs
@@ -15,7 +15,7 @@ use gpui::{
 ///
 /// Cloning this handle prolongs the native webview's lifetime. Dropping the owning [`WebView`]
 /// entity hides the child view, but final native destruction waits until all handle and frame
-/// clones are dropped.
+/// clones are dropped. All handles must be dropped before the parent window is destroyed.
 #[derive(Clone)]
 pub struct WebViewHandle(Rc<wry::WebView>);
 

--- a/crates/webview/src/lib.rs
+++ b/crates/webview/src/lib.rs
@@ -11,6 +11,21 @@ use gpui::{
     ParentElement as _, Pixels, Render, Size, Style, Styled as _, Window, canvas, div,
 };
 
+/// An owned, UI-thread-local handle to the raw wry webview.
+///
+/// Cloning this handle prolongs the native webview's lifetime. Dropping the owning [`WebView`]
+/// entity hides the child view, but final native destruction waits until all handle and frame
+/// clones are dropped.
+#[derive(Clone)]
+pub struct WebViewHandle(Rc<wry::WebView>);
+
+impl WebViewHandle {
+    /// Get the raw wry webview.
+    pub fn raw(&self) -> &wry::WebView {
+        &self.0
+    }
+}
+
 /// A webview based on wry WebView.
 ///
 /// [experimental]
@@ -76,6 +91,11 @@ impl WebView {
     /// Get the raw wry webview.
     pub fn raw(&self) -> &wry::WebView {
         &self.webview
+    }
+
+    /// Get an owned, UI-thread-local handle to the raw wry webview.
+    pub fn handle(&self) -> WebViewHandle {
+        WebViewHandle(self.webview.clone())
     }
 }
 


### PR DESCRIPTION
## Description

`WebView::raw()` returns a reference tied to an active `WebView` borrow.
This forces callers to keep a GPUI `Entity<WebView>` lease while running
Wry operations; some operations, including macOS cookie-store calls, may
drive the platform run loop.

This PR adds a cloneable, UI-thread-local `WebViewHandle` and
`WebView::handle()`. It reuses the existing private `Rc<wry::WebView>`,
does not make access `Send`, and does not change rendering or visibility
behavior.

An outstanding handle keeps the native WebView alive and must be dropped
before its parent window is destroyed. This complements the borrowed raw
access added in #1739.

## How to Test

- `cargo fmt -p gpui-wry -- --check`
- `cargo check -p gpui-wry --all-targets`
- `cargo clippy -p gpui-wry --all-targets -- -D warnings`
- `cargo test -p gpui-wry`
- On macOS, acquired the handle outside the Entity lease, exercised native
  user-agent and cookie operations, dropped it before popup teardown, and
  verified an empty cookie-store readback after cleanup.
- `cargo run -p webview`; verified loading, hiding, and closing.