### PR TITLE
markdown: Style tables with the `table_*` theme tokens

### DIFF
--- a/crates/ui/src/text/node.rs
+++ b/crates/ui/src/text/node.rs
@@ -2149,7 +2149,7 @@ impl BlockNode {
                         .px_2()
                         .py_1()
                         .when(!is_last_col, |this| {
-                            this.border_r_1().border_color(cx.theme().border)
+                            this.border_r_1().border_color(cx.theme().table_row_border)
                         })
                         .refine_style(&style.table_cell)
                         .child(cell.children.render(node_cx, window, cx)),
@@ -2160,9 +2160,17 @@ impl BlockNode {
                     .id("row")
                     .w_full()
                     .when(row_ix < row_count - 1, |this| this.border_b_1())
-                    .border_color(cx.theme().border)
+                    .border_color(cx.theme().table_row_border)
                     .flex()
                     .flex_row()
+                    // The first row is the header, as everywhere else that
+                    // reads a table (`table_data`, `to_markdown`). The
+                    // refinement comes last so it can override the defaults.
+                    .when(row_ix == 0, |this| {
+                        this.bg(cx.theme().tokens.table_head)
+                            .text_color(cx.theme().table_head_foreground)
+                            .refine_style(&style.table_head)
+                    })
                     .children(cells),
             );
         }
@@ -2187,6 +2195,7 @@ impl BlockNode {
                     div()
                         .min_w_full()
                         .w(px(min_total_w))
+                        .bg(cx.theme().tokens.table)
                         .border_1()
                         .border_color(cx.theme().border)
                         .rounded(cx.theme().radius)
@@ -2246,7 +2255,7 @@ impl BlockNode {
                         .px_2()
                         .py_1()
                         .when(!is_last_col, |this| {
-                            this.border_r_1().border_color(cx.theme().border)
+                            this.border_r_1().border_color(cx.theme().table_row_border)
                         })
                         .refine_style(&style.table_cell)
                         .child(cell.children.render(node_cx, window, cx)),
@@ -2258,9 +2267,17 @@ impl BlockNode {
                     .id("row")
                     .w_full()
                     .when(row_ix < row_count - 1, |this| this.border_b_1())
-                    .border_color(cx.theme().border)
+                    .border_color(cx.theme().table_row_border)
                     .flex()
                     .flex_row()
+                    // The first row is the header, as everywhere else that
+                    // reads a table (`table_data`, `to_markdown`). The
+                    // refinement comes last so it can override the defaults.
+                    .when(row_ix == 0, |this| {
+                        this.bg(cx.theme().tokens.table_head)
+                            .text_color(cx.theme().table_head_foreground)
+                            .refine_style(&style.table_head)
+                    })
                     .children(cells),
             );
         }
@@ -2272,6 +2289,7 @@ impl BlockNode {
                 div()
                     .id(("table", options.ix))
                     .w_full()
+                    .bg(cx.theme().tokens.table)
                     .border_1()
                     .border_color(cx.theme().border)
                     .rounded(cx.theme().radius)

--- a/crates/ui/src/text/style.rs
+++ b/crates/ui/src/text/style.rs
@@ -29,6 +29,9 @@ pub struct TextViewStyle {
     /// scrolls horizontally instead of squeezing further, e.g.
     /// `TextViewStyle::default().table({ let mut s = StyleRefinement::default(); s.overflow.x = Some(Overflow::Scroll); s })`.
     pub table: StyleRefinement,
+    /// Style refinement applied to the header row (the first row) of a table,
+    /// on top of the `table_head` background and foreground from the theme.
+    pub table_head: StyleRefinement,
     /// Style refinement applied to each table cell.
     ///
     /// With the scroll layout, set `white_space: nowrap` here to keep cells
@@ -58,6 +61,7 @@ impl PartialEq for TextViewStyle {
             && self.highlight_theme == other.highlight_theme
             && self.code_block == other.code_block
             && self.table == other.table
+            && self.table_head == other.table_head
             && self.table_cell == other.table_cell
             && self.inline_code == other.inline_code
             && self.is_dark == other.is_dark
@@ -73,6 +77,7 @@ impl Default for TextViewStyle {
             highlight_theme: HighlightTheme::default_light().clone(),
             code_block: StyleRefinement::default(),
             table: StyleRefinement::default(),
+            table_head: StyleRefinement::default(),
             table_cell: StyleRefinement::default(),
             inline_code: HighlightStyle::default(),
             is_dark: false,
@@ -114,6 +119,12 @@ impl TextViewStyle {
     /// the table scrolls horizontally instead of shrinking further.
     pub fn table(mut self, style: StyleRefinement) -> Self {
         self.table = style;
+        self
+    }
+
+    /// Set extra style for the table header row.
+    pub fn table_head(mut self, style: StyleRefinement) -> Self {
+        self.table_head = style;
         self
     }
 


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="1012" height="844" alt="image" src="https://github.com/user-attachments/assets/b15edcca-002d-4bf4-8ef8-b76e28d99869" /> | <img width="1012" height="844" alt="image" src="https://github.com/user-attachments/assets/08795999-3694-4477-bc0d-ec2d9a78ae9b" /> |

Markdown tables in `TextView` never used the `table_*` theme tokens — only `theme().border` and `theme().radius`. The header row was pixel-identical to the body rows, the grid lines sat a shade darker than every other table in the library, and the container had no background, so a table dropped onto a colored surface let it show through.

This aligns them with `Table` / `DataTable`:

- the header row (the first row, as `table_data` and `to_markdown` already treat it) gets the `table_head` background and `table_head_foreground` text — no bold, same as `TableHeader`;
- inner grid lines move from `border` to `table_row_border`, keeping the outer frame on `border` like `DataTable`;
- the bordered container gets the `table` background.

`render_wrap_table` and `render_scroll_table` change together. Column separators, font size and cell padding are untouched. `TextViewStyle::table_head` is a new hook for overriding the header row.

Verified in `examples/markdown` in both table layouts.