### PR TITLE
tab: Keep the segmented indicator's shadow inside the clip

### DIFF
--- a/crates/ui/src/styled.rs
+++ b/crates/ui/src/styled.rs
@@ -92,6 +92,33 @@ pub(crate) fn toast_shadow(strength: f32) -> Vec<BoxShadow> {
     ]
 }
 
+/// shadcn/ui's `shadow-sm`, the elevation it spends on a control raised out of
+/// the container it sits in — the active pill of a segmented tab bar — at full
+/// ink.
+///
+/// Unlike a popover or a toast this surface is not floating over the page: it
+/// sits *inside* a trough only a few pixels wider than itself, and that trough
+/// clips. Both are reasons to keep the falloff tight — there is no room for a
+/// wide one, and a wide one would read as grime against the trough wall rather
+/// than as lift.
+///
+/// The radii are Tailwind's halved, for the reason [`popover_shadow`] explains:
+/// CSS defines a box shadow's blur radius as twice the gaussian's standard
+/// deviation, while GPUI's shader takes the field as the deviation itself
+/// (`gaussian(y, sigma)`). Copying Tailwind's `3px` and `2px` across therefore
+/// spreads the shadow over twice the distance, which is why
+/// [`Styled::shadow_sm`] leaves a haze around a 24px pill where shadcn draws a
+/// compact line.
+pub(crate) fn raised_shadow() -> Vec<BoxShadow> {
+    let ink = hsla(0., 0., 0., SURFACE_SHADOW_INK);
+    vec![
+        BoxShadow::new(px(0.), px(1.), ink).blur_radius(px(1.5)),
+        BoxShadow::new(px(0.), px(1.), ink)
+            .blur_radius(px(1.))
+            .spread_radius(px(-1.)),
+    ]
+}
+
 /// Finished styles that read the theme.
 ///
 /// Separate from [`StyledExt`], which holds neutral helpers that make no

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -14,7 +14,7 @@ use crate::button::{Button, ButtonVariants as _};
 use crate::menu::{DropdownMenu as _, PopupMenuItem};
 use crate::{
     ActiveTheme, ElementExt, Icon, InteractiveElementExt as _, Selectable, Sizable, Size,
-    StyledExt, h_flex,
+    StyledExt, h_flex, styled::raised_shadow,
 };
 
 /// Slide motion for the selected-tab indicator.
