### PR TITLE
text_view: Add `max_lines` to clamp rendered content to whole lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8331,6 +8331,7 @@ dependencies = [
  "gpui-component",
  "gpui-component-assets",
  "gpui_platform",
+ "reqwest_client",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8323,6 +8323,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "text_max_lines"
+version = "0.5.1"
+dependencies = [
+ "anyhow",
+ "gpui",
+ "gpui-component",
+ "gpui-component-assets",
+ "gpui_platform",
+]
+
+[[package]]
 name = "text_selection"
 version = "0.5.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "examples/focus_trap",
     "examples/tooltip_top_edge",
     "examples/sidebar",
+    "examples/text_max_lines",
     "examples/text_selection",
     "examples/root_borderless",
     "examples/table_in_scrollable",

--- a/crates/ui/src/text/inline.rs
+++ b/crates/ui/src/text/inline.rs
@@ -19,6 +19,7 @@ use crate::{
     text::TextViewMultiClickKind,
     text::node::LinkMark,
     text::selection::word_range_at,
+    text::state::LineSpan,
     text::text_view::{LinkClickHandlerFn, handle_link_click},
 };
 
@@ -389,6 +390,23 @@ impl Element for Inline {
     ) -> Self::PrepaintState {
         self.styled_text
             .prepaint(id, inspector_id, bounds, &mut (), window, cx);
+
+        // Report this element's laid-out extent so an ancestor TextView with
+        // `max_lines` can snap its clip to a whole-line boundary. The state
+        // stack only holds an entry during prepaint when that view set
+        // `max_lines`, so this is a no-op otherwise.
+        if let Some(text_view_state) = UiGlobalState::global(cx).text_view_state().cloned() {
+            let state = text_view_state.read(cx);
+            if state.max_lines.is_some()
+                && let Ok(mut line_spans) = state.line_spans.lock()
+            {
+                line_spans.push(LineSpan {
+                    top: bounds.top(),
+                    bottom: bounds.bottom(),
+                    line_height: window.line_height(),
+                });
+            }
+        }
 
         let hitbox = window.insert_hitbox(bounds, HitboxBehavior::Normal);
         hitbox

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -1,5 +1,10 @@
 use futures::Stream as _;
-use std::{ops::RangeInclusive, pin::Pin, sync::Arc, task::Poll};
+use std::{
+    ops::RangeInclusive,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::Poll,
+};
 
 use gpui::{
     App, AppContext as _, Bounds, Context, FocusHandle, IntoElement, KeyBinding, ListState,
@@ -67,6 +72,16 @@ pub enum SelectionFormat {
     Source,
 }
 
+/// One text element's laid-out vertical extent, reported by `Inline` during
+/// prepaint so `TextView` can snap its `max_lines` clip to a whole-line
+/// boundary.
+#[derive(Clone, Copy)]
+pub(super) struct LineSpan {
+    pub(super) top: Pixels,
+    pub(super) bottom: Pixels,
+    pub(super) line_height: Pixels,
+}
+
 /// The state of a TextView.
 pub struct TextViewState {
     pub(super) focus_handle: FocusHandle,
@@ -78,6 +93,12 @@ pub struct TextViewState {
     pub(super) selectable: bool,
     pub(super) selection_format: SelectionFormat,
     pub(super) scrollable: bool,
+    pub(super) max_lines: Option<usize>,
+    /// Line spans reported by `Inline` during prepaint (collected only while
+    /// [`Self::max_lines`] is set); cleared by `TextView` at each frame start.
+    pub(super) line_spans: Arc<Mutex<Vec<LineSpan>>>,
+    /// Whether the last painted frame clipped content due to `max_lines`.
+    pub(super) clamped: bool,
     pub(super) text_view_style: TextViewStyle,
     pub(super) code_block_actions: Option<std::sync::Arc<CodeBlockActionsFn>>,
     pub(super) table_actions: Option<std::sync::Arc<TableActionsFn>>,
@@ -168,6 +189,9 @@ impl TextViewState {
             selectable: false,
             selection_format: SelectionFormat::default(),
             scrollable: false,
+            max_lines: None,
+            line_spans: Arc::default(),
+            clamped: false,
             // Measure all blocks (not just visible ones) so the scrollbar
             // thumb size stays stable. Without this, off-screen blocks count
             // as zero height until scrolled into view, which makes the
@@ -242,6 +266,12 @@ impl TextViewState {
         }
         self.scrollable = scrollable;
         cx.notify();
+    }
+
+    /// Whether the last painted frame clipped content because of
+    /// [`TextView::max_lines`](crate::text::TextView::max_lines).
+    pub fn is_clamped(&self) -> bool {
+        self.clamped
     }
 
     /// Set the text content.

--- a/crates/ui/src/text/state.rs
+++ b/crates/ui/src/text/state.rs
@@ -595,7 +595,10 @@ impl Render for TextViewState {
         node_cx.style = self.text_view_style.clone();
 
         v_flex()
-            .size_full()
+            .w_full()
+            // Clamped content must keep its natural height: stretching it to
+            // the capped box would hide the overflow the clamp has to measure.
+            .when(self.max_lines.is_none(), |this| this.h_full())
             .map(|this| match &mut self.parsed_error {
                 None => this.child(document.render_root(
                     if self.scrollable {

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -208,9 +208,11 @@ impl TextView {
     /// The view's height is capped at `n` × the base line height, and a line
     /// of glyphs is never cut in half: a line that would straddle the bottom
     /// of the box is left out whole, across paragraphs, lists, headings, code
-    /// blocks and tables. Everything else is cut on the box edge, so an image
-    /// or a rule crossing it shows the part that fits rather than disappearing
-    /// and leaving blank space behind.
+    /// blocks and tables. Nothing is shown with less than a line of itself to
+    /// show, so the border and padding a table row leads with never strands at
+    /// the bottom; whatever has more than that is cut on the box edge and keeps
+    /// the part that fits, rather than disappearing and leaving blank space
+    /// behind.
     ///
     /// Check [`TextViewState::is_clamped`] (which answers for the frame that
     /// was last painted) to decide whether to show an "expand" affordance.
@@ -344,37 +346,80 @@ pub struct TextViewPrepaintState {
     clip_bottom: Option<Pixels>,
 }
 
-/// Where to clip so that a line of glyphs is never cut in half: `Some(y)` when
-/// a line reported by a descendant `Inline` straddles `box_bottom`, pulling the
-/// clip up to that line's top.
+/// Absorbs sub-pixel layout jitter: a line ending within a pixel of the box
+/// bottom counts as fitting inside it.
+const CLIP_EPSILON: Pixels = px(1.);
+
+/// The bottom of the last whole line at or above `y`, with the height of a line
+/// where it sits.
+fn last_line_bottom_above(spans: &[LineSpan], y: Pixels) -> Option<(Pixels, Pixels)> {
+    let mut last: Option<(Pixels, Pixels)> = None;
+    let mut keep = |bottom: Pixels, line_height: Pixels| {
+        if bottom <= y + CLIP_EPSILON && last.is_none_or(|(last, _)| bottom > last) {
+            last = Some((bottom, line_height));
+        }
+    };
+
+    for span in spans {
+        if span.line_height <= px(0.) {
+            continue;
+        }
+        let mut bottom = span.top + span.line_height;
+        while bottom <= span.bottom + CLIP_EPSILON {
+            keep(bottom, span.line_height);
+            bottom += span.line_height;
+        }
+        // The span's own bottom covers a last line taller than the rest.
+        keep(span.bottom, span.line_height);
+    }
+
+    last
+}
+
+/// Where to clip, given the lines a descendant `Inline` reported. `None` leaves
+/// the clip on the box edge.
 ///
-/// `None` when no line straddles it, which leaves the clip on the box edge —
-/// content with no glyph lines of its own, an image or a rule, is cut there
-/// rather than dropped, and the box never holds blank space it could have
-/// filled.
-fn line_safe_clip_bottom(spans: &[LineSpan], box_bottom: Pixels) -> Option<Pixels> {
-    // Absorb sub-pixel layout jitter: a line ending within a pixel of the box
-    // bottom counts as fitting inside it.
-    let epsilon = px(1.);
-    let mut clip: Option<Pixels> = None;
+/// Two things are never shown: half a line of glyphs, and anything with less
+/// than a line of itself to show. A line straddling `box_bottom` is left out
+/// whole, and so is the strip between it and the line before — the border and
+/// padding a table row leads with reads as a rendering fault rather than as a
+/// row. Whatever has more than a line to show is cut on the edge and keeps the
+/// part that fits, so the box holds no blank space it could have filled.
+fn line_safe_clip_bottom(
+    spans: &[LineSpan],
+    box_bottom: Pixels,
+    content_bottom: Pixels,
+) -> Option<Pixels> {
+    let mut clip = box_bottom;
 
     for span in spans {
         if span.line_height <= px(0.)
-            || span.bottom <= box_bottom + epsilon
             || span.top >= box_bottom
+            || span.bottom <= box_bottom + CLIP_EPSILON
         {
             continue;
         }
         let whole_lines = ((box_bottom - span.top) / span.line_height).floor();
         let line_top = span.top + span.line_height * whole_lines;
         // A line starting on the box edge is not straddling it.
-        if line_top >= box_bottom - epsilon {
-            continue;
+        if line_top < box_bottom - CLIP_EPSILON {
+            clip = clip.min(line_top);
         }
-        clip = Some(clip.map_or(line_top, |clip: Pixels| clip.min(line_top)));
     }
 
-    clip
+    // Snap away a scrap. Only content that continues past the box can leave
+    // one: the space under the last line of a document that fits is the box's
+    // own, not a piece of something below.
+    if content_bottom > box_bottom + CLIP_EPSILON
+        && let Some((bottom, line_height)) = last_line_bottom_above(spans, clip)
+    {
+        let strip = clip - bottom;
+        if strip > CLIP_EPSILON && strip < line_height {
+            clip = bottom;
+        }
+    }
+
+    (clip < box_bottom - CLIP_EPSILON).then_some(clip)
 }
 
 impl Element for TextView {
@@ -530,7 +575,7 @@ impl Element for TextView {
                 });
             }
             if clipped {
-                clip_bottom = line_safe_clip_bottom(&line_spans, bounds.bottom());
+                clip_bottom = line_safe_clip_bottom(&line_spans, bounds.bottom(), content_bottom);
             }
         }
 
@@ -926,15 +971,62 @@ mod tests {
             },
         ];
 
-        // A box ending inside the line 88..108 leaves that line out whole.
-        assert_eq!(line_safe_clip_bottom(&spans, px(100.)), Some(px(88.)));
+        // Content continues well past the box in every case but the last.
+        let below = px(400.);
 
-        // A box ending on a line boundary, in a gap between blocks, or past
-        // all the text has no line to pull the clip up for — whatever else
-        // crosses the edge is cut there.
-        assert_eq!(line_safe_clip_bottom(&spans, px(88.)), None);
-        assert_eq!(line_safe_clip_bottom(&spans, px(64.)), None);
-        assert_eq!(line_safe_clip_bottom(&spans, px(130.)), None);
+        // A box ending inside the line 88..108 leaves that line out whole.
+        assert_eq!(
+            line_safe_clip_bottom(&spans, px(100.), below),
+            Some(px(88.))
+        );
+
+        // A box ending on a line boundary has nothing to pull the clip up for.
+        assert_eq!(line_safe_clip_bottom(&spans, px(88.), below), None);
+
+        // A strip below the last line shorter than a line — the border and
+        // padding a block leads with — is not worth showing.
+        assert_eq!(line_safe_clip_bottom(&spans, px(64.), below), Some(px(60.)));
+
+        // One taller than a line is: whatever crosses the edge keeps the part
+        // that fits rather than leaving the box half empty.
+        let one_block = [LineSpan {
+            top: px(0.),
+            bottom: px(60.),
+            line_height: px(20.),
+        }];
+        assert_eq!(line_safe_clip_bottom(&one_block, px(200.), below), None);
+
+        // Nothing crosses the edge at all: the space under the last line is
+        // the box's own, not a scrap of something below.
+        assert_eq!(line_safe_clip_bottom(&spans, px(130.), px(128.)), None);
+    }
+
+    #[test]
+    fn the_clip_does_not_stop_on_a_row_of_border_and_padding() {
+        use super::line_safe_clip_bottom;
+        use crate::text::state::LineSpan;
+
+        // Two table rows, each one line of text, 9px of border and padding
+        // between them.
+        let rows = [
+            LineSpan {
+                top: px(100.),
+                bottom: px(126.),
+                line_height: px(26.),
+            },
+            LineSpan {
+                top: px(135.),
+                bottom: px(161.),
+                line_height: px(26.),
+            },
+        ];
+
+        // Leaving out the second row's text would strand the 9px it leads
+        // with, so the clip goes back to the row above it.
+        assert_eq!(
+            line_safe_clip_bottom(&rows, px(148.), px(400.)),
+            Some(px(126.))
+        );
     }
 
     /// A clamped view nested the way an application nests one: inside a card,
@@ -944,6 +1036,7 @@ mod tests {
     /// box, nothing looks clipped and lines get cut in half.
     struct ClampedPageRoot {
         text_view: Entity<TextViewState>,
+        max_lines: usize,
     }
 
     impl Render for ClampedPageRoot {
@@ -966,7 +1059,7 @@ mod tests {
                                 .max_w(px(480.))
                                 .p_3()
                                 .gap_2()
-                                .child(TextView::new(&self.text_view).max_lines(3)),
+                                .child(TextView::new(&self.text_view).max_lines(self.max_lines)),
                         )
                         .overflow_y_scrollbar(),
                 )
@@ -983,7 +1076,10 @@ mod tests {
                     cx,
                 )
             });
-            ClampedPageRoot { text_view }
+            ClampedPageRoot {
+                text_view,
+                max_lines: 3,
+            }
         });
         let cx: &mut VisualTestContext = cx;
 

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -217,9 +217,10 @@ impl TextView {
     /// Check [`TextViewState::is_clamped`] (which answers for the frame that
     /// was last painted) to decide whether to show an "expand" affordance.
     ///
-    /// With paragraph spacing or oversized headings, fewer than `n` full lines
-    /// may fit inside the capped height. Ignored when [`Self::scrollable`] is
-    /// set.
+    /// `n` counts lines of body text, so paragraph spacing and taller lines
+    /// mean fewer of them fit inside the capped height. A line taller than the
+    /// whole budget keeps the part that fits rather than emptying the box.
+    /// Ignored when [`Self::scrollable`] is set.
     pub fn max_lines(mut self, max_lines: usize) -> Self {
         self.max_lines = Some(max_lines);
         self
@@ -407,15 +408,21 @@ fn line_safe_clip_bottom(
         }
     }
 
+    let Some((last_line_bottom, line_height)) = last_line_bottom_above(spans, clip) else {
+        // Leaving the straddling line out would leave nothing at all — a first
+        // line taller than the whole budget, a heading in a one-line box. It
+        // keeps the part that fits instead, because an empty clamp reads as
+        // broken where a cut one reads as more to come.
+        return None;
+    };
+
     // Snap away a scrap. Only content that continues past the box can leave
     // one: the space under the last line of a document that fits is the box's
     // own, not a piece of something below.
-    if content_bottom > box_bottom + CLIP_EPSILON
-        && let Some((bottom, line_height)) = last_line_bottom_above(spans, clip)
-    {
-        let strip = clip - bottom;
+    if content_bottom > box_bottom + CLIP_EPSILON {
+        let strip = clip - last_line_bottom;
         if strip > CLIP_EPSILON && strip < line_height {
-            clip = bottom;
+            clip = last_line_bottom;
         }
     }
 
@@ -999,6 +1006,21 @@ mod tests {
         // Nothing crosses the edge at all: the space under the last line is
         // the box's own, not a scrap of something below.
         assert_eq!(line_safe_clip_bottom(&spans, px(130.), px(128.)), None);
+    }
+
+    #[test]
+    fn a_line_taller_than_the_budget_keeps_the_part_that_fits() {
+        use super::line_safe_clip_bottom;
+        use crate::text::state::LineSpan;
+
+        // A heading line of 28px, in a box capped at one 26px body line.
+        let heading = [LineSpan {
+            top: px(70.),
+            bottom: px(98.),
+            line_height: px(28.),
+        }];
+
+        assert_eq!(line_safe_clip_bottom(&heading, px(96.), px(400.)), None);
     }
 
     #[test]

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -205,16 +205,19 @@ impl TextView {
 
     /// Clamp the rendered content to at most `n` lines of body text.
     ///
-    /// The view's height is capped at `n` × the base line height, and the
-    /// paint-time clip snaps up to the nearest whole-line boundary so a line
-    /// of glyphs is never cut in half — across paragraphs, lists, headings,
-    /// code blocks and tables. Check [`TextViewState::is_clamped`] (reflects
-    /// the previous painted frame) to decide whether to show an "expand"
-    /// affordance.
+    /// The view's height is capped at `n` × the base line height, and a line
+    /// of glyphs is never cut in half: a line that would straddle the bottom
+    /// of the box is left out whole, across paragraphs, lists, headings, code
+    /// blocks and tables. Everything else is cut on the box edge, so an image
+    /// or a rule crossing it shows the part that fits rather than disappearing
+    /// and leaving blank space behind.
     ///
-    /// With paragraph spacing or oversized headings, fewer than `n` full
-    /// lines may fit inside the capped height. Ignored when
-    /// [`Self::scrollable`] is set.
+    /// Check [`TextViewState::is_clamped`] (which answers for the frame that
+    /// was last painted) to decide whether to show an "expand" affordance.
+    ///
+    /// With paragraph spacing or oversized headings, fewer than `n` full lines
+    /// may fit inside the capped height. Ignored when [`Self::scrollable`] is
+    /// set.
     pub fn max_lines(mut self, max_lines: usize) -> Self {
         self.max_lines = Some(max_lines);
         self
@@ -335,38 +338,43 @@ pub struct TextViewLayoutState {
 
 pub struct TextViewPrepaintState {
     hitbox: Hitbox,
-    /// Absolute bottom of the `max_lines` clip when content was clipped this
-    /// frame — the largest whole-line boundary that fits inside the box.
+    /// Where paint has to pull the `max_lines` clip up to, because a glyph line
+    /// straddles the bottom of the box. `None` leaves the clip at the box edge,
+    /// where the container's hidden overflow already applies it.
     clip_bottom: Option<Pixels>,
 }
 
-/// The largest whole-line bottom edge (derived from the spans reported by
-/// descendant `Inline`s) that fits within `box_bottom`, plus whether any
-/// reported line extends past the box (content is clipped).
-fn snapped_clip_bottom(spans: &[LineSpan], box_bottom: Pixels) -> (Option<Pixels>, bool) {
-    // Absorb sub-pixel layout jitter so a line that exactly touches the box
-    // bottom still counts as fitting.
+/// Where to clip so that a line of glyphs is never cut in half: `Some(y)` when
+/// a line reported by a descendant `Inline` straddles `box_bottom`, pulling the
+/// clip up to that line's top.
+///
+/// `None` when no line straddles it, which leaves the clip on the box edge —
+/// content with no glyph lines of its own, an image or a rule, is cut there
+/// rather than dropped, and the box never holds blank space it could have
+/// filled.
+fn line_safe_clip_bottom(spans: &[LineSpan], box_bottom: Pixels) -> Option<Pixels> {
+    // Absorb sub-pixel layout jitter: a line ending within a pixel of the box
+    // bottom counts as fitting inside it.
     let epsilon = px(1.);
-    let mut best: Option<Pixels> = None;
-    let mut clipped = false;
+    let mut clip: Option<Pixels> = None;
 
     for span in spans {
-        if span.line_height <= px(0.) {
+        if span.line_height <= px(0.)
+            || span.bottom <= box_bottom + epsilon
+            || span.top >= box_bottom
+        {
             continue;
         }
-        if span.bottom > box_bottom + epsilon {
-            clipped = true;
+        let whole_lines = ((box_bottom - span.top) / span.line_height).floor();
+        let line_top = span.top + span.line_height * whole_lines;
+        // A line starting on the box edge is not straddling it.
+        if line_top >= box_bottom - epsilon {
+            continue;
         }
-        let mut bottom = span.top + span.line_height;
-        while bottom <= span.bottom + epsilon && bottom <= box_bottom + epsilon {
-            if best.is_none_or(|best| bottom > best) {
-                best = Some(bottom);
-            }
-            bottom += span.line_height;
-        }
+        clip = Some(clip.map_or(line_top, |clip: Pixels| clip.min(line_top)));
     }
 
-    (best, clipped)
+    clip
 }
 
 impl Element for TextView {
@@ -498,15 +506,21 @@ impl Element for TextView {
 
         let mut clip_bottom = None;
         if max_lines_active {
-            let (snapped, clipped) = {
+            let (line_spans, content_bottom) = {
                 let state = state.read(cx);
-                let line_spans = state
-                    .line_spans
-                    .lock()
-                    .map(|spans| spans.clone())
-                    .unwrap_or_default();
-                snapped_clip_bottom(&line_spans, bounds.bottom())
+                (
+                    state
+                        .line_spans
+                        .lock()
+                        .map(|spans| spans.clone())
+                        .unwrap_or_default(),
+                    state.bounds().bottom(),
+                )
             };
+            // The content keeps its natural height inside the capped box, so
+            // this sees everything the box cannot show — including a tall image
+            // that reports no lines of its own.
+            let clipped = content_bottom > bounds.bottom() + px(1.);
             // Notify on change so observers (e.g. an "expand" button gated on
             // `is_clamped`) re-render once the flag flips.
             if state.read(cx).clamped != clipped {
@@ -516,7 +530,7 @@ impl Element for TextView {
                 });
             }
             if clipped {
-                clip_bottom = snapped.filter(|bottom| *bottom < bounds.bottom() - px(0.5));
+                clip_bottom = line_safe_clip_bottom(&line_spans, bounds.bottom());
             }
         }
 
@@ -893,8 +907,8 @@ mod tests {
     }
 
     #[test]
-    fn snapped_clip_bottom_snaps_to_whole_lines() {
-        use super::snapped_clip_bottom;
+    fn the_clip_only_moves_for_a_straddling_glyph_line() {
+        use super::line_safe_clip_bottom;
         use crate::text::state::LineSpan;
 
         let spans = [
@@ -912,15 +926,68 @@ mod tests {
             },
         ];
 
-        // A box ending mid-line snaps down to the last whole line above it.
-        let (snap, clipped) = snapped_clip_bottom(&spans, px(100.));
-        assert_eq!(snap, Some(px(88.)));
-        assert!(clipped);
+        // A box ending inside the line 88..108 leaves that line out whole.
+        assert_eq!(line_safe_clip_bottom(&spans, px(100.)), Some(px(88.)));
 
-        // A box that fits everything reports no clipping.
-        let (snap, clipped) = snapped_clip_bottom(&spans, px(130.));
-        assert_eq!(snap, Some(px(128.)));
-        assert!(!clipped);
+        // A box ending on a line boundary, in a gap between blocks, or past
+        // all the text has no line to pull the clip up for — whatever else
+        // crosses the edge is cut there.
+        assert_eq!(line_safe_clip_bottom(&spans, px(88.)), None);
+        assert_eq!(line_safe_clip_bottom(&spans, px(64.)), None);
+        assert_eq!(line_safe_clip_bottom(&spans, px(130.)), None);
+    }
+
+    /// A clamped view nested the way an application nests one: inside a card,
+    /// inside a region that fills a window of a known height. The height an
+    /// ancestor hands down must not reach the clamped content and hide the
+    /// overflow the clamp measures — with the content stretched to the capped
+    /// box, nothing looks clipped and lines get cut in half.
+    struct ClampedPageRoot {
+        text_view: Entity<TextViewState>,
+    }
+
+    impl Render for ClampedPageRoot {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            use crate::scroll::ScrollableElement as _;
+            use crate::{h_flex, v_flex};
+
+            v_flex()
+                .size_full()
+                .p_4()
+                .gap_4()
+                .child(h_flex().max_w(px(480.)).gap_3().child("header"))
+                .child(
+                    v_flex()
+                        .flex_1()
+                        .min_h_0()
+                        .gap_4()
+                        .child(
+                            v_flex()
+                                .max_w(px(480.))
+                                .p_3()
+                                .gap_2()
+                                .child(TextView::new(&self.text_view).max_lines(3)),
+                        )
+                        .overflow_y_scrollbar(),
+                )
+        }
+    }
+
+    #[gpui::test]
+    fn max_lines_measures_overflow_inside_a_sized_page(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (root, cx) = cx.add_window_view(|_, cx| {
+            let text_view = cx.new(|cx| {
+                TextViewState::markdown(
+                    "first\n\nsecond\n\nthird\n\nfourth\n\nfifth\n\nsixth\n\nseventh",
+                    cx,
+                )
+            });
+            ClampedPageRoot { text_view }
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        assert!(root.read_with(cx, |root, cx| root.text_view.read(cx).is_clamped()));
     }
 
     #[gpui::test]

--- a/crates/ui/src/text/text_view.rs
+++ b/crates/ui/src/text/text_view.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    AnyElement, App, Bounds, ClickEvent, Element, ElementId, Entity, GlobalElementId, Hitbox,
-    HitboxBehavior, InspectorElementId, InteractiveElement, IntoElement, LayoutId, MouseButton,
-    ParentElement, Pixels, SharedString, StyleRefinement, Styled, Window, div,
+    AnyElement, App, Bounds, ClickEvent, ContentMask, Element, ElementId, Entity, GlobalElementId,
+    Hitbox, HitboxBehavior, InspectorElementId, InteractiveElement, IntoElement, LayoutId,
+    MouseButton, ParentElement, Pixels, Refineable as _, SharedString, StyleRefinement, Styled,
+    Window, div, point, px,
 };
 
 use crate::StyledExt;
@@ -12,7 +13,7 @@ use crate::scroll::ScrollableElement;
 use crate::text::TextViewFormat;
 use crate::text::markdown_ext::{MarkdownExtensions, MarkdownNode, MarkdownPlugin};
 use crate::text::node::{CodeBlock, TableData};
-use crate::text::state::{SelectionFormat, TextViewState};
+use crate::text::state::{LineSpan, SelectionFormat, TextViewState};
 use crate::{global_state::UiGlobalState, text::TextViewStyle};
 
 /// Type for code block actions generator function.
@@ -73,6 +74,7 @@ pub struct TextView {
     selectable: bool,
     selection_format: SelectionFormat,
     scrollable: bool,
+    max_lines: Option<usize>,
     code_block_actions: Option<Arc<CodeBlockActionsFn>>,
     table_actions: Option<Arc<TableActionsFn>>,
     link_click_handler: Option<Arc<LinkClickHandlerFn>>,
@@ -115,6 +117,7 @@ impl TextView {
             selectable: false,
             selection_format: SelectionFormat::default(),
             scrollable: false,
+            max_lines: None,
             code_block_actions: None,
             table_actions: None,
             link_click_handler: None,
@@ -134,6 +137,7 @@ impl TextView {
             selectable: false,
             selection_format: SelectionFormat::default(),
             scrollable: false,
+            max_lines: None,
             code_block_actions: None,
             table_actions: None,
             link_click_handler: None,
@@ -153,6 +157,7 @@ impl TextView {
             selectable: false,
             selection_format: SelectionFormat::default(),
             scrollable: false,
+            max_lines: None,
             code_block_actions: None,
             table_actions: None,
             link_click_handler: None,
@@ -195,6 +200,23 @@ impl TextView {
     /// This mode is suitable for small content, such as a few lines of text, a label, etc.
     pub fn scrollable(mut self, scrollable: bool) -> Self {
         self.scrollable = scrollable;
+        self
+    }
+
+    /// Clamp the rendered content to at most `n` lines of body text.
+    ///
+    /// The view's height is capped at `n` × the base line height, and the
+    /// paint-time clip snaps up to the nearest whole-line boundary so a line
+    /// of glyphs is never cut in half — across paragraphs, lists, headings,
+    /// code blocks and tables. Check [`TextViewState::is_clamped`] (reflects
+    /// the previous painted frame) to decide whether to show an "expand"
+    /// affordance.
+    ///
+    /// With paragraph spacing or oversized headings, fewer than `n` full
+    /// lines may fit inside the capped height. Ignored when
+    /// [`Self::scrollable`] is set.
+    pub fn max_lines(mut self, max_lines: usize) -> Self {
+        self.max_lines = Some(max_lines);
         self
     }
 
@@ -311,9 +333,45 @@ pub struct TextViewLayoutState {
     element: AnyElement,
 }
 
+pub struct TextViewPrepaintState {
+    hitbox: Hitbox,
+    /// Absolute bottom of the `max_lines` clip when content was clipped this
+    /// frame — the largest whole-line boundary that fits inside the box.
+    clip_bottom: Option<Pixels>,
+}
+
+/// The largest whole-line bottom edge (derived from the spans reported by
+/// descendant `Inline`s) that fits within `box_bottom`, plus whether any
+/// reported line extends past the box (content is clipped).
+fn snapped_clip_bottom(spans: &[LineSpan], box_bottom: Pixels) -> (Option<Pixels>, bool) {
+    // Absorb sub-pixel layout jitter so a line that exactly touches the box
+    // bottom still counts as fitting.
+    let epsilon = px(1.);
+    let mut best: Option<Pixels> = None;
+    let mut clipped = false;
+
+    for span in spans {
+        if span.line_height <= px(0.) {
+            continue;
+        }
+        if span.bottom > box_bottom + epsilon {
+            clipped = true;
+        }
+        let mut bottom = span.top + span.line_height;
+        while bottom <= span.bottom + epsilon && bottom <= box_bottom + epsilon {
+            if best.is_none_or(|best| bottom > best) {
+                best = Some(bottom);
+            }
+            bottom += span.line_height;
+        }
+    }
+
+    (best, clipped)
+}
+
 impl Element for TextView {
     type RequestLayoutState = TextViewLayoutState;
-    type PrepaintState = Hitbox;
+    type PrepaintState = TextViewPrepaintState;
 
     fn id(&self) -> Option<ElementId> {
         Some(self.id.clone())
@@ -351,6 +409,10 @@ impl Element for TextView {
             state
         };
 
+        // `max_lines` needs the whole document laid out to snap the clip to a
+        // whole line, so it only applies to the fit-content mode.
+        let max_lines = self.max_lines.filter(|_| !self.scrollable);
+
         state.update(cx, |state, cx| {
             state.code_block_actions = self.code_block_actions.clone();
             state.table_actions = self.table_actions.clone();
@@ -359,6 +421,7 @@ impl Element for TextView {
             state.selectable = self.selectable;
             state.selection_format = self.selection_format;
             state.scrollable = self.scrollable;
+            state.max_lines = max_lines;
             if state.text_view_style != self.text_view_style {
                 state.selection_revision = state.selection_revision.wrapping_add(1);
             }
@@ -372,12 +435,22 @@ impl Element for TextView {
         let focus_handle = state.read(cx).focus_handle.clone();
         let list_state = state.read(cx).list_state.clone();
 
+        // Cap the box at `n` body-text lines (the effective text style may be
+        // refined by this view's own style, e.g. `.text_sm()`); hidden
+        // overflow also clips descendant hitboxes to the box during prepaint.
+        let max_lines_cap = max_lines.map(|max_lines| {
+            let mut text_style = window.text_style();
+            text_style.refine(&self.style.text);
+            text_style.line_height_in_pixels(window.rem_size()) * max_lines as f32
+        });
+
         let mut el = div()
             .key_context("TextView")
             .track_focus(&focus_handle)
             .when(self.scrollable, |this| {
                 this.size_full().vertical_scrollbar(&list_state)
             })
+            .when_some(max_lines_cap, |this, cap| this.max_h(cap).overflow_hidden())
             .relative()
             .on_action(move |_: &crate::input::Copy, window, cx| {
                 let text = gpui_base::TextSelection::selected_text(window, cx)
@@ -406,17 +479,60 @@ impl Element for TextView {
         window: &mut Window,
         cx: &mut App,
     ) -> Self::PrepaintState {
+        let state = request_layout.state.clone();
+        let max_lines_active = state.read(cx).max_lines.is_some();
+        if max_lines_active {
+            if let Ok(mut line_spans) = state.read(cx).line_spans.lock() {
+                line_spans.clear();
+            }
+            // Descendant `Inline`s report their line spans through the state
+            // stack during prepaint (in addition to the paint-time push below).
+            UiGlobalState::global_mut(cx)
+                .text_view_state_stack
+                .push(state.clone());
+        }
         request_layout.element.prepaint(window, cx);
-        window.insert_hitbox(bounds, HitboxBehavior::Normal)
+        if max_lines_active {
+            UiGlobalState::global_mut(cx).text_view_state_stack.pop();
+        }
+
+        let mut clip_bottom = None;
+        if max_lines_active {
+            let (snapped, clipped) = {
+                let state = state.read(cx);
+                let line_spans = state
+                    .line_spans
+                    .lock()
+                    .map(|spans| spans.clone())
+                    .unwrap_or_default();
+                snapped_clip_bottom(&line_spans, bounds.bottom())
+            };
+            // Notify on change so observers (e.g. an "expand" button gated on
+            // `is_clamped`) re-render once the flag flips.
+            if state.read(cx).clamped != clipped {
+                state.update(cx, |state, cx| {
+                    state.clamped = clipped;
+                    cx.notify();
+                });
+            }
+            if clipped {
+                clip_bottom = snapped.filter(|bottom| *bottom < bounds.bottom() - px(0.5));
+            }
+        }
+
+        TextViewPrepaintState {
+            hitbox: window.insert_hitbox(bounds, HitboxBehavior::Normal),
+            clip_bottom,
+        }
     }
 
     fn paint(
         &mut self,
         _: Option<&GlobalElementId>,
         _: Option<&InspectorElementId>,
-        _bounds: Bounds<Pixels>,
+        bounds: Bounds<Pixels>,
         request_layout: &mut Self::RequestLayoutState,
-        hitbox: &mut Self::PrepaintState,
+        prepaint: &mut Self::PrepaintState,
         window: &mut Window,
         cx: &mut App,
     ) {
@@ -428,7 +544,18 @@ impl Element for TextView {
         UiGlobalState::global_mut(cx)
             .text_view_state_stack
             .push(state.clone());
-        request_layout.element.paint(window, cx);
+        if let Some(clip_bottom) = prepaint.clip_bottom {
+            // Snap the `max_lines` clip to the last whole line that fits, so a
+            // line of glyphs is never cut in half.
+            let mask = ContentMask {
+                bounds: Bounds::from_corners(bounds.origin, point(bounds.right(), clip_bottom)),
+            };
+            window.with_content_mask(Some(mask), |window| {
+                request_layout.element.paint(window, cx);
+            });
+        } else {
+            request_layout.element.paint(window, cx);
+        }
         UiGlobalState::global_mut(cx).text_view_state_stack.pop();
 
         if self.selectable {
@@ -442,7 +569,7 @@ impl Element for TextView {
             };
             let document_order = UiGlobalState::global_mut(cx).next_selection_document_order();
             adapter.register(
-                hitbox.clone(),
+                prepaint.hitbox.clone(),
                 content_bounds,
                 scroll_offset,
                 document_order,
@@ -738,6 +865,102 @@ mod tests {
         let cx: &mut VisualTestContext = cx;
 
         cx.simulate_click(point(px(10.), px(34.)), Modifiers::default());
+
+        assert_eq!(cx.opened_url(), None);
+    }
+
+    struct MaxLinesTestRoot {
+        text_view: Entity<TextViewState>,
+        max_lines: usize,
+    }
+
+    impl MaxLinesTestRoot {
+        fn new(text: &str, max_lines: usize, cx: &mut Context<Self>) -> Self {
+            let text_view = cx.new(|cx| TextViewState::markdown(text, cx));
+            Self {
+                text_view,
+                max_lines,
+            }
+        }
+    }
+
+    impl Render for MaxLinesTestRoot {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .w(px(200.))
+                .child(TextView::new(&self.text_view).max_lines(self.max_lines))
+        }
+    }
+
+    #[test]
+    fn snapped_clip_bottom_snaps_to_whole_lines() {
+        use super::snapped_clip_bottom;
+        use crate::text::state::LineSpan;
+
+        let spans = [
+            // Lines end at 20 / 40 / 60.
+            LineSpan {
+                top: px(0.),
+                bottom: px(60.),
+                line_height: px(20.),
+            },
+            // A second block after an 8px gap; lines end at 88 / 108 / 128.
+            LineSpan {
+                top: px(68.),
+                bottom: px(128.),
+                line_height: px(20.),
+            },
+        ];
+
+        // A box ending mid-line snaps down to the last whole line above it.
+        let (snap, clipped) = snapped_clip_bottom(&spans, px(100.));
+        assert_eq!(snap, Some(px(88.)));
+        assert!(clipped);
+
+        // A box that fits everything reports no clipping.
+        let (snap, clipped) = snapped_clip_bottom(&spans, px(130.));
+        assert_eq!(snap, Some(px(128.)));
+        assert!(!clipped);
+    }
+
+    #[gpui::test]
+    fn max_lines_clamps_overflowing_content(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (root, cx) = cx.add_window_view(|_, cx| {
+            MaxLinesTestRoot::new(
+                "first\n\nsecond\n\nthird\n\nfourth\n\nfifth\n\nsixth",
+                2,
+                cx,
+            )
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        assert!(root.read_with(cx, |root, cx| root.text_view.read(cx).is_clamped()));
+    }
+
+    #[gpui::test]
+    fn max_lines_leaves_short_content_unclamped(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (root, cx) = cx.add_window_view(|_, cx| MaxLinesTestRoot::new("only line", 3, cx));
+        let cx: &mut VisualTestContext = cx;
+
+        assert!(!root.read_with(cx, |root, cx| root.text_view.read(cx).is_clamped()));
+    }
+
+    #[gpui::test]
+    fn max_lines_disables_links_hidden_by_the_clamp(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, cx| {
+            MaxLinesTestRoot::new(
+                "first\n\nsecond\n\nthird\n\n[hidden](https://example.com)",
+                2,
+                cx,
+            )
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        // Click far below the clamped box, where the link would sit unclamped.
+        cx.simulate_click(point(px(10.), px(150.)), Modifiers::default());
 
         assert_eq!(cx.opened_url(), None);
     }

--- a/examples/text_max_lines/Cargo.toml
+++ b/examples/text_max_lines/Cargo.toml
@@ -11,6 +11,7 @@ gpui.workspace = true
 gpui_platform.workspace = true
 gpui-component = { workspace = true }
 gpui-component-assets.workspace = true
+reqwest_client.workspace = true
 
 [lints]
 workspace = true

--- a/examples/text_max_lines/Cargo.toml
+++ b/examples/text_max_lines/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "text_max_lines"
+description = "Clamp rendered Markdown to N whole lines with TextView::max_lines."
+version = "0.5.1"
+publish = false
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+gpui.workspace = true
+gpui_platform.workspace = true
+gpui-component = { workspace = true }
+gpui-component-assets.workspace = true
+
+[lints]
+workspace = true

--- a/examples/text_max_lines/src/main.rs
+++ b/examples/text_max_lines/src/main.rs
@@ -1,21 +1,18 @@
-//! Clamp rendered Markdown to N whole lines with `TextView::max_lines`.
+//! Clamp rendered Markdown to a number of whole lines with
+//! `TextView::max_lines`.
 //!
-//! - Drag the slider (1 to 60 lines) to change the line budget: the first card
-//!   re-clamps, and a line of text is never cut in half. The photo crossing the
-//!   edge is cut there, showing the part that fits.
-//! - An Expand / Collapse button shows only while `is_clamped()` reports true
-//!   (or the card is expanded).
-//! - The second card fits within the cap, so it renders at natural height and
-//!   no button shows.
-//! - Resize the window: reflow changes where lines wrap, and the clip keeps
-//!   snapping to whole lines.
+//! - Drag the slider to change the line budget: a line of text is never cut in
+//!   half, and nothing is shown with less than a line of itself to show.
+//! - The photo crossing the edge is cut there, keeping the part that fits.
+//! - "Show more" appears only while `TextViewState::is_clamped()` reports that
+//!   the previous painted frame clipped something.
 //!
 //! Run: `cargo run -p text_max_lines`
 
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{
-    ActiveTheme as _,
-    button::Button,
+    ActiveTheme as _, IconName, Sizable as _,
+    button::{Button, ButtonVariants as _},
     scroll::ScrollableElement as _,
     slider::{Slider, SliderEvent, SliderState},
     text::{TextView, TextViewState},
@@ -31,8 +28,8 @@ const LONG_MARKDOWN: &str = r#"### Quarterly summary
 rollout and the new [market data](https://longbridge.com) subscriptions —
 legacy plans are ~~discontinued~~ and folded into `pro`.
 
-> The clip must land on a whole-line boundary: however you drag the slider,
-> no line of glyphs is ever cut in half.
+> The clip must land on a whole line: however you drag the slider, no line of
+> glyphs is ever cut in half.
 
 Inline image mix: PNG avatars <img src="https://avatars.githubusercontent.com/u/5518" alt="Jason Lee avatar" width="32" height="32" /> and <img src="https://avatars.githubusercontent.com/u/28998859" alt="GitHub avatar" width="32" height="32" /> stay inside the same text flow, and an SVG badge ![Rust](https://rust-lang.org/static/images/rust-logo-blk.svg) wraps with the text around it.
 
@@ -61,7 +58,8 @@ fn main() {
 Text lines are kept whole; the photo above is cut on the box edge instead, so
 the preview never holds blank space it could have filled."#;
 
-const SHORT_MARKDOWN: &str = "A **short** note that fits within the cap, so no button shows.";
+const SHORT_MARKDOWN: &str = "A **short** note that fits inside the cap, so it renders at its natural \
+     height and no button appears.";
 
 struct MaxLinesExample {
     long: Entity<TextViewState>,
@@ -75,8 +73,8 @@ impl MaxLinesExample {
     fn new(cx: &mut Context<Self>) -> Self {
         let long = cx.new(|cx| TextViewState::markdown(LONG_MARKDOWN, cx));
         let short = cx.new(|cx| TextViewState::markdown(SHORT_MARKDOWN, cx));
-        // `is_clamped` is written by TextView during draw; observe the states
-        // so the Expand button shows up as soon as the flag flips.
+        // `is_clamped` is written while the view paints; observe the states so
+        // the button follows it without the caller measuring the text again.
         cx.observe(&long, |_, _, cx| cx.notify()).detach();
         cx.observe(&short, |_, _, cx| cx.notify()).detach();
 
@@ -104,14 +102,22 @@ impl MaxLinesExample {
         }
     }
 
-    fn card(&self, content: impl IntoElement, cx: &App) -> Div {
+    /// Caption above a preview, then the preview itself on a hairline surface.
+    fn section(&self, caption: impl Into<SharedString>, body: Div, cx: &App) -> Div {
         v_flex()
-            .max_w(px(480.))
-            .p_3()
             .gap_2()
-            .rounded(cx.theme().radius_lg)
-            .bg(cx.theme().muted)
-            .child(content)
+            .child(
+                div()
+                    .text_xs()
+                    .text_color(cx.theme().muted_foreground)
+                    .child(caption.into()),
+            )
+            .child(
+                body.p_4()
+                    .rounded(cx.theme().radius)
+                    .border_1()
+                    .border_color(cx.theme().border),
+            )
     }
 }
 
@@ -123,47 +129,101 @@ impl Render for MaxLinesExample {
 
         v_flex()
             .size_full()
-            .p_4()
-            .gap_4()
+            .bg(cx.theme().background)
+            .text_color(cx.theme().foreground)
             .child(
-                h_flex()
-                    .max_w(px(480.))
-                    .gap_3()
-                    .items_center()
-                    .child(format!("max_lines: {max_lines}"))
-                    .child(div().flex_1().child(Slider::new(&self.slider))),
+                v_flex()
+                    .px_6()
+                    .pt_6()
+                    .pb_4()
+                    .gap_1()
+                    .child(div().text_lg().font_semibold().child("Clamped previews"))
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(cx.theme().muted_foreground)
+                            .child(
+                                "Rendered Markdown bounded to a number of whole lines. \
+                                 Drag the slider, or resize the window to reflow the text.",
+                            ),
+                    ),
             )
             .child(
-                // The cards scroll while the slider stays pinned above.
+                h_flex()
+                    .px_6()
+                    .pb_4()
+                    .gap_3()
+                    .items_center()
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(cx.theme().muted_foreground)
+                            .child("Lines"),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .max_w(px(320.))
+                            .child(Slider::new(&self.slider)),
+                    )
+                    // A fixed width keeps the slider still as the value grows.
+                    .child(div().w(px(24.)).text_sm().child(max_lines.to_string())),
+            )
+            .child(
                 v_flex()
                     .flex_1()
                     .min_h_0()
-                    .gap_4()
+                    .px_6()
+                    .pb_6()
+                    .gap_6()
                     .child(
-                        self.card(
-                            TextView::new(&self.long)
-                                .selectable(true)
-                                .when(!expanded, |this| this.max_lines(max_lines)),
+                        self.section(
+                            if expanded {
+                                "Expanded"
+                            } else {
+                                "Clamped to the line budget"
+                            },
+                            v_flex()
+                                .gap_3()
+                                .child(
+                                    TextView::new(&self.long)
+                                        .selectable(true)
+                                        .when(!expanded, |this| this.max_lines(max_lines)),
+                                )
+                                .when(clamped || expanded, |this| {
+                                    this.child(
+                                        h_flex().child(
+                                            Button::new("toggle")
+                                                .ghost()
+                                                .small()
+                                                .icon(if expanded {
+                                                    IconName::ChevronUp
+                                                } else {
+                                                    IconName::ChevronDown
+                                                })
+                                                .label(if expanded {
+                                                    "Show less"
+                                                } else {
+                                                    "Show more"
+                                                })
+                                                .on_click(cx.listener(|this, _, _, cx| {
+                                                    this.expanded = !this.expanded;
+                                                    cx.notify();
+                                                })),
+                                        ),
+                                    )
+                                }),
                             cx,
-                        )
-                        .when(clamped || expanded, |this| {
-                            this.child(
-                                h_flex().child(
-                                    Button::new("toggle")
-                                        .label(if expanded { "Collapse" } else { "Expand" })
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.expanded = !this.expanded;
-                                            cx.notify();
-                                        })),
-                                ),
-                            )
-                        }),
+                        ),
                     )
                     .child(
-                        self.card(
-                            TextView::new(&self.short)
-                                .selectable(true)
-                                .max_lines(max_lines),
+                        self.section(
+                            "Shorter than the budget",
+                            v_flex().child(
+                                TextView::new(&self.short)
+                                    .selectable(true)
+                                    .max_lines(max_lines),
+                            ),
                             cx,
                         ),
                     )
@@ -186,7 +246,7 @@ fn main() {
         cx.set_http_client(std::sync::Arc::new(http_client));
 
         let window_options = WindowOptions {
-            window_bounds: Some(WindowBounds::centered(size(px(680.), px(620.)), cx)),
+            window_bounds: Some(WindowBounds::centered(size(px(720.), px(680.)), cx)),
             ..Default::default()
         };
 

--- a/examples/text_max_lines/src/main.rs
+++ b/examples/text_max_lines/src/main.rs
@@ -1,7 +1,8 @@
 //! Clamp rendered Markdown to N whole lines with `TextView::max_lines`.
 //!
-//! - Drag the slider to change the line budget: the first card re-clamps and
-//!   the clip always lands on a whole-line boundary (no half-cut glyphs).
+//! - Drag the slider (1 to 60 lines) to change the line budget: the first card
+//!   re-clamps, and a line of text is never cut in half. The photo crossing the
+//!   edge is cut there, showing the part that fits.
 //! - An Expand / Collapse button shows only while `is_clamped()` reports true
 //!   (or the card is expanded).
 //! - The second card fits within the cap, so it renders at natural height and
@@ -33,9 +34,7 @@ legacy plans are ~~discontinued~~ and folded into `pro`.
 > The clip must land on a whole-line boundary: however you drag the slider,
 > no line of glyphs is ever cut in half.
 
-Reviewed by ![reviewer](https://avatars.githubusercontent.com/u/583231?v=4)
-octocat together with ![bot](https://avatars.githubusercontent.com/u/5518?v=4)
-the tooling team, inline within this very paragraph.
+Inline image mix: PNG avatars <img src="https://avatars.githubusercontent.com/u/5518" alt="Jason Lee avatar" width="32" height="32" /> and <img src="https://avatars.githubusercontent.com/u/28998859" alt="GitHub avatar" width="32" height="32" /> stay inside the same text flow, and an SVG badge ![Rust](https://rust-lang.org/static/images/rust-logo-blk.svg) wraps with the text around it.
 
 - Desktop DAU is up **24%**
   - macOS **+31%**, Windows *+19%*
@@ -49,7 +48,7 @@ the tooling team, inline within this very paragraph.
 | Mobile  | +9%    | steady               |
 | Web     | -3%    | migrating to desktop |
 
-![banner](https://avatars.githubusercontent.com/u/150917089?v=4)
+![Img](https://miro.medium.com/v2/resize:fit:1400/format:webp/1*WgEz5f3n3lD7MfC7NeQGOA.jpeg)
 
 ---
 
@@ -59,8 +58,8 @@ fn main() {
 }
 ```
 
-That table, banner image and code block only show once you press Expand — a
-block that does not fit as a whole is hidden entirely rather than sliced."#;
+Text lines are kept whole; the photo above is cut on the box edge instead, so
+the preview never holds blank space it could have filled."#;
 
 const SHORT_MARKDOWN: &str = "A **short** note that fits within the cap, so no button shows.";
 
@@ -84,7 +83,7 @@ impl MaxLinesExample {
         let slider = cx.new(|_| {
             SliderState::new()
                 .min(1.)
-                .max(20.)
+                .max(60.)
                 .step(1.)
                 .default_value(DEFAULT_MAX_LINES as f32)
         });

--- a/examples/text_max_lines/src/main.rs
+++ b/examples/text_max_lines/src/main.rs
@@ -1,0 +1,198 @@
+//! Clamp rendered Markdown to N whole lines with `TextView::max_lines`.
+//!
+//! - Drag the slider to change the line budget: the first card re-clamps and
+//!   the clip always lands on a whole-line boundary (no half-cut glyphs).
+//! - An Expand / Collapse button shows only while `is_clamped()` reports true
+//!   (or the card is expanded).
+//! - The second card fits within the cap, so it renders at natural height and
+//!   no button shows.
+//! - Resize the window: reflow changes where lines wrap, and the clip keeps
+//!   snapping to whole lines.
+//!
+//! Run: `cargo run -p text_max_lines`
+
+use gpui::{prelude::FluentBuilder as _, *};
+use gpui_component::{
+    ActiveTheme as _,
+    button::Button,
+    scroll::ScrollableElement as _,
+    slider::{Slider, SliderEvent, SliderState},
+    text::{TextView, TextViewState},
+    *,
+};
+use gpui_component_assets::Assets;
+
+const DEFAULT_MAX_LINES: usize = 5;
+
+const LONG_MARKDOWN: &str = r#"### Quarterly summary
+
+**Revenue** grew by *18%* quarter over quarter, driven by the desktop client
+rollout and the new [market data](https://longbridge.com) subscriptions —
+legacy plans are ~~discontinued~~ and folded into `pro`.
+
+> The clip must land on a whole-line boundary: however you drag the slider,
+> no line of glyphs is ever cut in half.
+
+Reviewed by ![reviewer](https://avatars.githubusercontent.com/u/583231?v=4)
+octocat together with ![bot](https://avatars.githubusercontent.com/u/5518?v=4)
+the tooling team, inline within this very paragraph.
+
+- Desktop DAU is up **24%**
+  - macOS **+31%**, Windows *+19%*
+  - Linux ships via `install.sh` now
+- The `max_lines` preview lands in this release
+- Churn stayed flat at 2.1%
+
+| Segment | QoQ    | Note                 |
+| ------- | ------ | -------------------- |
+| Desktop | +24%   | new dock layout      |
+| Mobile  | +9%    | steady               |
+| Web     | -3%    | migrating to desktop |
+
+![banner](https://avatars.githubusercontent.com/u/150917089?v=4)
+
+---
+
+```rust
+fn main() {
+    println!("hidden until expanded");
+}
+```
+
+That table, banner image and code block only show once you press Expand — a
+block that does not fit as a whole is hidden entirely rather than sliced."#;
+
+const SHORT_MARKDOWN: &str = "A **short** note that fits within the cap, so no button shows.";
+
+struct MaxLinesExample {
+    long: Entity<TextViewState>,
+    short: Entity<TextViewState>,
+    slider: Entity<SliderState>,
+    max_lines: usize,
+    expanded: bool,
+}
+
+impl MaxLinesExample {
+    fn new(cx: &mut Context<Self>) -> Self {
+        let long = cx.new(|cx| TextViewState::markdown(LONG_MARKDOWN, cx));
+        let short = cx.new(|cx| TextViewState::markdown(SHORT_MARKDOWN, cx));
+        // `is_clamped` is written by TextView during draw; observe the states
+        // so the Expand button shows up as soon as the flag flips.
+        cx.observe(&long, |_, _, cx| cx.notify()).detach();
+        cx.observe(&short, |_, _, cx| cx.notify()).detach();
+
+        let slider = cx.new(|_| {
+            SliderState::new()
+                .min(1.)
+                .max(20.)
+                .step(1.)
+                .default_value(DEFAULT_MAX_LINES as f32)
+        });
+        cx.subscribe(&slider, |this, _, event, cx| {
+            if let SliderEvent::Change(value) = event {
+                this.max_lines = value.start() as usize;
+                cx.notify();
+            }
+        })
+        .detach();
+
+        Self {
+            long,
+            short,
+            slider,
+            max_lines: DEFAULT_MAX_LINES,
+            expanded: false,
+        }
+    }
+
+    fn card(&self, content: impl IntoElement, cx: &App) -> Div {
+        v_flex()
+            .max_w(px(480.))
+            .p_3()
+            .gap_2()
+            .rounded(cx.theme().radius_lg)
+            .bg(cx.theme().muted)
+            .child(content)
+    }
+}
+
+impl Render for MaxLinesExample {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let clamped = self.long.read(cx).is_clamped();
+        let expanded = self.expanded;
+        let max_lines = self.max_lines;
+
+        v_flex()
+            .size_full()
+            .p_4()
+            .gap_4()
+            .child(
+                h_flex()
+                    .max_w(px(480.))
+                    .gap_3()
+                    .items_center()
+                    .child(format!("max_lines: {max_lines}"))
+                    .child(div().flex_1().child(Slider::new(&self.slider))),
+            )
+            .child(
+                // The cards scroll while the slider stays pinned above.
+                v_flex()
+                    .flex_1()
+                    .min_h_0()
+                    .gap_4()
+                    .child(
+                        self.card(
+                            TextView::new(&self.long)
+                                .selectable(true)
+                                .when(!expanded, |this| this.max_lines(max_lines)),
+                            cx,
+                        )
+                        .when(clamped || expanded, |this| {
+                            this.child(
+                                h_flex().child(
+                                    Button::new("toggle")
+                                        .label(if expanded { "Collapse" } else { "Expand" })
+                                        .on_click(cx.listener(|this, _, _, cx| {
+                                            this.expanded = !this.expanded;
+                                            cx.notify();
+                                        })),
+                                ),
+                            )
+                        }),
+                    )
+                    .child(
+                        self.card(
+                            TextView::new(&self.short)
+                                .selectable(true)
+                                .max_lines(max_lines),
+                            cx,
+                        ),
+                    )
+                    .overflow_y_scrollbar(),
+            )
+    }
+}
+
+fn main() {
+    let app = gpui_platform::application().with_assets(Assets);
+
+    app.run(move |cx| {
+        // This must be called before using any GPUI Component features.
+        gpui_component::init(cx);
+
+        let window_options = WindowOptions {
+            window_bounds: Some(WindowBounds::centered(size(px(680.), px(620.)), cx)),
+            ..Default::default()
+        };
+
+        cx.spawn(async move |cx| {
+            cx.open_window(window_options, |window, cx| {
+                let view = cx.new(|cx| MaxLinesExample::new(cx));
+                // The first level view on the window should be a Root.
+                cx.new(|cx| Root::new(view, window, cx))
+            })
+            .expect("Failed to open window");
+        })
+        .detach();
+    });
+}

--- a/examples/text_max_lines/src/main.rs
+++ b/examples/text_max_lines/src/main.rs
@@ -180,6 +180,12 @@ fn main() {
         // This must be called before using any GPUI Component features.
         gpui_component::init(cx);
 
+        // The document embeds remote images; without an HTTP client they
+        // silently never load.
+        let http_client = reqwest_client::ReqwestClient::user_agent("gpui-component/example")
+            .expect("Failed to create the HTTP client");
+        cx.set_http_client(std::sync::Arc::new(http_client));
+
         let window_options = WindowOptions {
             window_bounds: Some(WindowBounds::centered(size(px(680.), px(620.)), cx)),
             ..Default::default()

--- a/website/docs/components/text-view.md
+++ b/website/docs/components/text-view.md
@@ -44,6 +44,24 @@ TextView::markdown("preview", markdown_source)
 TextView::html("html-preview", "<strong>Hello</strong>")
 ```
 
+### Clamp to a number of lines
+
+Use `max_lines` to render a bounded preview of rich content — for example a
+collapsed "show more" section. The view's height is capped at `n` × the base
+line height, and the clip snaps up to the nearest whole-line boundary so a
+line of glyphs is never cut in half, across paragraphs, lists, headings, code
+blocks and tables:
+
+```rust
+TextView::markdown("preview", markdown_source).max_lines(5)
+```
+
+`TextViewState::is_clamped()` reports whether the previous painted frame
+actually clipped content, so the caller can decide whether to render an
+"expand" affordance. With paragraph spacing or oversized headings, fewer than
+`n` full lines may fit inside the capped height. `max_lines` only applies to
+the fit-content mode and is ignored when `scrollable` is set.
+
 ## Link Click Handling
 
 Use `on_link_click` when links should be routed by the application instead of

--- a/website/docs/components/text-view.md
+++ b/website/docs/components/text-view.md
@@ -56,8 +56,10 @@ headings, code blocks and tables:
 TextView::markdown("preview", markdown_source).max_lines(5)
 ```
 
-Everything else is cut on the box edge, so an image or a rule crossing it
-shows the part that fits instead of disappearing and leaving blank space
+Nothing is shown with less than a line of itself to show, so the border and
+padding a table row leads with never strands at the bottom. Whatever has more
+than that is cut on the box edge and keeps the part that fits, so an image
+crossing the edge shows instead of disappearing and leaving blank space
 behind.
 
 `TextViewState::is_clamped()` reports whether the previous painted frame

--- a/website/docs/components/text-view.md
+++ b/website/docs/components/text-view.md
@@ -48,13 +48,17 @@ TextView::html("html-preview", "<strong>Hello</strong>")
 
 Use `max_lines` to render a bounded preview of rich content — for example a
 collapsed "show more" section. The view's height is capped at `n` × the base
-line height, and the clip snaps up to the nearest whole-line boundary so a
-line of glyphs is never cut in half, across paragraphs, lists, headings, code
-blocks and tables:
+line height, and a line of glyphs is never cut in half: a line that would
+straddle the bottom of the box is left out whole, across paragraphs, lists,
+headings, code blocks and tables:
 
 ```rust
 TextView::markdown("preview", markdown_source).max_lines(5)
 ```
+
+Everything else is cut on the box edge, so an image or a rule crossing it
+shows the part that fits instead of disappearing and leaving blank space
+behind.
 
 `TextViewState::is_clamped()` reports whether the previous painted frame
 actually clipped content, so the caller can decide whether to render an

--- a/website/docs/components/text-view.md
+++ b/website/docs/components/text-view.md
@@ -64,9 +64,11 @@ behind.
 
 `TextViewState::is_clamped()` reports whether the previous painted frame
 actually clipped content, so the caller can decide whether to render an
-"expand" affordance. With paragraph spacing or oversized headings, fewer than
-`n` full lines may fit inside the capped height. `max_lines` only applies to
-the fit-content mode and is ignored when `scrollable` is set.
+"expand" affordance. `n` counts lines of body text, so paragraph spacing and
+taller lines mean fewer of them fit inside the capped height, and a line taller
+than the whole budget keeps the part that fits rather than emptying the box.
+`max_lines` only applies to the fit-content mode and is ignored when
+`scrollable` is set.
 
 ## Link Click Handling
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/6e83fabd-563b-4293-956f-9487104dbb21

A collapsed preview of rendered Markdown has nowhere clean to end. Clipping a `TextView` at a fixed height cuts a line of glyphs in half as soon as a paragraph gap or a heading shifts the layout, so the caller ends up hiding the cut under a gradient. Truncating the source instead throws away the formatting the view exists to render.

`max_lines(n)` caps the view at `n` line heights and keeps the cut off the text:

```rust
TextView::markdown("preview", source).max_lines(5)
```

A line that would straddle the bottom of the box is left out whole, and so is anything with less than a line of itself to show — the border and padding a table row leads with strands otherwise, and a few pixels of it reads as a rendering fault rather than as a row. Whatever has more than that is cut on the box edge, so an image crossing it shows the part that fits rather than disappearing and leaving blank space behind. `TextViewState::is_clamped()` answers for the frame that was last painted, so an expand button can appear and disappear on its own.

Two things to know: `n` counts lines of body text, so paragraph spacing and taller lines mean fewer of them fit inside the cap (and a line taller than the whole budget keeps the part that fits rather than emptying the box), and there is no ellipsis on the last line — that needs the line re-shaped, and is its own change. Selection is untouched, so copy still returns the whole document.

**Note for review:** `TextViewState`'s root now stretches to its box only when it is *not* clamping. A clamped view has to keep its natural height, or it cannot measure the overflow it is clipping — with the content stretched, nothing looked clipped and lines were cut in half inside a real application layout. The regression test nests the view the way the example does, because a root without a height of its own does not reproduce it.

Found while building a collapsed reasoning preview in a downstream app, where the gradient was covering for the cut.

## Test Plan

- `cargo test -p gpui-component --lib` (464 passed)
- `cargo clippy -p gpui-component -p text_max_lines`
- `cargo run -p text_max_lines` — a slider over a document with nested lists, a table, inline and block images, and a code fence: the cut stays off the text at every setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
