### PR TITLE
table: Fix the header lagging a frame behind column navigation

### DIFF
--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -389,9 +389,58 @@ where
     pub fn scroll_to_col(&mut self, col_ix: usize, cx: &mut Context<Self>) {
         let col_ix = col_ix.saturating_sub(self.fixed_left_cols_count());
 
-        self.horizontal_scroll_handle
-            .scroll_to_item(col_ix, ScrollStrategy::Top);
+        // Resolve the offset here instead of deferring it to the virtual list.
+        //
+        // The header and the rows share `horizontal_scroll_handle`, but only
+        // the rows are a `VirtualList`, and a deferred `scroll_to_item` is
+        // applied during that list's prepaint — which runs *after* the header
+        // has already been rendered and prepainted with the old offset. The
+        // header would therefore stay one frame behind the rows.
+        match self.horizontal_offset_for_col(col_ix) {
+            Some(offset_x) => {
+                let mut offset = self.horizontal_scroll_handle.offset();
+                offset.x = offset_x;
+                self.horizontal_scroll_handle.set_offset(offset);
+            }
+            // Before the first layout the viewport size is unknown, let the
+            // virtual list resolve the offset once it has been laid out.
+            None => self
+                .horizontal_scroll_handle
+                .scroll_to_item(col_ix, ScrollStrategy::Top),
+        }
+
         cx.notify();
+    }
+
+    /// The horizontal scroll offset that brings the scrollable (non-fixed)
+    /// column at `col_ix` fully into view.
+    ///
+    /// This mirrors the nearest-edge behavior of [`VirtualListScrollHandle::scroll_to_item`]
+    /// with [`ScrollStrategy::Top`]: an already visible column keeps the current
+    /// offset, otherwise the column is aligned to the edge it overflows. Both
+    /// of those move the offset towards a column that exists, so the result
+    /// never runs past the content and needs no extra clamping.
+    ///
+    /// Returns `None` when the viewport size is not known yet, or when `col_ix`
+    /// is out of range.
+    fn horizontal_offset_for_col(&self, col_ix: usize) -> Option<Pixels> {
+        let viewport_width = self.horizontal_scroll_handle.bounds().size.width;
+        if viewport_width <= px(0.) {
+            return None;
+        }
+
+        let cols = self.col_groups.get(self.fixed_left_cols_count()..)?;
+        let col_left: Pixels = cols.get(..col_ix)?.iter().map(|col| col.width).sum();
+        let col_right = col_left + cols.get(col_ix)?.width;
+        let offset_x = self.horizontal_scroll_handle.offset().x;
+
+        Some(if col_left + offset_x < px(0.) {
+            -col_left
+        } else if col_right + offset_x > viewport_width {
+            viewport_width - col_right
+        } else {
+            offset_x
+        })
     }
 
     /// Returns the selected row index.


### PR DESCRIPTION
## Description

Arrow-key column navigation scrolled the cells while the table header stayed
put, catching up only when a later frame redrew it.

`TableState::scroll_to_col` only recorded a deferred `scroll_to_item` on the
horizontal scroll handle that the header and rows share. That deferral is
resolved in `VirtualList::prepaint`, which the rows run but the header cannot:
the header is a plain `overflow_scroll` div tracking the same handle, and it
prepaints first, so it read the stale offset that the rows then overwrote.

It now resolves the offset up front from the column widths and the handle's
viewport bounds, mirroring the nearest-edge behavior of `ScrollStrategy::Top`.
Header and rows observe one settled offset for the whole frame, including the
header's column virtualization, which picks its rendered range during
`render()`. The deferred path remains a fallback before the first layout.
`

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="420" height="207" alt="image" src="https://github.com/user-attachments/assets/b4e93e93-e5f0-4dd0-bf71-3fdb643fe6a4" /> | <img width="420" height="207" alt="image" src="https://github.com/user-attachments/assets/bac542ff-b5a6-4b5e-bd5c-9e0e0ace2e6e" />|
| <img width="420" height="207" alt="image" src="https://github.com/user-attachments/assets/a9718933-37d7-4e79-a87b-e5e37901c3a6" /> | |

## How to Test

Use the story datatable example, with headers, Step using the keyboard until the screen scrolls.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
