### PR TITLE
markdown: Add Frontmatter plugin as structured metadata

### DIFF
--- a/crates/base/src/text/format/markdown.rs
+++ b/crates/base/src/text/format/markdown.rs
@@ -685,6 +685,54 @@ mod tests {
         }
     }
 
+    #[test]
+    fn yaml_frontmatter_is_disabled_by_default() {
+        let source = "---\nSome text\n---";
+        let mut cx = NodeContext::default();
+        let document = parse(source, &mut cx).unwrap();
+
+        assert!(matches!(
+            document.blocks[0],
+            BlockNode::HorizontalRule { .. }
+        ));
+        let BlockNode::Heading {
+            level, children, ..
+        } = &document.blocks[1]
+        else {
+            panic!("expected setext heading");
+        };
+        assert_eq!(*level, 2);
+        assert_eq!(children.text(), "Some text");
+    }
+
+    #[test]
+    fn non_mapping_yaml_frontmatter_falls_back_to_code_block() {
+        let extensions = MarkdownExtensions::default().frontmatter();
+        let mut cx = NodeContext {
+            markdown_extensions: extensions.into(),
+            ..NodeContext::default()
+        };
+        let document = parse("---\n- name: example\n---", &mut cx).unwrap();
+
+        let BlockNode::CodeBlock(code_block) = &document.blocks[0] else {
+            panic!("expected YAML code block fallback");
+        };
+        assert_eq!(code_block.lang().as_deref(), Some("yml"));
+        assert_eq!(code_block.code().as_ref(), "- name: example");
+    }
+
+    #[test]
+    fn fenced_yaml_remains_a_code_block() {
+        let mut cx = NodeContext::default();
+        let document = parse("```yaml\nname: example\n```", &mut cx).unwrap();
+
+        let BlockNode::CodeBlock(code_block) = &document.blocks[0] else {
+            panic!("expected fenced YAML code block");
+        };
+        assert_eq!(code_block.lang().as_deref(), Some("yaml"));
+        assert_eq!(code_block.code().as_ref(), "name: example");
+    }
+
     #[derive(Debug, Clone, PartialEq)]
     struct Ticker {
         symbol: String,

--- a/crates/base/src/text/markdown_ext.rs
+++ b/crates/base/src/text/markdown_ext.rs
@@ -176,12 +176,24 @@ impl PartialEq for MarkdownNode {
 #[derive(Clone, Default)]
 pub struct MarkdownExtensions {
     enable_mdx: bool,
+    enable_frontmatter: bool,
     block_parsers: Vec<Arc<MarkdownBlockParserFn>>,
     block_renderers: HashMap<SharedString, Arc<MarkdownBlockRenderFn>>,
     revision: u64,
 }
 
 impl MarkdownExtensions {
+    /// Enable YAML frontmatter parsing.
+    ///
+    /// Frontmatter is disabled by default because it is not part of CommonMark
+    /// or GFM. Register a block parser or [`MarkdownPlugin`] to render the
+    /// resulting [`mdast::Node::Yaml`] node.
+    pub fn frontmatter(mut self) -> Self {
+        self.enable_frontmatter = true;
+        self.bump_revision();
+        self
+    }
+
     /// Enable MDX JSX/expression constructs.
     ///
     /// This disables raw HTML constructs because `markdown-rs` gives HTML
@@ -246,6 +258,7 @@ impl MarkdownExtensions {
     /// stable; render handles may be refreshed without reparsing the document.
     pub(crate) fn has_same_parser_configuration(&self, other: &Self) -> bool {
         self.enable_mdx == other.enable_mdx
+            && self.enable_frontmatter == other.enable_frontmatter
             && self.block_parsers.len() == other.block_parsers.len()
             && self.block_renderers.len() == other.block_renderers.len()
             && self
@@ -279,6 +292,7 @@ impl MarkdownExtensions {
 
     pub(crate) fn parse_options(&self) -> ParseOptions {
         let mut options = ParseOptions::gfm();
+        options.constructs.frontmatter = self.enable_frontmatter;
         if self.enable_mdx {
             options.constructs.html_flow = false;
             options.constructs.html_text = false;

--- a/crates/component/src/text/frontmatter.rs
+++ b/crates/component/src/text/frontmatter.rs
@@ -1,0 +1,274 @@
+use gpui::{App, IntoElement, SharedString, Window};
+use markdown::mdast;
+
+use crate::description_list::{DescriptionItem, DescriptionList};
+
+use super::{MarkdownNode, MarkdownParseContext, MarkdownPlugin};
+
+const NODE_NAME: &str = "frontmatter";
+
+#[derive(Debug, Clone, PartialEq)]
+struct FrontmatterEntry {
+    key: SharedString,
+    value: SharedString,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct Frontmatter {
+    entries: Vec<FrontmatterEntry>,
+}
+
+impl Frontmatter {
+    fn text(&self) -> String {
+        self.entries
+            .iter()
+            .map(|entry| format!("{}: {}", entry.key, entry.value))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+/// Renders top-level YAML frontmatter mappings as a description list.
+///
+/// Enable frontmatter parsing with [`super::MarkdownExtensions::frontmatter`]
+/// before registering this plugin. Values are rendered as plain text; YAML
+/// sequences and other unsupported top-level values use TextView's YAML code
+/// block fallback.
+#[derive(Default)]
+pub struct FrontmatterPlugin;
+
+impl FrontmatterPlugin {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl MarkdownPlugin for FrontmatterPlugin {
+    fn is_block(&self) -> bool {
+        true
+    }
+
+    fn name(&self) -> &str {
+        NODE_NAME
+    }
+
+    fn parse(&self, node: &mdast::Node, cx: &MarkdownParseContext<'_>) -> Option<MarkdownNode> {
+        let mdast::Node::Yaml(yaml) = node else {
+            return None;
+        };
+        let frontmatter = parse_frontmatter(&yaml.value)?;
+        let text = frontmatter.text();
+
+        Some(
+            MarkdownNode::new(NODE_NAME, frontmatter)
+                .text(text)
+                .markdown(cx.node_source(node).unwrap_or(yaml.value.as_str())),
+        )
+    }
+
+    fn render(&self, node: &MarkdownNode, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let frontmatter = node.data::<Frontmatter>().expect("frontmatter node data");
+
+        DescriptionList::horizontal()
+            .label_width(gpui::rems(12.))
+            .columns(1)
+            .children(
+                frontmatter.entries.iter().map(|entry| {
+                    DescriptionItem::new(entry.key.clone()).value(entry.value.clone())
+                }),
+            )
+    }
+}
+
+fn parse_frontmatter(value: &str) -> Option<Frontmatter> {
+    #[derive(Clone, Copy)]
+    enum ScalarStyle {
+        Plain,
+        Folded,
+        Literal,
+        Empty,
+    }
+
+    struct Entry {
+        key: String,
+        value: String,
+        style: ScalarStyle,
+    }
+
+    fn push_continuation(entry: &mut Entry, line: &str) {
+        let line = line.trim();
+        match entry.style {
+            ScalarStyle::Folded => {
+                if line.is_empty() {
+                    if !entry.value.is_empty() {
+                        entry.value.push('\n');
+                    }
+                    return;
+                }
+                if !entry.value.is_empty() && !entry.value.ends_with('\n') {
+                    entry.value.push(' ');
+                }
+            }
+            ScalarStyle::Literal => {
+                if !entry.value.is_empty() {
+                    entry.value.push('\n');
+                }
+            }
+            ScalarStyle::Plain | ScalarStyle::Empty => return,
+        }
+        entry.value.push_str(line);
+    }
+
+    fn is_plain_key(key: &str) -> bool {
+        !key.is_empty()
+            && key
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'))
+    }
+
+    let mut entries = Vec::new();
+    let mut current: Option<Entry> = None;
+
+    for line in value.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            if current.as_ref().is_some_and(|entry| {
+                matches!(entry.style, ScalarStyle::Folded | ScalarStyle::Literal)
+            }) {
+                push_continuation(current.as_mut()?, line);
+            }
+            continue;
+        }
+
+        let is_top_level = !line.starts_with([' ', '\t']);
+        if trimmed.starts_with('#')
+            && (is_top_level
+                || !current.as_ref().is_some_and(|entry| {
+                    matches!(entry.style, ScalarStyle::Folded | ScalarStyle::Literal)
+                }))
+        {
+            continue;
+        }
+
+        if is_top_level {
+            let (key, raw_value) = line.split_once(':')?;
+            let key = key.trim();
+            if !is_plain_key(key) {
+                return None;
+            }
+
+            if let Some(entry) = current.take() {
+                entries.push(entry);
+            }
+
+            let raw_value = raw_value.trim();
+            let (value, style) = match raw_value {
+                ">" | ">-" | ">+" => (String::new(), ScalarStyle::Folded),
+                "|" | "|-" | "|+" => (String::new(), ScalarStyle::Literal),
+                "" => (String::new(), ScalarStyle::Empty),
+                _ => (raw_value.to_string(), ScalarStyle::Plain),
+            };
+            current = Some(Entry {
+                key: key.to_string(),
+                value,
+                style,
+            });
+        } else if current
+            .as_ref()
+            .is_some_and(|entry| matches!(entry.style, ScalarStyle::Folded | ScalarStyle::Literal))
+        {
+            push_continuation(current.as_mut()?, line);
+        } else {
+            return None;
+        }
+    }
+
+    if let Some(entry) = current {
+        entries.push(entry);
+    }
+    if entries.is_empty() {
+        return None;
+    }
+
+    Some(Frontmatter {
+        entries: entries
+            .into_iter()
+            .map(|entry| FrontmatterEntry {
+                key: entry.key.into(),
+                value: entry.value.into(),
+            })
+            .collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_mapping_as_metadata() {
+        let frontmatter = parse_frontmatter(
+            "name: gpui-component-dev\ndescription: Contributing to `crates/ui`.",
+        )
+        .expect("frontmatter mapping");
+
+        assert_eq!(frontmatter.entries.len(), 2);
+        assert_eq!(frontmatter.entries[0].key.as_ref(), "name");
+        assert_eq!(frontmatter.entries[0].value.as_ref(), "gpui-component-dev");
+        assert_eq!(
+            frontmatter.entries[1].value.as_ref(),
+            "Contributing to `crates/ui`."
+        );
+    }
+
+    #[test]
+    fn parses_block_scalars() {
+        let frontmatter = parse_frontmatter(
+            "description: >-\n  First line\n  second line.\nnotes: |-\n  # literal content\n\n  second line",
+        )
+        .expect("frontmatter mapping");
+
+        assert_eq!(
+            frontmatter.entries[0].value.as_ref(),
+            "First line second line."
+        );
+        assert_eq!(
+            frontmatter.entries[1].value.as_ref(),
+            "# literal content\n\nsecond line"
+        );
+    }
+
+    #[test]
+    fn preserves_blank_lines_in_folded_scalars() {
+        let frontmatter =
+            parse_frontmatter("description: >-\n  First paragraph.\n\n  Second paragraph.")
+                .expect("frontmatter mapping");
+
+        assert_eq!(
+            frontmatter.entries[0].value.as_ref(),
+            "First paragraph.\nSecond paragraph."
+        );
+    }
+
+    #[test]
+    fn preserves_indented_hashes_in_folded_scalars() {
+        let frontmatter =
+            parse_frontmatter("description: >-\n  First line\n  # not a comment\n  last line")
+                .expect("frontmatter mapping");
+
+        assert_eq!(
+            frontmatter.entries[0].value.as_ref(),
+            "First line # not a comment last line"
+        );
+    }
+
+    #[test]
+    fn rejects_nested_mappings() {
+        assert!(parse_frontmatter("config:\n  theme: dark").is_none());
+    }
+
+    #[test]
+    fn rejects_non_mapping_yaml() {
+        assert!(parse_frontmatter("- name: example").is_none());
+    }
+}

--- a/crates/component/src/text/frontmatter.rs
+++ b/crates/component/src/text/frontmatter.rs
@@ -32,8 +32,9 @@ impl Frontmatter {
 ///
 /// Enable frontmatter parsing with [`super::MarkdownExtensions::frontmatter`]
 /// before registering this plugin. Values are rendered as plain text; YAML
-/// sequences and other unsupported top-level values use TextView's YAML code
-/// block fallback.
+/// block scalars with `|-` and `>-` are supported. Quoted/compound values,
+/// comments after values, other block headers, and more-indented folded lines
+/// use TextView's YAML code block fallback.
 #[derive(Default)]
 pub struct FrontmatterPlugin;
 
@@ -93,30 +94,51 @@ fn parse_frontmatter(value: &str) -> Option<Frontmatter> {
         key: String,
         value: String,
         style: ScalarStyle,
+        indent: Option<usize>,
+        lines: usize,
     }
 
-    fn push_continuation(entry: &mut Entry, line: &str) {
-        let line = line.trim();
+    fn push_continuation(entry: &mut Entry, line: &str) -> Option<()> {
+        // Remove only the structural indentation, never scalar content spaces.
+        let line = if line.is_empty() {
+            ""
+        } else {
+            let indent = line.bytes().take_while(|byte| *byte == b' ').count();
+            if indent == line.len() && entry.indent.is_none() {
+                // Its significance depends on the indentation of a later line.
+                return None;
+            }
+            let required = *entry.indent.get_or_insert(indent);
+            if required == 0 || (indent < required && indent != line.len()) {
+                return None;
+            }
+            &line[required.min(line.len())..]
+        };
         match entry.style {
             ScalarStyle::Folded => {
+                // Folding more-indented lines requires a wider YAML grammar.
+                if line.starts_with([' ', '\t']) {
+                    return None;
+                }
                 if line.is_empty() {
-                    if !entry.value.is_empty() {
-                        entry.value.push('\n');
-                    }
-                    return;
+                    entry.value.push('\n');
+                    entry.lines += 1;
+                    return Some(());
                 }
                 if !entry.value.is_empty() && !entry.value.ends_with('\n') {
                     entry.value.push(' ');
                 }
             }
             ScalarStyle::Literal => {
-                if !entry.value.is_empty() {
+                if entry.lines > 0 {
                     entry.value.push('\n');
                 }
             }
-            ScalarStyle::Plain | ScalarStyle::Empty => return,
+            ScalarStyle::Plain | ScalarStyle::Empty => return None,
         }
         entry.value.push_str(line);
+        entry.lines += 1;
+        Some(())
     }
 
     fn is_plain_key(key: &str) -> bool {
@@ -135,7 +157,7 @@ fn parse_frontmatter(value: &str) -> Option<Frontmatter> {
             if current.as_ref().is_some_and(|entry| {
                 matches!(entry.style, ScalarStyle::Folded | ScalarStyle::Literal)
             }) {
-                push_continuation(current.as_mut()?, line);
+                push_continuation(current.as_mut()?, line)?;
             }
             continue;
         }
@@ -152,6 +174,9 @@ fn parse_frontmatter(value: &str) -> Option<Frontmatter> {
 
         if is_top_level {
             let (key, raw_value) = line.split_once(':')?;
+            if !raw_value.is_empty() && !raw_value.starts_with([' ', '\t']) {
+                return None;
+            }
             let key = key.trim();
             if !is_plain_key(key) {
                 return None;
@@ -163,21 +188,39 @@ fn parse_frontmatter(value: &str) -> Option<Frontmatter> {
 
             let raw_value = raw_value.trim();
             let (value, style) = match raw_value {
-                ">" | ">-" | ">+" => (String::new(), ScalarStyle::Folded),
-                "|" | "|-" | "|+" => (String::new(), ScalarStyle::Literal),
+                ">-" => (String::new(), ScalarStyle::Folded),
+                "|-" => (String::new(), ScalarStyle::Literal),
                 "" => (String::new(), ScalarStyle::Empty),
-                _ => (raw_value.to_string(), ScalarStyle::Plain),
+                _ => {
+                    // Decline syntax we cannot interpret faithfully. The caller
+                    // preserves it using the existing YAML code block fallback.
+                    if raw_value.starts_with([
+                        '\'', '"', '[', ']', '{', '}', '&', '*', '!', '|', '>', '#', '%', '@', '`',
+                    ]) || ["- ", "? ", ": ", "-\t", "?\t", ":\t"]
+                        .iter()
+                        .any(|prefix| raw_value.starts_with(prefix))
+                        || raw_value.ends_with(':')
+                        || [" #", "\t#", ": ", ":\t"]
+                            .iter()
+                            .any(|pattern| raw_value.contains(pattern))
+                    {
+                        return None;
+                    }
+                    (raw_value.to_string(), ScalarStyle::Plain)
+                }
             };
             current = Some(Entry {
                 key: key.to_string(),
                 value,
                 style,
+                indent: None,
+                lines: 0,
             });
         } else if current
             .as_ref()
             .is_some_and(|entry| matches!(entry.style, ScalarStyle::Folded | ScalarStyle::Literal))
         {
-            push_continuation(current.as_mut()?, line);
+            push_continuation(current.as_mut()?, line)?;
         } else {
             return None;
         }
@@ -195,7 +238,11 @@ fn parse_frontmatter(value: &str) -> Option<Frontmatter> {
             .into_iter()
             .map(|entry| FrontmatterEntry {
                 key: entry.key.into(),
-                value: entry.value.into(),
+                value: if matches!(entry.style, ScalarStyle::Folded | ScalarStyle::Literal) {
+                    entry.value.trim_end_matches('\n').to_owned().into()
+                } else {
+                    entry.value.into()
+                },
             })
             .collect(),
     })
@@ -270,5 +317,48 @@ mod tests {
     #[test]
     fn rejects_non_mapping_yaml() {
         assert!(parse_frontmatter("- name: example").is_none());
+    }
+
+    #[test]
+    fn preserves_literal_scalar_whitespace() {
+        let parsed = parse_frontmatter("notes: |-\n\n  first  \n    indented\n    \n  last\n\n")
+            .expect("literal scalar");
+        assert_eq!(
+            parsed.entries[0].value.as_ref(),
+            "\nfirst  \n  indented\n  \nlast"
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_scalar_syntax() {
+        for source in [
+            "title: Hello # comment",
+            "title: \"Hello\\nworld\"",
+            "title: 'Hello'",
+            "tags: [one, two]",
+            "config: {theme: dark}",
+            "value: &anchor hello",
+            "value: *anchor",
+            "value: !!str hello",
+            "value: a: b",
+            "notes: >-\n  first\n    indented\n  last",
+            "notes: |-\n    first\n  invalid indentation",
+            "notes: |2-\n  text",
+            "notes: |\n  text",
+            "notes: >+\n  text",
+        ] {
+            assert!(parse_frontmatter(source).is_none(), "{source:?}");
+        }
+    }
+
+    #[test]
+    fn preserves_plain_scalar_punctuation() {
+        let parsed = parse_frontmatter("url: https://example.com/#section\nvalue: -42")
+            .expect("plain values");
+        assert_eq!(
+            parsed.entries[0].value.as_ref(),
+            "https://example.com/#section"
+        );
+        assert_eq!(parsed.entries[1].value.as_ref(), "-42");
     }
 }

--- a/crates/component/src/text/mod.rs
+++ b/crates/component/src/text/mod.rs
@@ -1,11 +1,13 @@
 //! Compatibility facade for rich text now owned by `gpui-base`.
 
 mod compat;
+mod frontmatter;
 mod style;
 
 pub use compat::{
     Text, TextView, TextViewLayoutState, TextViewPlugin, TextViewPrepaintState, html, markdown,
 };
+pub use frontmatter::FrontmatterPlugin;
 pub use gpui_base::text::{
     MarkdownBlockParserFn, MarkdownBlockRenderFn, MarkdownExtensions, MarkdownNode,
     MarkdownParseContext, MarkdownPlugin, SelectionFormat, TableData, TextViewState, markdown_ast,

--- a/website/base/text-view.md
+++ b/website/base/text-view.md
@@ -103,6 +103,27 @@ TextView::markdown("highlighted", source).code_block_highlighter(|block| {
 
 Ranges are UTF-8 byte ranges relative to `CodeBlock::code()`. Invalid ranges are discarded. The highlighter implementation and its language registrations remain entirely application-owned.
 
+## Markdown extensions
+
+`MarkdownExtensions` starts with CommonMark/GFM-compatible parsing. YAML
+frontmatter is disabled by default because it is not part of either standard.
+Enable the construct explicitly when a block parser or plugin handles
+`markdown_ast::Node::Yaml`:
+
+```rust
+use gpui_base::{MarkdownExtensions, TextView};
+
+let extensions = MarkdownExtensions::default().frontmatter();
+
+TextView::markdown("metadata", source)
+    .markdown_extensions(extensions)
+```
+
+Without a matching plugin, enabled YAML frontmatter uses the existing YAML
+code-block fallback. A custom plugin can be attached with `.plugin(...)`;
+`gpui-component` provides a themed
+`FrontmatterPlugin`; Base remains independent of that presentation.
+
 ## Retained state and streaming updates
 
 Use `TextViewState` when content changes without replacing the view:

--- a/website/component/text-view.md
+++ b/website/component/text-view.md
@@ -212,6 +212,25 @@ fn is_block(&self) -> bool {
 
 Inline plugins are reserved for future `TextView` support.
 
+## YAML Frontmatter
+
+YAML frontmatter is opt-in because it is not part of CommonMark or GFM. Enable
+the parser construct and attach `FrontmatterPlugin` to render top-level mappings
+as a `DescriptionList`:
+
+```rust
+use gpui_component::text::{markdown, FrontmatterPlugin, MarkdownExtensions};
+
+let extensions = MarkdownExtensions::default().frontmatter();
+
+markdown("---\nname: example\ndescription: Example metadata.\n---")
+    .markdown_extensions(extensions)
+    .plugin(FrontmatterPlugin::new())
+```
+
+Values are rendered as plain text. Folded and literal block scalars are
+supported; unsupported YAML frontmatter falls back to a YAML code block.
+
 ## Code Block Actions
 
 You can render controls for Markdown code blocks:

--- a/website/component/text-view.md
+++ b/website/component/text-view.md
@@ -228,8 +228,11 @@ markdown("---\nname: example\ndescription: Example metadata.\n---")
     .plugin(FrontmatterPlugin::new())
 ```
 
-Values are rendered as plain text. Folded and literal block scalars are
-supported; unsupported YAML frontmatter falls back to a YAML code block.
+Values are rendered as plain text. Simple unquoted values and block scalars
+using `|-` or `>-` are supported; literal scalars preserve content indentation.
+Quoted values, inline comments, collections, aliases, other block headers, and
+more-indented folded lines fall back to a YAML code block, preserving the source
+instead of displaying an incorrectly interpreted value.
 
 ## Code Block Actions
 

--- a/website/zh-CN/base/text-view.md
+++ b/website/zh-CN/base/text-view.md
@@ -103,6 +103,26 @@ TextView::markdown("highlighted", source).code_block_highlighter(|block| {
 
 范围相对于 `CodeBlock::code()`；无效范围会被丢弃。高亮器实现和语言注册完全由应用管理。
 
+## Markdown 扩展
+
+`MarkdownExtensions` 默认使用兼容 CommonMark/GFM 的解析方式。YAML
+frontmatter 不属于这两项标准，因此默认关闭。当 block parser 或插件处理
+`markdown_ast::Node::Yaml` 时，需要明确启用该 construct：
+
+```rust
+use gpui_base::{MarkdownExtensions, TextView};
+
+let extensions = MarkdownExtensions::default().frontmatter();
+
+TextView::markdown("metadata", source)
+    .markdown_extensions(extensions)
+```
+
+如果没有匹配的插件，已启用的 YAML frontmatter 会使用现有的 YAML
+code-block fallback。可以通过 `.plugin(...)` 挂载自定义插件；
+`gpui-component` 提供带主题样式的
+`FrontmatterPlugin`；Base 不依赖该 presentation。
+
 ## 保留状态与动态更新
 
 内容需要持续更新时使用 `TextViewState`：

--- a/website/zh-CN/component/text-view.md
+++ b/website/zh-CN/component/text-view.md
@@ -156,6 +156,25 @@ fn is_block(&self) -> bool {
 
 Inline 插件保留给未来的 `TextView` 支持。
 
+## YAML Frontmatter
+
+YAML frontmatter 不属于 CommonMark 或 GFM，因此默认不启用。启用 parser
+construct 并挂载 `FrontmatterPlugin` 后，顶层 mapping 会渲染为
+`DescriptionList`：
+
+```rust
+use gpui_component::text::{markdown, FrontmatterPlugin, MarkdownExtensions};
+
+let extensions = MarkdownExtensions::default().frontmatter();
+
+markdown("---\nname: example\ndescription: Example metadata.\n---")
+    .markdown_extensions(extensions)
+    .plugin(FrontmatterPlugin::new())
+```
+
+值以纯文本渲染。支持 folded 与 literal block scalar；不支持的 YAML
+frontmatter 会回退为 YAML code block。
+
 ## 代码块操作
 
 可以为 Markdown 代码块渲染操作控件：

--- a/website/zh-CN/component/text-view.md
+++ b/website/zh-CN/component/text-view.md
@@ -172,8 +172,10 @@ markdown("---\nname: example\ndescription: Example metadata.\n---")
     .plugin(FrontmatterPlugin::new())
 ```
 
-值以纯文本渲染。支持 folded 与 literal block scalar；不支持的 YAML
-frontmatter 会回退为 YAML code block。
+值以纯文本渲染。支持简单的无引号值，以及使用 `|-` 或 `>-` 的 block scalar；
+literal scalar 会保留内容缩进。带引号的值、行尾注释、集合、别名、其他 block
+header，以及包含额外缩进行的 folded scalar 会回退为 YAML code block，
+保留原始内容，避免显示错误解析的值。
 
 ## 代码块操作
 


### PR DESCRIPTION
## Summary

YAML frontmatter rendering is now opt-in through `MarkdownExtensions::frontmatter()` and `FrontmatterPlugin`. Top-level mappings use the existing `DescriptionList`; values remain plain text, and folded/literal block scalars are supported. Unsupported frontmatter falls back to a YAML code block. Default CommonMark/GFM rendering is unchanged.

## Before

<img width="1918" height="1078" alt="before" src="https://github.com/user-attachments/assets/b9578f0f-428f-45ad-a92c-bc716d62940d" />

## After

<img width="1918" height="1078" alt="after" src="https://github.com/user-attachments/assets/f7bb55f1-93e2-4990-8d3c-1b820d8a2c03" />

## Implementation

- Adds opt-in parsing to `gpui-base`, disabled by default.
- Keeps themed presentation in `crates/ui` through `MarkdownPlugin`.
- Adds no `BlockNode` variant and preserves original Markdown serialization.

## Testing

- `cargo test -p gpui-base frontmatter --lib`
- `cargo test -p gpui-component frontmatter --lib`
- `cargo test -p gpui-base text::format::markdown::tests --lib`
- `cargo clippy -p gpui-base -p gpui-component --tests -- --deny warnings`