@@ -265,7 +265,7 @@ impl TabBar {
                         .h(inner_height)
                         .bg(cx.theme().tokens.background)
                         .rounded(inner_radius)
-                        .shadow_sm(),
+                        .shadow(raised_shadow()),
                 ),
                 TabVariant::Pill => el.flex().items_center().child(
                     div()

--- a/crates/ui/src/tab/tab_bar.rs
+++ b/crates/ui/src/tab/tab_bar.rs
@@ -192,6 +192,7 @@ impl TabBar {
     fn render_indicator(
         &self,
         bounds_rc: &Option<Rc<RefCell<TabIndicatorBounds>>>,
+        inset: Pixels,
         window: &mut Window,
         cx: &mut App,
     ) -> Option<(AnyElement, u64)> {
@@ -255,7 +256,7 @@ impl TabBar {
             .absolute()
             .top_0()
             .bottom_0()
-            .left(left)
+            .left(left + inset)
             .w(width)
             .map(|el| match variant {
                 TabVariant::Segmented => el.flex().items_center().child(
@@ -423,7 +424,8 @@ impl RenderOnce for TabBar {
             None
         };
 
-        let indicator = self.render_indicator(&bounds_rc, window, cx);
+        let padding_x = paddings.left;
+        let indicator = self.render_indicator(&bounds_rc, padding_x, window, cx);
         let indicator_epoch = indicator.as_ref().map(|(_, epoch)| *epoch).unwrap_or(0);
         let indicator_element = indicator.map(|(el, _)| el);
         let indicator_ready = indicator_element.is_some();
@@ -498,25 +500,33 @@ impl RenderOnce for TabBar {
             .refine_style(&self.style)
             .when_some(self.prefix, |this, prefix| this.child(prefix))
             .child(
-                h_flex().id("tabs").flex_1().overflow_x_hidden().child(
-                    h_flex()
-                        .id("tabs-inner")
-                        .relative()
-                        .gap(gap)
-                        .overflow_x_scroll()
-                        .lock_scroll_axis()
-                        .when_some(self.scroll_handle, |this, scroll_handle| {
-                            this.track_scroll(&scroll_handle)
-                        })
-                        .when_some(bounds_rc.clone(), |this, rc| {
-                            this.on_prepaint(move |bounds, _, _| {
-                                rc.borrow_mut().container = bounds;
+                h_flex()
+                    .id("tabs")
+                    .flex_1()
+                    .mx(-padding_x)
+                    .px(padding_x)
+                    .overflow_x_hidden()
+                    .child(
+                        h_flex()
+                            .id("tabs-inner")
+                            .mx(-padding_x)
+                            .px(padding_x)
+                            .relative()
+                            .gap(gap)
+                            .overflow_x_scroll()
+                            .lock_scroll_axis()
+                            .when_some(self.scroll_handle, |this, scroll_handle| {
+                                this.track_scroll(&scroll_handle)
                             })
-                        })
-                        .when_some(indicator_element, |this, ind| this.child(ind))
-                        .children(rendered_tabs)
-                        .when(has_suffix_or_menu, |this| this.child(self.last_empty_space)),
-                ),
+                            .when_some(bounds_rc.clone(), |this, rc| {
+                                this.on_prepaint(move |bounds, _, _| {
+                                    rc.borrow_mut().container = bounds;
+                                })
+                            })
+                            .when_some(indicator_element, |this, ind| this.child(ind))
+                            .children(rendered_tabs)
+                            .when(has_suffix_or_menu, |this| this.child(self.last_empty_space)),
+                    ),
             )
             .when(self.menu, |this| {
                 this.child(


### PR DESCRIPTION
## Description

The segmented `TabBar` indicator paints a shadow, but `#tabs` and `#tabs-inner` clip exactly on its edges, so the horizontal blur was sliced off on both sides. The vertical blur survived only because the 24px pill sits inside a 32px tab.

Both containers now expand outward with a negative margin and push their content back with an equal padding, so the clip rect has room while every tab keeps its exact position and size. `on_prepaint` reports the container's content origin while taffy resolves an absolute child's `left` from the border box, so the indicator adds that padding to stay aligned with its tab.

The indicator also moves off `Styled::shadow_sm` onto a `raised_shadow()` helper with Tailwind's radii halved — the conversion `popover_shadow` and `toast_shadow` already make, since GPUI's shader reads the blur radius as the gaussian's deviation while CSS defines it as twice that.

`paddings` is non-zero only for `Segmented`, so both changes are a no-op for the other four variants.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="162" height="65" alt="image" src="https://github.com/user-attachments/assets/3b5fe403-ffae-4689-8a74-0f8ed709e862" /> | <img width="145" height="55" alt="image" src="https://github.com/user-attachments/assets/b4066b2a-6155-4052-a0ac-830ce3191d29" /> |

## How to Test

`cargo run -p gpui-component-story` and open the Tabs story. In **Segmented Tabs** and **Dynamic Tabs**, the active pill's shadow is now complete on all four sides, reads as a compact line rather than a haze, and the pill still lines up exactly with its tab.

Geometry was checked with a temporary probe test (removed before commit):

- the selected tab and the indicator report identical bounds (`origin.x = 4px`, `58x32`)
- tab bounds are byte-identical to `main` for all five variants

`cargo test -p gpui-component --lib tab::` passes (10 tests). `cargo clippy -p gpui-component --lib` reports no new warnings.

## AI Assistance

The code changes and this description were generated by Claude Code, then reviewed and tested locally (`cargo check`, `clippy`, `tab::` tests, and a visual check in the story app).

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
