### PR TITLE
scrollbar: fix repaint after clicking the track to jump

### DIFF
--- a/crates/base/src/scrollbar.rs
+++ b/crates/base/src/scrollbar.rs
@@ -1546,8 +1546,6 @@ impl Element for Scrollbar {
 
                                         scroll_handle.start_drag();
                                         state.set(state.get().with_drag_pos(axis, pos));
-
-                                        cx.notify(view_id);
                                     } else {
                                         // click on the scrollbar, jump to the position
                                         // Set the thumb bar center to the click position
@@ -1575,6 +1573,8 @@ impl Element for Scrollbar {
                                             ));
                                         }
                                     }
+
+                                    cx.notify(view_id);
                                 }
                             }
                         });


### PR DESCRIPTION
## Description

The MouseDown handler only notified for the thumb-drag path; the other branch (click-on-track jump) called set_offset() without cx.notify(). GPUI redraws after a mouse event only while an active drag is in flight, so a bare track click left the window clean and the moved scroll position wasn't painted until an unrelated repaint (e.g. the next mouse move), making track jumps feel delayed.

Hoist a single cx.notify(view_id) after the thumb/track branch, covering both axes, so a track jump repaints immediately like a drag does.

## Why this triggers in custom-painted viewports (and not the Scrollbar story)

A single track-click never repaints the scrolled content, because GPUI only
force-redraws after a mouse event while an active drag is in flight; a click-on-track jump emits no drag, and (before this fix) no notify, leaving the window clean — the moved offset simply isn't painted until some unrelated event dirties the window.

Concrete scenario: a flame-chart / timeline widget with a scrollbar overlaid on a hand-painted canvas. The canvas is a bare Element; its redraw is driven solely by cx.observe on a state entity, and the scrollbar is bound to a custom handle whose offset is not read live by any Scrollable element — it is staged in shared state and flushed into the canvas on the next repaint. Sequence:

1. Move the pointer onto the track — hover reveals the bar, one repaint.
2. Click the track (beside the thumb) to jump — set_offset stages the new offset but issues no notify.
3. Nothing is dirty, so no frame is produced; the jump doesn't appear until the pointer moves (a hover notify) or any other event dirties the window.

The thumb drag never shows the symptom because each MouseMove during the drag keeps notifying per frame — only the click-to-jump path is dead-stuck.

Why the Scrollbar story doesn't expose it: it binds the scrollbar to a real ScrollHandle driving a Scrollable/uniform_list, whose content re-reads handle.offset() live in its own prepaint every frame. So the first repaint from any cause (hover state, cursor move over the list, other animations in the story shell) already renders the moved content at the right offset — the missing notify is masked by the story's constant redraws. An isolated viewport with observer-only repaint has no such masking and shows the bug immediately.