### PR TITLE
shell: Price the template cache's fill path, and settle what its surface would be

### DIFF
--- a/crates/shell/src/tests/structure.rs
+++ b/crates/shell/src/tests/structure.rs
@@ -150,6 +150,45 @@ export default class Watchlist extends View {
 }
 "#;
 
+/// The census panel with the one thing a template cannot fill removed, and
+/// nothing else changed: the difference between rebuilding this and rebuilding
+/// [`WATCHLIST`] is what minting forty closures and registering forty callbacks
+/// costs.
+const WATCHLIST_WITHOUT_HANDLERS: &str = r#"
+import { View, div } from "gpui";
+import { v_flex, h_flex, Button } from "gpui-base";
+
+export default class Watchlist extends View {
+  init() {
+    this.tick = 0;
+    this.rows = 40;
+  }
+
+  row(index) {
+    const price = (100 + index + this.tick / 100).toFixed(2);
+    return h_flex()
+      .gap(6)
+      .py(2)
+      .px(6)
+      .rounded(4)
+      .bg("surface")
+      .child(div().w(80).text_sm().text_color("foreground").child(`SYM${index}`))
+      .child(div().w(80).text_sm().text_color("foreground").child(price))
+      .child(div().w(60).text_sm().text_color("muted_foreground").child("+1.42%"))
+      .child(Button.new(`trade-${index}`).px(8).py(2).child("Trade"));
+  }
+
+  render() {
+    this.tick += 1;
+    const rows = [];
+    for (let index = 0; index < this.rows; index += 1) {
+      rows.push(this.row(index));
+    }
+    return v_flex().size_full().p(12).gap(4).bg("background").children(rows);
+  }
+}
+"#;
+
 #[gpui::test]
 fn a_value_only_change_repeats_the_structure(cx: &mut TestAppContext) {
     let (runtime, mut context, view) = script_view(cx, VALUES_ONLY);
@@ -290,7 +329,9 @@ fn percent(part: usize, whole: usize) -> f64 {
 /// after both borrows have ended.
 struct Census {
     structure: crate::spec::StructureFingerprint,
+    root: crate::spec::SpecId,
     nodes: Vec<(Option<Component>, Vec<SpecOp>)>,
+    children: Vec<Vec<crate::spec::SpecId>>,
 }
 
 /// How many positions two descriptions of the same shape disagree on.
@@ -332,11 +373,15 @@ fn census(snapshot: &crate::RenderSnapshot) -> Census {
     let arena = snapshot.arena();
     Census {
         structure: snapshot.structure(),
+        root: snapshot.root(),
         nodes: (0..arena.len() as u32)
             .map(|id| {
                 let node = arena.node(id).expect("node");
                 (node.component().cloned(), node.ops().to_vec())
             })
+            .collect(),
+        children: (0..arena.len() as u32)
+            .map(|id| arena.node(id).expect("node").children().to_vec())
             .collect(),
     }
 }
@@ -406,4 +451,157 @@ fn render_once(context: &mut VisualTestContext, view: &Entity<ScriptView>) {
 fn invalidate(context: &mut VisualTestContext, view: &Entity<ScriptView>) {
     context.update(|_, cx| view.update(cx, |view, _| view.invalidate()));
     render_once(context, view);
+}
+
+/// What level 2 would cost, if the surface existed to reach it.
+///
+/// §20.7's second problem is that a template cache only pays if the *builder
+/// calls are not made* — reusing the arena on the Rust side while JavaScript
+/// still runs `div().flex().gap(4)` removes the smaller half of a recorded
+/// call and leaves the interpreter cost untouched. That is an argument, not a
+/// number, and the number is what decides whether the surface is worth
+/// designing.
+///
+/// So this replays one description into a fresh arena through the arena's own
+/// API — `push`, `push_op`, `attach`, the exact calls an instantiation would
+/// make — with this render's values written into the positions the census
+/// found varying. No JavaScript runs, nothing crosses the bridge, and no
+/// `Bridged` is converted. It is the fill path with the surface left out.
+///
+/// It is a floor rather than a promise. A real instantiation carries costs
+/// this does not — resolving which template and which variant, and minting the
+/// handlers §20.7's third problem says stay — and the census above says half of
+/// what a watchlist row writes is exactly those handlers.
+#[gpui::test]
+fn the_fill_path_against_the_rebuild_it_would_replace(cx: &mut TestAppContext) {
+    const ITERATIONS: usize = 50;
+    const ROUNDS: usize = 7;
+
+    let (runtime, mut context, object) = script_object(cx, WATCHLIST);
+
+    let (rebuild, fill, nodes, ops) = context.update(|window, cx| {
+        let mut build = || {
+            runtime
+                .build_snapshot(&object, None, crate::policy::default(), window, cx)
+                .expect("render")
+        };
+
+        build();
+        let template = census(&build());
+        let ops: usize = template.nodes.iter().map(|node| node.1.len()).sum();
+
+        // Best of several batches rather than one average, for the reason
+        // `benchmark.rs` gives: every source of noise on a shared machine adds
+        // time and none removes it.
+        let mut rebuild = std::time::Duration::MAX;
+        for _ in 0..ROUNDS {
+            let started = std::time::Instant::now();
+            for _ in 0..ITERATIONS {
+                build();
+            }
+            rebuild = rebuild.min(started.elapsed() / ITERATIONS as u32);
+        }
+
+        let mut fill = std::time::Duration::MAX;
+        for _ in 0..ROUNDS {
+            let started = std::time::Instant::now();
+            for _ in 0..ITERATIONS {
+                std::hint::black_box(replay(&template));
+            }
+            fill = fill.min(started.elapsed() / ITERATIONS as u32);
+        }
+
+        (rebuild, fill, template.nodes.len(), ops)
+    });
+
+    // The same panel with `.on_click(...)` removed and nothing else changed.
+    // The gap between the two rebuilds is the cost a template keeps paying:
+    // forty closures allocated and forty callbacks registered, which happen
+    // whether or not the structure around them was reused.
+    let (bare_runtime, mut bare_context, bare) = script_object(cx, WATCHLIST_WITHOUT_HANDLERS);
+    let handlerless = bare_context.update(|window, cx| {
+        let runtime = &bare_runtime;
+        let mut build = || {
+            runtime
+                .build_snapshot(&bare, None, crate::policy::default(), window, cx)
+                .expect("render")
+        };
+        build();
+        let mut best = std::time::Duration::MAX;
+        for _ in 0..ROUNDS {
+            let started = std::time::Instant::now();
+            for _ in 0..ITERATIONS {
+                build();
+            }
+            best = best.min(started.elapsed() / ITERATIONS as u32);
+        }
+        best
+    });
+
+    let handlers = rebuild.saturating_sub(handlerless);
+    let realistic = fill + handlers;
+
+    println!(
+        "\n[G] fill against rebuild — 40-row watchlist, {nodes} nodes, {ops} recorded ops\
+         \n    rebuild (script → snapshot)        {:.3} ms\
+         \n    fill    (replay + slots)           {:.3} ms   {:.1}x\
+         \n    rebuild without the 40 handlers    {:.3} ms\
+         \n    ...so handlers cost               {:.3} ms, and a template still pays them\
+         \n    fill + handlers                    {:.3} ms   {:.1}x",
+        rebuild.as_secs_f64() * 1000.0,
+        fill.as_secs_f64() * 1000.0,
+        rebuild.as_secs_f64() / fill.as_secs_f64().max(f64::MIN_POSITIVE),
+        handlerless.as_secs_f64() * 1000.0,
+        handlers.as_secs_f64() * 1000.0,
+        realistic.as_secs_f64() * 1000.0,
+        rebuild.as_secs_f64() / realistic.as_secs_f64().max(f64::MIN_POSITIVE),
+    );
+
+    // A smoke bound rather than the real reading, which is the printed number:
+    // the assertion has to hold in a debug build too, where both sides are
+    // slower by different factors.
+    assert!(
+        fill < rebuild,
+        "replaying a description in Rust should not cost more than describing it \
+         through the bridge: fill {fill:?} against rebuild {rebuild:?}"
+    );
+}
+
+/// Rebuilds one description into a fresh arena, through the calls an
+/// instantiation would make.
+///
+/// Nodes first, then their operations, then the tree — because the arena
+/// refuses an operation on a node that has already been attached, which is the
+/// same rule that stops a script reusing an element.
+fn replay(template: &Census) -> crate::spec::SpecArena {
+    let mut arena = crate::spec::SpecArena::new();
+
+    for (component, _) in &template.nodes {
+        let component = component.clone().expect("a described node");
+        arena.push(component);
+    }
+
+    for (id, (_, ops)) in template.nodes.iter().enumerate() {
+        for op in ops {
+            arena.push_op(id as u32, op.clone()).expect("op");
+        }
+    }
+
+    // The tree, bottom up. The arena refuses an attachment to a node that has
+    // already been attached itself — the same rule that stops a script reusing
+    // an element — so a parent has to receive all of its children before its
+    // own parent receives it. A post-order walk from the root is exactly that
+    // order, and it is the order the builder produces naturally.
+    attach_below(&mut arena, template, template.root);
+
+    arena
+}
+
+fn attach_below(arena: &mut crate::spec::SpecArena, template: &Census, parent: u32) {
+    for child in &template.children[parent as usize] {
+        attach_below(arena, template, *child);
+    }
+    for child in &template.children[parent as usize] {
+        arena.attach(parent, *child).expect("attach");
+    }
 }

--- a/docs/gpui-shell.md
+++ b/docs/gpui-shell.md
@@ -3425,13 +3425,78 @@ Four shapes, and the design's existing commitments eliminate two of them.
 | --- | --- | --- |
 | **Build-time transform** — lift each `render` body's static chains into a template constant, leave a value function | Automatic, full win | **Out of scope.** It is a compile step, which §5.3 and §24 reject by name, and it costs the source-map-free line numbers of §21.1 |
 | **Engine call-site keys** — key a template on the QuickJS bytecode position of the builder chain | Automatic, no source change | Reaches into the engine's internals from above the seam (§6.5), and the seam exists to keep exactly this out of the contract |
-| **Author-declared templates** — an explicit form the script opts into, carrying its own key and its values | Explicit, full win, no compile step | The only shape that fits the design as written. Costs an API and asks the author to mark hot paths |
+| **Author-declared templates** — an explicit form the script opts into, carrying its own key and its values | Explicit, full win, no compile step | The only shape that fits the design as written. Costs an API and asks the author to mark hot paths — see the next section for what it would look like |
 | **Record and compare** — record as today, hash the structure, reuse on a match | No win on the JavaScript side (problem 2) | Not a shipping design, but the right *instrumentation* — see below |
 
 The author-declared shape is also the one that composes with `gpui.memo`
 (§8.6, §20.6) rather than replacing it. The two cache opposite halves: memo
 reuses a subtree whose **values** did not change, a template reuses a structure
 whose values **did**. A panel wants both — memo the chrome, template the rows.
+
+#### The surface: a template discovers its own slots
+
+The author-declared shape is the only one the table leaves standing, and what it
+left open is what that shape *looks like* — because a form asking the author to
+write a second language is §5.3's DSL under another name.
+
+It does not have to be one. The separation can be discovered at run time, by
+calling the body once with values that are not values:
+
+```js
+import { template } from "gpui";
+
+const Row = template((symbol, price, onSelect) =>
+  h_flex().gap(6).py(2)
+    .child(div().w(80).text_sm().child(symbol))
+    .child(div().w(80).text_sm().child(price))
+    .child(Button.new("trade").on_click(onSelect).child("Trade")));
+
+render() {
+  return v_flex().children(
+    this.quotes.map((quote) =>
+      Row(quote.symbol, quote.price, () => this.select(quote))),
+  );
+}
+```
+
+The body is ordinary builder code. On its first call the runtime runs it once
+with a **sentinel** in each parameter position, records the description exactly
+as it records any other, and notes every place a sentinel came to rest — a text
+child, a style argument, a handler. What is left over is the structure, and the
+notes are the `slots` list of the IR above. Every call after that grafts the
+structure and writes the arguments into the slots: no builder call is made,
+nothing crosses the bridge, and no JavaScript runs beyond the caller's own
+`map`.
+
+Three properties are what make this work where a call-site key would not:
+
+- **Validity is O(slots).** The template is selected by *which function was
+  called*, before any builder call — which is problem 1's requirement, met by
+  construction rather than by a comparison after the fact.
+- **There is no compile step.** `template(...)` is a function, its body is
+  JavaScript, and a reported line number is still a source line number
+  (§5.3, §21.1).
+- **A variant is a second template.** A conditional inside a body would freeze
+  at discovery, so the rule is that a body has none: a loading state and a
+  content state are two templates. That is the variant story written by the
+  author rather than inferred, and it is the honest version of it.
+
+And two rules the runtime has to *enforce* rather than document:
+
+- **An argument may be passed through, not computed on.** `price` may be handed
+  to `.child(...)`; `` `${price}` `` would consume the sentinel during discovery
+  and bake a constant into the structure. So the sentinel refuses to become a
+  primitive — `Symbol.toPrimitive`, `toString` and `valueOf` all throw a message
+  naming the rule — and the mistake is a diagnostic at first use rather than a
+  panel that silently stops updating. Formatting belongs at the call site, where
+  it is a value being computed rather than a structure being described.
+- **A handler must arrive as an argument.** A closure written inside the body is
+  created once, at discovery, and would capture that call's values for the life
+  of the template. A body that registers one is refused for the same reason.
+
+The second rule is also where the ceiling sits. A handler passed in is allocated
+and registered per call, which is exactly the cost the census below says a
+template cannot remove.
 
 #### Why this comes before a QuickJS JIT
 
@@ -3486,6 +3551,25 @@ the fingerprint and **0.623 ms** after. Two or three mixes per recorded
 operation sit below the noise of the measurement they are inside, which is why
 the counter is always on rather than behind a flag.
 
+**And filling is worth about 5× on that panel, not 30×.** The fill path is
+priced without the surface, by replaying the same watchlist into a fresh arena
+through `push` / `push_op` / `attach` — the exact calls an instantiation would
+make, with no JavaScript, no bridge crossing and no `Bridged` conversion
+(`tests/structure.rs`). Release build, same machine and method:
+
+| | Per build |
+| --- | ---: |
+| Rebuild: script → snapshot | **0.315 ms** |
+| Fill: replay the structure and write the slots | **0.036 ms** — 8.7× |
+| The same panel rebuilt with its forty `on_click`s removed | 0.292 ms |
+| …so the handlers cost | **0.023 ms**, and a template pays them too |
+| **Fill + handlers** | **0.060 ms** — **5.3×** |
+
+The 8.7× is a floor with the hard part left out; the 5.3× is the number to plan
+against, and the gap between them is problem 3 priced rather than argued.
+Neither includes selecting the template and its variant, which the surface above
+makes a property lookup rather than a search — but which is not zero.
+
 #### What that licenses, and what it does not
 
 It licenses designing the surface. The assumption the whole idea rested on is
@@ -3493,12 +3577,13 @@ not merely plausible on a real script — it was unanimous on the workload
 measured, which is the outcome that makes an author-declared template worth an
 API rather than a note.
 
-It does not license expecting the full `C_op` back. The census sizes problem 3
-rather than dissolving it: a panel with one button per row spends half its write
-set on handlers, and *that* half is not builder calls a template skips — it is
-closure allocation and registration that happen whether or not the structure was
-reused. A panel with fewer handlers per row does better; one that is mostly
-controls does worse.
+It does not license expecting the full `C_op` back. The census and the fill
+measurement size problem 3 rather than dissolving it: a panel with one button
+per row spends half its write set on handlers, and *that* half is not builder
+calls a template skips — it is closure allocation and registration that happen
+whether or not the structure was reused. On the watchlist they are 7% of the
+rebuild and 38% of what the fill would still cost. A panel with fewer handlers
+per row does better; one that is mostly controls does worse.
 
 Two things are still unmeasured. The Longbridge terminal of §20.3 is a larger
 and less obliging workload than the story's board, and its rate is the one that
@@ -3508,10 +3593,11 @@ reason §5.3's refusal of a DSL is not also a refusal of this.
 
 #### What is left to do, in order
 
-3. **Choose the surface.** The author-declared form is the only shape §20.7's
-   table leaves standing, so the question is what it looks like: how a template
-   is keyed, how a variant is selected, and how the values reach the slots
-   without the author writing a second language. Composition with `gpui.memo`
+3. **Build the surface.** Sentinel discovery above answers what it looks like;
+   what is left is the implementation and the two refusals that keep it honest —
+   a sentinel that throws on coercion, and a body that refuses an inline
+   handler. The pieces it needs from the arena are a graft with id remapping and
+   a slot write; everything else already exists. Composition with `gpui.memo`
    belongs in the same design rather than after it.
 4. **Target virtual list rows first.** Row descriptions are produced from
    GPUI's layout pass, twice a frame per list


### PR DESCRIPTION
> **Outcome** (see #2858): the template cache was built and measured. Worth **3.5×** to a script written for it and **1.25×** with no authoring change, so it ships unexposed. The numbers this PR produces are the first two rows of §20.7's conclusion table.

