### PR TITLE
shell: Fix the --watch panic and a virtual list's stale cx

### DIFF
--- a/crates/shell/src/bin/gpui-shell.rs
+++ b/crates/shell/src/bin/gpui-shell.rs
@@ -17,8 +17,8 @@ use std::{
 };
 
 use gpui::{
-    App, AppContext as _, Bounds, Context, Entity, IntoElement, Render, TitlebarOptions, Window,
-    WindowBounds, WindowHandle, WindowOptions, px, size,
+    AnyWindowHandle, App, AppContext as _, Bounds, Context, Entity, IntoElement, Render,
+    TitlebarOptions, Window, WindowBounds, WindowHandle, WindowOptions, px, size,
 };
 use gpui_shell::{AppAssets, Capabilities, ShellRoot, ShellRuntime};
 use tracing::{
@@ -656,7 +656,12 @@ fn watch_sources(
     window: WindowHandle<ShellRoot>,
     cx: &mut App,
 ) {
-    let started = window.update(cx, |_, window, cx| runtime.watch(&root, window, cx));
+    // Through the untyped handle on purpose. `WindowHandle::<ShellRoot>::update`
+    // leases the root view for the length of the closure, and `watch` reads that
+    // same entity to find the mounted application — a second borrow GPUI answers
+    // with a panic. All this call wants from the window is a `&mut Window`.
+    let started =
+        AnyWindowHandle::from(window).update(cx, |_, window, cx| runtime.watch(&root, window, cx));
 
     match started {
         // Detached on purpose: this watcher lasts as long as the window, and

--- a/crates/shell/src/engine/quickjs/mod.rs
+++ b/crates/shell/src/engine/quickjs/mod.rs
@@ -1604,6 +1604,11 @@ impl ShellRuntime {
             policy,
             entry.application.clone(),
         );
+        // The renderer is a closure the script wrote inside `render(cx)`, and
+        // the row helpers it calls take that `cx`. Layout is a frame of its own,
+        // so without this the enclosing render's `cx` would read as stale here
+        // and every helper would need a second, list-only plumbing.
+        scope::adopt(entry.registered_in);
 
         let outer = std::mem::take(&mut *self.arena.borrow_mut());
         let described = self.with_js(|ctx| {
@@ -4236,6 +4241,7 @@ impl ShellRuntime {
                     value: saved,
                     view: scope::current_view().map(|view| view.downgrade()),
                     application: scope::current_application_generation(),
+                    registered_in: scope::current_generation(),
                 });
                 let name = match method {
                     "on_click" => "on_click",
@@ -4769,11 +4775,13 @@ fn virtual_list_constructor(
                     value: get_key.0,
                     view: scope::current_view().map(|view| view.downgrade()),
                     application: scope::current_application_generation(),
+                    registered_in: scope::current_generation(),
                 });
                 let callback = store.callbacks.borrow_mut().push(CallbackEntry {
                     value: render.0,
                     view: scope::current_view().map(|view| view.downgrade()),
                     application: scope::current_application_generation(),
+                    registered_in: scope::current_generation(),
                 });
                 Ok(store.push_node(Component::VirtualList(Rc::new(
                     crate::spec::VirtualListSpec::new(

--- a/crates/shell/src/runtime.rs
+++ b/crates/shell/src/runtime.rs
@@ -233,6 +233,14 @@ pub(crate) struct CallbackEntry<T> {
     pub(crate) value: T,
     pub(crate) view: Option<WeakEntity<ScriptView>>,
     pub(crate) application: Option<Rc<ApplicationGeneration>>,
+    /// The host call this callback was registered from, as
+    /// [`crate::scope`] numbers them.
+    ///
+    /// Only the virtualized list reads it, and only to keep the `cx` of that
+    /// call usable inside the item renderer it registered — see
+    /// [`crate::scope::adopt`]. Every other dispatch opens a scope of its own
+    /// and has no use for the one it came from.
+    pub(crate) registered_in: Option<u64>,
 }
 
 impl<T> CallbackEntry<T> {
@@ -254,6 +262,7 @@ impl<T: Clone> Clone for CallbackEntry<T> {
             value: self.value.clone(),
             view: self.view.clone(),
             application: self.application.clone(),
+            registered_in: self.registered_in,
         }
     }
 }
@@ -899,6 +908,7 @@ mod identity_tests {
             value,
             view: None,
             application: None,
+            registered_in: None,
         }
     }
 

--- a/crates/shell/src/scope.rs
+++ b/crates/shell/src/scope.rs
@@ -5,6 +5,9 @@
 //! would point at a dead stack frame. [`CallScope`] turns "am I inside a legal
 //! host call?" into a runtime-checkable fact: every entry point pushes a frame
 //! with a fresh generation, and the script-side `cx` only carries that generation.
+//! A frame may additionally [`adopt`] one earlier call's generation, which widens
+//! the set of `cx` values it answers for without changing where their pointers
+//! come from.
 //!
 //! # Safety
 //!
@@ -63,6 +66,8 @@ struct Frame {
     app: *mut App,
     phase: ScopePhase,
     generation: u64,
+    /// An earlier call this frame also answers for, if any. See [`adopt`].
+    adopted: Option<u64>,
     view: Option<Entity<ScriptView>>,
     /// Whose authority this code runs under.
     ///
@@ -238,6 +243,7 @@ pub(crate) fn enter_application(
             app: frame.1,
             phase: frame.2,
             generation,
+            adopted: None,
             view: None,
             policy: frame.3,
             application: Some(application),
@@ -268,6 +274,7 @@ fn enter_with_runtime_opt(
             app: app as *mut App,
             phase,
             generation,
+            adopted: None,
             view,
             policy,
             application,
@@ -276,6 +283,29 @@ fn enter_with_runtime_opt(
     });
 
     (CallScopeGuard { _private: () }, generation)
+}
+
+/// Lets the innermost frame answer for an earlier call's `cx` as well as its own.
+///
+/// One caller: the frame a virtualized list's item renderer runs in. That
+/// renderer is a closure the script wrote inside `render(cx)`, and the `cx` it
+/// closed over is the render's — but GPUI calls it from inside layout, long
+/// after the render frame was popped, so every helper the rows call would
+/// otherwise have to be re-plumbed for lists alone. Naming the render's
+/// generation here keeps that one `cx` working and leaves every other stale one
+/// refused; the pointers a member reaches are still the live frame's.
+///
+/// `None` is a no-op, which is what a callback registered outside any host call
+/// deserves.
+pub(crate) fn adopt(generation: Option<u64>) {
+    let Some(generation) = generation else {
+        return;
+    };
+    STACK.with(|stack| {
+        if let Some(frame) = stack.borrow_mut().last_mut() {
+            frame.adopted = Some(generation);
+        }
+    });
 }
 
 pub fn current_runtime() -> Option<Rc<ShellRuntime>> {
@@ -352,7 +382,8 @@ pub(crate) fn current_application_generation() -> Option<Rc<ApplicationGeneratio
     })
 }
 
-/// Runs `f` with the innermost scope's context, if `generation` is still current.
+/// Runs `f` with the innermost scope's context, if `generation` still names a
+/// live call — the innermost frame's own, or one that frame [`adopt`]ed.
 ///
 /// A stale generation is a programming error in the script, not a host bug, so
 /// it produces a descriptive error rather than a panic.
@@ -364,7 +395,7 @@ pub fn with_context<R>(
         stack
             .borrow()
             .last()
-            .filter(|frame| frame.generation == generation)
+            .filter(|frame| frame.generation == generation || frame.adopted == Some(generation))
             .map(|frame| (frame.window, frame.app))
     });
 

--- a/crates/shell/src/tests/render.rs
+++ b/crates/shell/src/tests/render.rs
@@ -6073,6 +6073,98 @@ fn a_row_cannot_register_a_handler_of_its_own(cx: &mut TestAppContext) {
     );
 }
 
+/// The row helpers an application already has all take the `cx` of the render
+/// they were written in — `label(text, cx)`, `surface(cx)`, and so on. The item
+/// renderer is a closure inside that same `render()`, so that `cx` is what it
+/// has in hand, even though GPUI calls it from a layout pass of its own.
+#[gpui::test]
+fn an_item_renderer_may_use_the_cx_of_the_render_that_registered_it(cx: &mut TestAppContext) {
+    let (_runtime, _window, view, mut context) = mount_virtual_list(
+        cx,
+        "try { row.text_color(cx.theme().colors.foreground); this.refused = \"none\"; } \
+         catch (error) { this.refused = String(error.message); }",
+    );
+
+    let tree = redraw_and_read(&mut context, &view);
+    assert!(
+        tree.contains("refused none"),
+        "the enclosing render's cx must still speak for a live call here: {tree}"
+    );
+}
+
+/// And no further than that. Adopting one generation is what keeps the rule
+/// checkable: a `cx` from a render that has already been replaced is as dead
+/// inside a list as it is anywhere else.
+#[gpui::test]
+fn an_item_renderer_still_refuses_a_cx_from_an_earlier_render(cx: &mut TestAppContext) {
+    cx.update(crate::init);
+    let runtime = ShellRuntime::new_isolated().expect("runtime");
+    cx.update(|cx| runtime.set_global(cx));
+    let source = r#"
+import { div, View } from "gpui";
+import { v_flex, v_virtual_list } from "gpui-base";
+
+export default class Rows extends View {
+  init() {
+    this.result = "not reached";
+  }
+
+  render(cx) {
+    const previous = this.saved;
+    this.saved = cx;
+    return v_flex()
+      .w(300)
+      .h(400)
+      .child(
+        v_flex()
+          .h(200)
+          .child(
+            v_virtual_list("rows", 500, 20, (index) => String(index), (range) => {
+              const items = [];
+              for (let index = range.start; index < range.end; index++) {
+                items.push(div().h(20).child(`row ${index}`));
+              }
+              if (previous) {
+                try {
+                  previous.theme();
+                  this.result = "accepted";
+                } catch (error) {
+                  this.result = "refused";
+                }
+              }
+              return items;
+            }),
+          ),
+      )
+      .child(`result ${this.result}`);
+  }
+}
+"#;
+    let view_type = runtime.load_source("stale-rows.js", source).expect("load");
+    let runtime_for_view = Rc::clone(&runtime);
+    let window = cx.add_window(move |window, cx| {
+        let view = runtime_for_view
+            .instantiate_view(&view_type, window, cx)
+            .expect("instantiate");
+        RootedScriptView(view)
+    });
+    let mut context = VisualTestContext::from_window(*window.deref(), cx);
+    context.update(|window, cx| window.draw(cx).clear(cx));
+    let view = window
+        .root(&mut context)
+        .expect("view")
+        .read_with(&context, |root, _| root.0.clone());
+
+    // The first pass has no earlier render to reach for; the second does, and
+    // the third is what shows what the second decided.
+    redraw_and_read(&mut context, &view);
+    let tree = redraw_and_read(&mut context, &view);
+    assert!(
+        tree.contains("result refused"),
+        "only the render that registered the renderer is adopted: {tree}"
+    );
+}
+
 #[gpui::test]
 fn a_virtual_list_reports_which_row_was_clicked(cx: &mut TestAppContext) {
     let (_runtime, _window, view, mut context) = mount_virtual_list(cx, "");

--- a/crates/shell/src/typings.rs
+++ b/crates/shell/src/typings.rs
@@ -1937,6 +1937,12 @@ const BASE: &str = r#"  /** A row. */
    *   and the rest throw there as they do in `render()`, and `cx.notify()` is
    *   refused: asking for a re-render from inside layout is a loop.
    *
+   * What the layout pass does *not* cost you is the `cx` you already had: the
+   * renderer is a closure inside `render(cx)`, so the row helpers written
+   * against that `cx` — `label(text, cx)`, `surface(cx)` — keep working
+   * unchanged. The `cx` the renderer is handed reaches the same window and app,
+   * and is there for a renderer written somewhere `render`'s is not in scope.
+   *
    * The list paints no scrollbar of its own. Pair one with it by name, exactly
    * as with a scroll area:
    *

--- a/crates/shell/src/watch.rs
+++ b/crates/shell/src/watch.rs
@@ -402,6 +402,11 @@ impl ShellRuntime {
     ///
     /// The root retains the resolved directory, manifest entry, and typed
     /// script view, so the host does not repeat metadata or downcast content.
+    ///
+    /// It reads that root, so the caller must not already be holding it: reach
+    /// the window through `AnyWindowHandle::update` or `App::update_window`,
+    /// not through `WindowHandle::<ShellRoot>::update`, which leases the root
+    /// view for the length of its closure.
     pub fn watch(
         self: &Rc<Self>,
         root: &Entity<ShellRoot>,


### PR DESCRIPTION
Closes #2844, both halves of it.

**`--dev` / `--watch` panicked on startup.** `WindowHandle::<ShellRoot>::update` leases the root view for the length of its closure, and `ShellRuntime::watch` reads that same entity to find the mounted application — a second borrow GPUI answers with `cannot read ShellRoot while it is already being updated`. The call only ever wanted a `&mut Window`, so it goes through the untyped handle now. Embedded hosts reaching `watch` from a plain window update were never affected, which is why no test caught it; the method now says which form it needs.

**A virtual list drew nothing.** Its item renderer is a closure written inside `render(cx)`, but GPUI calls it from a layout pass in a scope frame of its own, so the `cx` it closed over read as stale. Every row helper written against that `cx` — `label(text, cx)`, `surface(cx)` — threw, the range came back empty, and the reason went only to the log. A frame can now adopt one earlier call's generation, and the renderer's frame adopts the render that registered it. Pointers still come from the live frame and `cx.notify()` is still refused during layout; only *which* `cx` is accepted changed, and only for the one call the renderer belongs to. A `cx` from a render that has already been replaced stays as dead inside a list as anywhere else — there is a test for each side.

Verified by running the issue's script under `gpui-shell --dev`: rows render, and saving the file reloads instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)