### PR TITLE
story: Take the click's own context in the Summary handler

### DIFF
--- a/crates/story/js/quotes/main.js
+++ b/crates/story/js/quotes/main.js
@@ -125,7 +125,7 @@ export default class QuoteBoard extends View {
         h_flex()
           .gap(SPACE.xs)
           .child(
-            action("summary", "Summary", () => this.loadSummary(cx), cx, {
+            action("summary", "Summary", (_event, cx) => this.loadSummary(cx), cx, {
               disabled: this.loading === true,
             }),
           )


### PR DESCRIPTION
## Description

Clicking **Summary** in the Shell story logged a refusal and did nothing:

```
cx is no longer valid: it was captured during an earlier call and used later.
Use cx.spawn or take cx from the callback arguments instead.
  at loadSummary (crates/story/js/quotes/main.js:169)
  at <anonymous> (crates/story/js/quotes/main.js:128)
```

The handler was `() => this.loadSummary(cx)`, closing over the `cx` that `render` was given. A script `Context` carries a generation checked against the live scope stack, so one kept past its call is refused rather than silently used against the wrong frame — which is the point of the type. `loadSummary` then calls `cx.notify()` and `cx.spawn()`, neither of which a render-phase context would have allowed anyway.

```diff
- action("summary", "Summary", () => this.loadSummary(cx), cx, {
+ action("summary", "Summary", (_event, cx) => this.loadSummary(cx), cx, {
```

The other three handlers in the file call host functions that need no context, which is why this was the only one.

One line, in the story's own script. No `crates/ui` API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqZjY9mYmDynuVFMyNTFci