### PR TITLE
base: Center tab and toggle content

### DIFF
--- a/crates/base/src/tabs.rs
+++ b/crates/base/src/tabs.rs
@@ -4,6 +4,7 @@ use gpui::{
     AnyElement, App, ClickEvent, Div, ElementId, InteractiveElement, Interactivity, IntoElement,
     MouseButton, ParentElement, Refineable as _, RenderOnce, Role, SharedString,
     StatefulInteractiveElement, StyleRefinement, Styled, Window, div, prelude::FluentBuilder as _,
+    relative,
 };
 use smallvec::SmallVec;
 
@@ -150,6 +151,13 @@ impl RenderOnce for Tab {
         self.base
             .id(self.id)
             .role(Role::Tab)
+            // Match Button's neutral control geometry: a fixed-size tab
+            // centers ordinary content, while callers still own its size,
+            // spacing and visual treatment.
+            .flex()
+            .items_center()
+            .justify_center()
+            .line_height(relative(1.))
             .when_some(self.accessibility_label, |this, label| {
                 this.aria_label(label)
             })
@@ -224,6 +232,7 @@ impl RenderOnce for Tabs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ElementExt as _;
     use std::{
         cell::Cell,
         rc::Rc,
@@ -272,6 +281,52 @@ mod tests {
         let (cx, clicks) = harness(cx, true);
         cx.simulate_click(point(px(10.), px(10.)), Modifiers::default());
         assert_eq!(clicks.get(), 0);
+    }
+
+    #[gpui::test]
+    fn fixed_height_tab_centers_ordinary_child_geometry(cx: &mut gpui::TestAppContext) {
+        type Captured = Arc<
+            Mutex<(
+                Option<gpui::Bounds<gpui::Pixels>>,
+                Option<gpui::Bounds<gpui::Pixels>>,
+            )>,
+        >;
+
+        struct AlignmentProbe(Captured);
+
+        impl Render for AlignmentProbe {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                let root_capture = self.0.clone();
+                let child_capture = self.0.clone();
+                Tab::new("alignment-tab")
+                    .w(px(120.))
+                    .h(px(40.))
+                    .child(
+                        div()
+                            .w(px(48.))
+                            .h(px(12.))
+                            .on_prepaint(move |bounds, _, _| {
+                                child_capture.lock().unwrap().1 = Some(bounds);
+                            }),
+                    )
+                    .on_prepaint(move |bounds, _, _| {
+                        root_capture.lock().unwrap().0 = Some(bounds);
+                    })
+            }
+        }
+
+        let captured = Arc::new(Mutex::new((None, None)));
+        let (_, context) = cx.add_window_view({
+            let captured = captured.clone();
+            move |_, _| AlignmentProbe(captured)
+        });
+        context.update(|window, cx| window.draw(cx).clear(cx));
+
+        let (root, child) = captured.lock().unwrap().clone();
+        assert_eq!(
+            child.expect("child bounds").center(),
+            root.expect("tab bounds").center()
+        );
     }
 
     #[gpui::test]

--- a/crates/base/src/toggle.rs
+++ b/crates/base/src/toggle.rs
@@ -4,7 +4,7 @@ use gpui::{
     AnyElement, App, ClickEvent, Div, ElementId, FocusHandle, InteractiveElement, Interactivity,
     IntoElement, MouseButton, ParentElement, Refineable as _, RenderOnce, Role, SharedString,
     Stateful, StatefulInteractiveElement, StyleRefinement, Styled, Toggled, Window, div,
-    prelude::FluentBuilder as _,
+    prelude::FluentBuilder as _, relative,
 };
 use smallvec::SmallVec;
 
@@ -170,6 +170,13 @@ impl RenderOnce for Toggle {
 
         self.base
             .role(Role::Button)
+            // Match Button's neutral control geometry: a fixed-size toggle
+            // centers ordinary content, while callers still own its size,
+            // spacing and visual treatment.
+            .flex()
+            .items_center()
+            .justify_center()
+            .line_height(relative(1.))
             .aria_toggled(if pressed {
                 Toggled::True
             } else {
@@ -206,6 +213,7 @@ impl RenderOnce for Toggle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ElementExt as _;
     use std::{
         cell::{Cell, RefCell},
         rc::Rc,
@@ -301,6 +309,52 @@ mod tests {
         cx.simulate_click(point(px(10.), px(10.)), Modifiers::default());
         cx.simulate_keystrokes("enter space");
         assert!(changes.borrow().is_empty());
+    }
+
+    #[gpui::test]
+    fn fixed_height_toggle_centers_ordinary_child_geometry(cx: &mut TestAppContext) {
+        type Captured = Arc<
+            Mutex<(
+                Option<gpui::Bounds<gpui::Pixels>>,
+                Option<gpui::Bounds<gpui::Pixels>>,
+            )>,
+        >;
+
+        struct AlignmentProbe(Captured);
+
+        impl Render for AlignmentProbe {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                let root_capture = self.0.clone();
+                let child_capture = self.0.clone();
+                Toggle::new("alignment-toggle")
+                    .w(px(120.))
+                    .h(px(40.))
+                    .child(
+                        div()
+                            .w(px(48.))
+                            .h(px(12.))
+                            .on_prepaint(move |bounds, _, _| {
+                                child_capture.lock().unwrap().1 = Some(bounds);
+                            }),
+                    )
+                    .on_prepaint(move |bounds, _, _| {
+                        root_capture.lock().unwrap().0 = Some(bounds);
+                    })
+            }
+        }
+
+        let captured = Arc::new(Mutex::new((None, None)));
+        let (_, context) = cx.add_window_view({
+            let captured = captured.clone();
+            move |_, _| AlignmentProbe(captured)
+        });
+        context.update(|window, cx| window.draw(cx).clear(cx));
+
+        let (root, child) = captured.lock().unwrap().clone();
+        assert_eq!(
+            child.expect("child bounds").center(),
+            root.expect("toggle bounds").center()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Align `Tab` and `Toggle` with `Button` neutral control geometry by applying flex centering and a unit line height at the component root. Fixed-height controls now vertically center ordinary child content while applications continue to own size, padding, colors, and selected/pressed styling.

## Screenshot

Not included; this is a base layout correction covered by geometry regression tests.

## How to Test

```bash
cargo test -p gpui-base fixed_height_tab_centers_ordinary_child_geometry
cargo test -p gpui-base fixed_height_toggle_centers_ordinary_child_geometry
cargo test -p gpui-base --lib
```

Verified on Linux: 572 gpui-base library tests passed.

## Checklist

- [x] I have read the CONTRIBUTING document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code is accurate.
- [x] Passed the story-related component regression tests.
- [x] Tested Linux; the change is platform-independent layout behavior.