### PR TITLE
chore: Expose / allow setting accessibility labels on UI components

### DIFF
--- a/crates/ui/src/checkbox.rs
+++ b/crates/ui/src/checkbox.rs
@@ -27,6 +27,7 @@ pub struct Checkbox {
     // `Text` is legacy presentation state. During render it is composed into
     // the Base Checkbox child seam together with application children.
     label: Option<Text>,
+    accessibility_label: Option<SharedString>,
     children: Vec<AnyElement>,
     checked: bool,
     disabled: bool,
@@ -48,6 +49,7 @@ impl Checkbox {
             base: gpui_base::Checkbox::new(id),
             style: StyleRefinement::default(),
             label: None,
+            accessibility_label: None,
             children: Vec::new(),
             checked: false,
             disabled: false,
@@ -75,6 +77,14 @@ impl Checkbox {
     /// Set the label for the checkbox.
     pub fn label(mut self, label: impl Into<Text>) -> Self {
         self.label = Some(label.into());
+        self
+    }
+
+    /// Set the name a screen reader announces, overriding the visible label.
+    ///
+    /// This does not change the label drawn on screen.
+    pub fn accessibility_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.accessibility_label = Some(label.into());
         self
     }
 
@@ -206,7 +216,9 @@ impl RenderOnce for Checkbox {
 
         let base = self.base;
         let children = self.children;
-        let accessibility_label = self.label.as_ref().map(|label| label.get_text(cx));
+        let accessibility_label = self
+            .accessibility_label
+            .or_else(|| self.label.as_ref().map(|label| label.get_text(cx)));
         let on_click = self.on_click.clone();
         let focus_handle = window
             .use_keyed_state(self.id.clone(), cx, |_, cx| cx.focus_handle())
@@ -349,6 +361,25 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn an_explicit_accessibility_label_replaces_the_visible_one() {
+        let plain = Checkbox::new("remember").label("Remember me");
+        assert_eq!(plain.accessibility_label, None);
+
+        let named = Checkbox::new("remember")
+            .label("Remember me")
+            .accessibility_label("Remember this account");
+        assert_eq!(
+            named.accessibility_label.as_deref(),
+            Some("Remember this account"),
+            "an explicit name must win over the visible label"
+        );
+        assert!(
+            matches!(named.label.as_ref(), Some(Text::String(label)) if label.as_ref() == "Remember me"),
+            "and must not change what is drawn"
+        );
+    }
 
     struct CheckboxHarness {
         disabled: bool,

--- a/crates/ui/src/color_picker.rs
+++ b/crates/ui/src/color_picker.rs
@@ -56,6 +56,8 @@ pub struct ColorPicker {
     state: Entity<ColorPickerState>,
     featured_colors: Option<Vec<Hsla>>,
     label: Option<SharedString>,
+    /// The announced name, when the visible label is not it.
+    accessibility_label: Option<SharedString>,
     icon: Option<Icon>,
     size: Size,
     anchor: Anchor,
@@ -71,6 +73,7 @@ impl ColorPicker {
             featured_colors: None,
             size: Size::Medium,
             label: None,
+            accessibility_label: None,
             icon: None,
             anchor: Anchor::TopLeft,
         }
@@ -99,6 +102,17 @@ impl ColorPicker {
     /// Default is `None`.
     pub fn label(mut self, label: impl Into<SharedString>) -> Self {
         self.label = Some(label.into());
+        self
+    }
+
+    /// Set the name a screen reader announces, when the visible label is not
+    /// it.
+    ///
+    /// A color picker's name comes from its [`label`](Self::label) by default.
+    /// Setting this replaces the announced name without changing the visible
+    /// label.
+    pub fn accessibility_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.accessibility_label = Some(label.into());
         self
     }
 
@@ -462,9 +476,12 @@ impl RenderOnce for ColorPicker {
         BaseColorPicker::new(self.id.clone())
             .open(open)
             .track_focus(&focus_handle)
-            .when_some(self.label.clone(), |this, label| {
-                this.accessibility_label(label)
-            })
+            .when_some(
+                self.accessibility_label
+                    .clone()
+                    .or_else(|| self.label.clone()),
+                |this, label| this.accessibility_label(label),
+            )
             .on_open_change(move |open, _, cx| {
                 open_state.update(cx, |state, cx| state.set_open(open, cx));
             })
@@ -490,6 +507,40 @@ impl RenderOnce for ColorPicker {
                     })
                     .child(self.render_colors(window, cx)),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gpui::{AppContext as _, TestAppContext};
+
+    use super::*;
+
+    #[gpui::test]
+    fn an_explicit_accessibility_label_replaces_the_visible_one(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let state = cx.new(|cx| ColorPickerState::new(window, cx));
+
+            let plain = ColorPicker::new(&state).label("Color");
+            assert_eq!(plain.accessibility_label, None);
+            assert_eq!(plain.label.as_deref(), Some("Color"));
+
+            let named = ColorPicker::new(&state)
+                .label("Color")
+                .accessibility_label("Text color");
+            assert_eq!(
+                named.accessibility_label.as_deref(),
+                Some("Text color"),
+                "an explicit name must win over the visible label"
+            );
+            assert_eq!(
+                named.label.as_deref(),
+                Some("Color"),
+                "and must not change what is drawn"
+            );
+        });
     }
 }
 

--- a/crates/ui/src/progress/progress.rs
+++ b/crates/ui/src/progress/progress.rs
@@ -1,7 +1,7 @@
 use crate::{ActiveTheme, Sizable, Size, StyledExt};
 use gpui::{
     Animation, AnimationExt as _, App, Background, ElementId, Hsla, IntoElement, IsZero as _,
-    ParentElement, RenderOnce, StyleRefinement, Styled, Window, ease_in_out,
+    ParentElement, RenderOnce, SharedString, StyleRefinement, Styled, Window, ease_in_out,
     prelude::FluentBuilder, px, relative,
 };
 use gpui_base::{
@@ -16,6 +16,7 @@ pub struct Progress {
     style: StyleRefinement,
     color: Option<Hsla>,
     value: f32,
+    accessibility_label: Option<SharedString>,
     size: Size,
     loading: bool,
 }
@@ -27,6 +28,7 @@ impl Progress {
             id: id.into(),
             value: Default::default(),
             color: None,
+            accessibility_label: None,
             style: StyleRefinement::default(),
             size: Size::default(),
             loading: false,
@@ -55,6 +57,12 @@ impl Progress {
         self.value = value.clamp(0., 100.);
         self
     }
+
+    /// Set the accessible name exposed by the progress indicator.
+    pub fn accessibility_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.accessibility_label = Some(label.into());
+        self
+    }
 }
 
 impl Styled for Progress {
@@ -78,6 +86,7 @@ impl RenderOnce for Progress {
             .unwrap_or(cx.theme().tokens.progress_bar.into());
         let value = self.value;
         let loading = self.loading;
+        let accessibility_label = self.accessibility_label;
         let reduce_motion = cx.reduce_motion();
 
         let radius = self.style.corner_radii.clone();
@@ -110,6 +119,9 @@ impl RenderOnce for Progress {
         BaseProgress::new(self.id)
             .value(value)
             .indeterminate(loading)
+            .when_some(accessibility_label, |this, label| {
+                this.accessibility_label(label)
+            })
             .w_full()
             .relative()
             .h(height)
@@ -155,5 +167,22 @@ impl RenderOnce for Progress {
                         }
                     }),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stores_an_explicit_accessibility_label() {
+        let plain = Progress::new("upload");
+        assert_eq!(plain.accessibility_label, None);
+
+        let named = Progress::new("upload").accessibility_label("Upload progress");
+        assert_eq!(
+            named.accessibility_label.as_deref(),
+            Some("Upload progress")
+        );
     }
 }

--- a/crates/ui/src/progress/progress_circle.rs
+++ b/crates/ui/src/progress/progress_circle.rs
@@ -3,7 +3,8 @@ use gpui::Bounds;
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     Animation, AnimationExt as _, AnyElement, App, ElementId, Hsla, IntoElement, ParentElement,
-    Pixels, RenderOnce, StyleRefinement, Styled, Window, canvas, ease_in_out, px, relative,
+    Pixels, RenderOnce, SharedString, StyleRefinement, Styled, Window, canvas, ease_in_out, px,
+    relative,
 };
 use gpui_base::Progress as BaseProgress;
 use instant::Duration;
@@ -19,6 +20,7 @@ pub struct ProgressCircle {
     style: StyleRefinement,
     color: Option<Hsla>,
     value: f32,
+    accessibility_label: Option<SharedString>,
     size: Size,
     children: Vec<AnyElement>,
     loading: bool,
@@ -31,6 +33,7 @@ impl ProgressCircle {
             id: id.into(),
             value: Default::default(),
             color: None,
+            accessibility_label: None,
             style: StyleRefinement::default(),
             size: Size::default(),
             children: Vec::new(),
@@ -58,6 +61,12 @@ impl ProgressCircle {
     /// The value should be between 0.0 and 100.0.
     pub fn value(mut self, value: f32) -> Self {
         self.value = value.clamp(0., 100.);
+        self
+    }
+
+    /// Set the accessible name exposed by the progress indicator.
+    pub fn accessibility_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.accessibility_label = Some(label.into());
         self
     }
 
@@ -155,6 +164,7 @@ impl RenderOnce for ProgressCircle {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let value = self.value;
         let loading = self.loading;
+        let accessibility_label = self.accessibility_label;
         let state = window.use_keyed_state(self.id.clone(), cx, |_, _| ProgressState::new(value));
         let prev_target = state.read(cx).target();
         let has_changed = prev_target != value;
@@ -164,6 +174,9 @@ impl RenderOnce for ProgressCircle {
         BaseProgress::new(self.id.clone())
             .value(value)
             .indeterminate(loading)
+            .when_some(accessibility_label, |this, label| {
+                this.accessibility_label(label)
+            })
             .flex()
             .items_center()
             .justify_center()
@@ -219,5 +232,22 @@ impl RenderOnce for ProgressCircle {
                         .into_any_element()
                 }
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stores_an_explicit_accessibility_label() {
+        let plain = ProgressCircle::new("upload");
+        assert_eq!(plain.accessibility_label, None);
+
+        let named = ProgressCircle::new("upload").accessibility_label("Upload progress");
+        assert_eq!(
+            named.accessibility_label.as_deref(),
+            Some("Upload progress")
+        );
     }
 }

--- a/crates/ui/src/radio.rs
+++ b/crates/ui/src/radio.rs
@@ -21,6 +21,8 @@ pub struct Radio {
     style: StyleRefinement,
     id: ElementId,
     label: Option<Text>,
+    /// The announced name, when the visible label is not it.
+    accessibility_label: Option<SharedString>,
     children: Vec<AnyElement>,
     checked: bool,
     disabled: bool,
@@ -43,6 +45,7 @@ impl Radio {
             id,
             style: StyleRefinement::default(),
             label: None,
+            accessibility_label: None,
             children: Vec::new(),
             checked: false,
             disabled: false,
@@ -66,6 +69,16 @@ impl Radio {
     /// Set the label of the Radio element.
     pub fn label(mut self, label: impl Into<Text>) -> Self {
         self.label = Some(label.into());
+        self
+    }
+
+    /// Set the name a screen reader announces, when the visible label is not
+    /// it.
+    ///
+    /// A radio's name comes from its [`label`](Self::label) by default. Setting
+    /// this replaces the announced name without changing what is displayed.
+    pub fn accessibility_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.accessibility_label = Some(label.into());
         self
     }
 
@@ -149,6 +162,10 @@ impl RenderOnce for Radio {
             .clone();
         let is_focused = focus_handle.is_focused(window);
         let disabled = self.disabled;
+        let accessibility_label = self
+            .accessibility_label
+            .clone()
+            .or_else(|| self.label.as_ref().map(|label| label.get_text(cx)));
 
         let (border_color, bg) = if checked {
             (cx.theme().primary, cx.theme().primary)
@@ -168,10 +185,9 @@ impl RenderOnce for Radio {
             .track_focus(&focus_handle)
             .tab_stop(self.tab_stop)
             .tab_index(self.tab_index)
-            .when_some(
-                self.label.as_ref().map(|l| l.get_text(cx)),
-                |this, label| this.accessibility_label(label),
-            )
+            .when_some(accessibility_label, |this, label| {
+                this.accessibility_label(label)
+            })
             .when_some(
                 self.position_in_set.zip(self.size_of_set),
                 |this, (position, size)| this.set_position(position, size),
@@ -379,5 +395,36 @@ impl RenderOnce for RadioGroup {
                         )
                     })),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_explicit_accessibility_label_replaces_the_visible_one() {
+        let plain = Radio::new("automatic").label("Automatic");
+        assert_eq!(plain.accessibility_label, None);
+        assert!(matches!(
+            &plain.label,
+            Some(Text::String(label)) if label.as_ref() == "Automatic"
+        ));
+
+        let named = Radio::new("automatic")
+            .label("Automatic")
+            .accessibility_label("Choose automatic mode");
+        assert_eq!(
+            named.accessibility_label.as_deref(),
+            Some("Choose automatic mode"),
+            "an explicit name must win over the visible label"
+        );
+        assert!(
+            matches!(
+                &named.label,
+                Some(Text::String(label)) if label.as_ref() == "Automatic"
+            ),
+            "and must not change what is drawn"
+        );
     }
 }

--- a/crates/ui/src/select.rs
+++ b/crates/ui/src/select.rs
@@ -81,6 +81,7 @@ struct SelectOptions {
     icon: Option<Icon>,
     cleanable: bool,
     placeholder: Option<SharedString>,
+    accessibility_label: Option<SharedString>,
     title_prefix: Option<SharedString>,
     search_placeholder: Option<SharedString>,
     menu_width: Length,
@@ -98,6 +99,7 @@ impl Default for SelectOptions {
             icon: None,
             cleanable: false,
             placeholder: None,
+            accessibility_label: None,
             title_prefix: None,
             menu_width: Length::Auto,
             menu_max_h: rems(20.).into(),
@@ -608,6 +610,15 @@ where
         self
     }
 
+    /// Set the name a screen reader announces for the select.
+    ///
+    /// The placeholder and selected value are not used as the accessible name,
+    /// because they describe the current value rather than the control itself.
+    pub fn accessibility_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.options.accessibility_label = Some(label.into());
+        self
+    }
+
     /// Override the trailing icon, replacing the default chevron.
     pub fn icon(mut self, icon: impl Into<Icon>) -> Self {
         self.options.icon = Some(icon.into());
@@ -729,6 +740,7 @@ where
 {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
         let disabled = self.options.disabled;
+        let accessibility_label = self.options.accessibility_label.clone();
         let focus_handle = self.state.read(cx).state.focus_handle.clone();
         let empty = self.empty;
         let opts = self.options;
@@ -759,6 +771,9 @@ where
         BaseSelect::new(self.id)
             .open(is_open)
             .disabled(disabled)
+            .when_some(accessibility_label, |this, label| {
+                this.accessibility_label(label)
+            })
             .focus_handle(&focus_handle)
             .content_focus_handle(&content_focus_handle)
             .on_open_change(move |open, _, cx| {
@@ -778,8 +793,38 @@ mod tests {
     use crate::{
         IndexPath,
         searchable_list::{SearchableListDelegate as _, SearchableVec},
-        select::{SelectGroup, SelectState},
+        select::{Select, SelectGroup, SelectState},
     };
+
+    #[gpui::test]
+    fn an_explicit_accessibility_label_does_not_replace_the_placeholder(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let cx = cx.add_empty_window();
+        cx.update(|window, cx| {
+            let items = SearchableVec::new(vec!["Rust", "Go", "C++"]);
+            let state = cx.new(|cx| SelectState::new(items, None, window, cx));
+
+            let plain = Select::new(&state).placeholder("Choose a language");
+            assert_eq!(plain.options.accessibility_label, None);
+            assert_eq!(
+                plain.options.placeholder.as_deref(),
+                Some("Choose a language")
+            );
+
+            let named = Select::new(&state)
+                .placeholder("Choose a language")
+                .accessibility_label("Programming language");
+            assert_eq!(
+                named.options.accessibility_label.as_deref(),
+                Some("Programming language")
+            );
+            assert_eq!(
+                named.options.placeholder.as_deref(),
+                Some("Choose a language"),
+                "an accessible name must not change what is drawn"
+            );
+        });
+    }
 
     #[gpui::test]
     fn test_select_initial_selection_seeds_cursor(cx: &mut TestAppContext) {

--- a/crates/ui/src/switch.rs
+++ b/crates/ui/src/switch.rs
@@ -23,6 +23,8 @@ pub struct Switch {
     checked: bool,
     disabled: bool,
     label: Option<Text>,
+    /// The announced name, when the visible label is not it.
+    accessibility_label: Option<SharedString>,
     label_side: Side,
     on_click: Option<Rc<dyn Fn(&bool, &mut Window, &mut App)>>,
     size: Size,
@@ -40,6 +42,7 @@ impl Switch {
             checked: false,
             disabled: false,
             label: None,
+            accessibility_label: None,
             on_click: None,
             label_side: Side::Right,
             size: Size::Medium,
@@ -57,6 +60,17 @@ impl Switch {
     /// Set the label of the switch.
     pub fn label(mut self, label: impl Into<Text>) -> Self {
         self.label = Some(label.into());
+        self
+    }
+
+    /// Set the name a screen reader announces, when the visible label is not
+    /// it.
+    ///
+    /// A switch's name comes from its [`label`](Self::label) by default.
+    /// Setting this replaces the announced name without changing what is
+    /// displayed.
+    pub fn accessibility_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.accessibility_label = Some(label.into());
         self
     }
 
@@ -107,6 +121,10 @@ impl RenderOnce for Switch {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let checked = self.checked;
         let on_click = self.on_click.clone();
+        let accessibility_label = self
+            .accessibility_label
+            .clone()
+            .or_else(|| self.label.as_ref().map(|label| label.get_text(cx)));
 
         let checked_bg = self
             .color
@@ -152,10 +170,9 @@ impl RenderOnce for Switch {
             BaseSwitch::new(self.id.clone())
                 .checked(checked)
                 .disabled(self.disabled)
-                .when_some(
-                    self.label.as_ref().map(|l| l.get_text(cx)),
-                    |this, label| this.accessibility_label(label),
-                )
+                .when_some(accessibility_label, |this, label| {
+                    this.accessibility_label(label)
+                })
                 .when_some(on_click, |this, on_click| {
                     this.on_change(move |next, _, window, cx| on_click(&next, window, cx))
                 })
@@ -229,6 +246,32 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn an_explicit_accessibility_label_replaces_the_visible_one() {
+        let plain = Switch::new("wifi").label("Wi-Fi");
+        assert_eq!(plain.accessibility_label, None);
+        assert!(matches!(
+            &plain.label,
+            Some(Text::String(label)) if label.as_ref() == "Wi-Fi"
+        ));
+
+        let named = Switch::new("wifi")
+            .label("Wi-Fi")
+            .accessibility_label("Toggle Wi-Fi");
+        assert_eq!(
+            named.accessibility_label.as_deref(),
+            Some("Toggle Wi-Fi"),
+            "an explicit name must win over the visible label"
+        );
+        assert!(
+            matches!(
+                &named.label,
+                Some(Text::String(label)) if label.as_ref() == "Wi-Fi"
+            ),
+            "and must not change what is drawn"
+        );
+    }
 
     struct SwitchHarness {
         disabled: bool,

--- a/crates/ui/src/table/table.rs
+++ b/crates/ui/src/table/table.rs
@@ -1,6 +1,7 @@
 use gpui::{
     AnyElement, App, InteractiveElement as _, IntoElement, ParentElement, Pixels, RenderOnce,
-    StyleRefinement, Styled, TextAlign, Window, div, prelude::FluentBuilder as _, px, relative,
+    SharedString, StyleRefinement, Styled, TextAlign, Window, div, prelude::FluentBuilder as _, px,
+    relative,
 };
 use gpui_base::{
     Table as BaseTable, TableBody as BaseTableBody, TableCaption as BaseTableCaption,
@@ -42,6 +43,7 @@ pub struct Table {
     style: StyleRefinement,
     children: Vec<AnyChildElement>,
     size: Size,
+    accessibility_label: Option<SharedString>,
 }
 
 impl Table {
@@ -51,7 +53,17 @@ impl Table {
             style: StyleRefinement::default(),
             children: Vec::new(),
             size: Size::default(),
+            accessibility_label: None,
         }
+    }
+
+    /// Set the name a screen reader announces for the table.
+    ///
+    /// A [`TableCaption`] is visible descriptive content and is not used
+    /// automatically as the table's accessible name.
+    pub fn accessibility_label(mut self, label: impl Into<SharedString>) -> Self {
+        self.accessibility_label = Some(label.into());
+        self
     }
 
     pub fn child(mut self, child: impl ChildElement + 'static) -> Self {
@@ -92,6 +104,9 @@ impl ChildElement for Table {
 impl RenderOnce for Table {
     fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
         BaseTable::new(("table", self.ix))
+            .when_some(self.accessibility_label, |this, label| {
+                this.accessibility_label(label)
+            })
             .w_full()
             .text_sm()
             .overflow_hidden()
@@ -103,6 +118,23 @@ impl RenderOnce for Table {
                     .enumerate()
                     .map(|(ix, c)| c.into_any(ix, self.size)),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stores_an_explicit_accessibility_label() {
+        let plain = Table::new();
+        assert_eq!(plain.accessibility_label, None);
+
+        let named = Table::new().accessibility_label("Recent invoices");
+        assert_eq!(
+            named.accessibility_label.as_deref(),
+            Some("Recent invoices")
+        );
     }
 }
 


### PR DESCRIPTION
<!-- Closes #<issue number> -->

## Description

Expose `.accessibility_label(...)` on these UI components:

- `Select`
- `Checkbox`
- `Switch`
- `Radio`
- `ColorPicker`
- `Table`
- `Progress`
- `ProgressCircle`

Their corresponding `gpui-base` primitives already accept an accessible name, but the styled wrappers did not provide a way to pass one through.

### Implementation reference in the existing code

This follows the existing `ui::Button` accessibility-label pattern:

1. [Stores an optional `SharedString` accessibility label](https://github.com/longbridge/gpui-component/blob/6d07863fe7077f85abfa0ec2fcb05f3e17c573b2/crates/ui/src/button/button.rs#L192)
2. [Exposes a public `.accessibility_label(...)` builder](https://github.com/longbridge/gpui-component/blob/6d07863fe7077f85abfa0ec2fcb05f3e17c573b2/crates/ui/src/button/button.rs#L320-L332)
3. [Prefers the explicit accessibility label over the visible label](https://github.com/longbridge/gpui-component/blob/6d07863fe7077f85abfa0ec2fcb05f3e17c573b2/crates/ui/src/button/button.rs#L626-L631)
4. [Forwards the resolved name to the corresponding `gpui-base` component](https://github.com/longbridge/gpui-component/blob/6d07863fe7077f85abfa0ec2fcb05f3e17c573b2/crates/ui/src/button/button.rs#L698-L700)
5. [Matching test](https://github.com/longbridge/gpui-component/blob/6d07863fe7077f85abfa0ec2fcb05f3e17c573b2/crates/ui/src/button/button.rs#L1261-L1282)

### Notes
- `Checkbox`, `Switch`, `Radio`, and `ColorPicker` fall back to their visible labels.
- `Select`, `Table`, `Progress`, and `ProgressCircle` use explicit-only naming. Placeholders, selected values, captions, progress values, and arbitrary child content are not inferred as accessible names.
- The change does not alter visual rendering, layout, interaction behavior, or displayed labels.
- AI assistance: Codex generated portions of the repetitive component wiring and tests.

## Screenshot

Not applicable. This changes accessibility metadata and public builder APIs without changing visual rendering.

## How to Test

Run the focused accessibility-label tests:

```bash
cargo test -p gpui-component accessibility_label --lib
```

You should see the following a11y tests pass:

```sh
test progress::progress::tests::stores_an_explicit_accessibility_label ... ok
test checkbox::tests::an_explicit_accessibility_label_replaces_the_visible_one ... ok
test button::button::tests::an_explicit_accessibility_label_replaces_the_visible_one ... ok
test radio::tests::an_explicit_accessibility_label_replaces_the_visible_one ... ok
test switch::tests::an_explicit_accessibility_label_replaces_the_visible_one ... ok
test progress::progress_circle::tests::stores_an_explicit_accessibility_label ... ok
test table::table::tests::stores_an_explicit_accessibility_label ... ok
test select::tests::an_explicit_accessibility_label_does_not_replace_the_placeholder ... ok
test color_picker::tests::an_explicit_accessibility_label_replaces_the_visible_one ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 464 filtered out; finished in 0.00s
```

Can run the complete UI library test suite as well:

```bash
cargo test -p gpui-component --lib
```

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)