### PR TITLE
fps: Report CPU per core and memory as private, and add the frame tail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3653,6 +3653,7 @@ version = "0.1.0"
 dependencies = [
  "gpui",
  "instant",
+ "libc",
  "objc2-core-foundation",
  "objc2-io-kit",
  "sysinfo 0.37.2",

--- a/crates/fps/Cargo.toml
+++ b/crates/fps/Cargo.toml
@@ -24,10 +24,12 @@ instant.workspace = true
 sysinfo = "0.37"
 
 # This process' GPU usage is read straight from the platform, since `sysinfo`
-# does not report it. Each backend is the counter the platform's own activity
-# monitor attributes per process with, so no vendor SDK or elevated privilege
-# is involved.
+# does not report it, and so is its private memory, which `sysinfo` reports only
+# as a resident set that counts every shared library page. Each backend is the
+# counter the platform's own activity monitor attributes per process with, so no
+# vendor SDK or elevated privilege is involved.
 [target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
 objc2-core-foundation = { version = "0.3", default-features = false, features = [
     "std",
     "CFArray",
@@ -41,7 +43,11 @@ objc2-io-kit = { version = "0.3", default-features = false, features = [
 ] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { workspace = true, features = ["Win32_System_Performance"] }
+windows = { workspace = true, features = [
+    "Win32_System_Performance",
+    "Win32_System_ProcessStatus",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/fps/README.md
+++ b/crates/fps/README.md
@@ -7,10 +7,11 @@ usage.
 ```
 ┌──────────────────────────┐
 │  ﹋﹏  118 FPS  ﹋︿﹏﹋   │  ← the trace runs behind the headline
-│ FRAME             8.4 ms │
-│ DROP                0.0% │
+│ FRAME             8.4 ms │  ← what a typical frame cost
+│ P95              14.1 ms │  ← what its slow tail cost
+│ DROP 0.0%       INV  1.0 │
 │ GPU                31.0% │
-│ CPU 12.4%      MEM 84 MB │
+│ CPU 142%       MEM 84 MB │
 └──────────────────────────┘
 ```
 
@@ -161,9 +162,48 @@ window redraws for its own reasons, and reads zero while the window is idle.
   frames a second, so the headline goes red while every one of those frames was
   in fact drawn well inside the budget — `FRAME` staying green is what says the
   application is fine and simply has nothing to redraw.
-- CPU and memory are sampled with `sysinfo` on a background thread; the values
-  are for this process, and CPU is normalized so 100 means every logical core is
-  saturated. Resource sampling is unavailable on the web.
+- `FRAME` is the mean draw time and `P95` the time 95% of the retained frames
+  came in under. A run of quick frames pulls a mean down over a spike, so the
+  mean alone reads comfortable through jank the user can see; the two together
+  say both what a frame usually costs and what its slow tail costs. `P95` is
+  robust to a single outlier by construction — the chart and its axis are what
+  show that one.
+- `INV` is the mean number of invalidations coalesced into one frame. One means
+  every redraw the window was asked for became a frame; well above one means it
+  was asked far more often than it could answer, and the excess is work being
+  thrown away. It does not show up in the frame times at all, since each frame
+  that *is* drawn may be perfectly quick. It is the one reading the HUD does not
+  grade: in continuous mode the monitor requests an animation frame of its own
+  every render, so an application invalidating once a frame measures two, and
+  the baseline depends on a switch the HUD cannot judge against.
+- CPU, memory and GPU are sampled on a background thread, and each reading is
+  the mean over a trailing three second window — they are coarse samples of
+  quantities that move between one sample and the next, and published raw they
+  churn too fast to read. Resource sampling is unavailable on the web.
+- `CPU` is on the single-core scale that `top`, Activity Monitor and Task
+  Manager's per-process column all use: **100 is one saturated logical core**, so
+  a process spread over a core and a half reads 140. It is deliberately not
+  divided by the core count — normalizing so that 100 is the whole machine makes
+  the same work read 12% on a four core laptop and 2% on a twenty-four core
+  desktop, and pushes every interesting value into the bottom of the range,
+  where a UI thread pinning a core looks idle.
+- `MEM` is the memory this process is *responsible for*, not its resident set.
+  RSS counts the read-only pages of every shared library the process maps, which
+  on a windowed application is a graphics stack running to hundreds of megabytes
+  of code it neither allocated nor can release — and which every other window on
+  the machine is mapping at the same time, so the number moves when a different
+  program starts. Each platform reads the counter its own activity monitor
+  shows, and falls back to RSS where there is none:
+  - **macOS** — `ri_phys_footprint` from `proc_pid_rusage`, the counter behind
+    Activity Monitor's Memory column and the one jetsam judges a process on.
+  - **Windows** — `PrivateUsage` from `GetProcessMemoryInfo`, this process'
+    private commit, which Task Manager shows as its commit size.
+  - **Linux** — `RssAnon` from `/proc/self/status`: resident anonymous memory,
+    the heap and stacks and private mappings, and none of the files it maps.
+    `Private_Dirty` from `smaps_rollup` is the closer analogue of the other two,
+    but it is computed by walking every mapping under the address space lock —
+    ~425µs a read against ~5µs — and a HUD should not perturb what it measures
+    to account for a few megabytes of relocations.
 - `GPU` is this process' own share, like the CPU beside it and unlike a
   device-wide reading, which would move for work the application cannot act on.
   Each platform is read where it attributes GPU time per process, and none of

--- a/crates/fps/src/lib.rs
+++ b/crates/fps/src/lib.rs
@@ -32,6 +32,8 @@
 
 #[cfg(not(target_family = "wasm"))]
 mod gpu;
+#[cfg(not(target_family = "wasm"))]
+mod memory;
 mod monitor;
 mod overlay;
 mod sampler;

--- a/crates/fps/src/memory.rs
+++ b/crates/fps/src/memory.rs
@@ -51,23 +51,47 @@ impl MemoryProbe {
 mod tests {
     use super::*;
 
+    /// How much anonymous memory the reading has to move by to prove its unit.
+    const BALLAST: usize = 64 * 1024 * 1024;
+
     /// Whether a probe exists is the platform's answer; what must hold is that
-    /// one which does exist reports bytes rather than the kibibytes or pages
-    /// its counter is published in. A test process running the rest of this
-    /// suite owns megabytes, so a reading under one is a unit that never got
-    /// converted.
+    /// one which does exist reports *bytes*, since the counters behind it are
+    /// published in different units — kibibytes on Linux, bytes through the
+    /// other two — and the conversion is the one thing every backend has to get
+    /// right.
+    ///
+    /// Asserted as growth rather than as an absolute floor: what a process
+    /// happens to own says nothing, and a lean test binary owns well under a
+    /// megabyte. Allocating a known amount and watching the reading follow is
+    /// what separates the units — a backend reporting unconverted kibibytes
+    /// would move by a thousandth of the ballast, and one reporting pages by a
+    /// four-thousandth.
     #[test]
-    fn a_reading_is_in_bytes() {
+    fn a_reading_follows_what_the_process_allocates_in_bytes() {
         let Some(mut probe) = MemoryProbe::new() else {
             return;
         };
-        let Some(bytes) = probe.sample() else {
+        let Some(before) = probe.sample() else {
             return;
         };
 
+        // Touched a page at a time, because two of the three counters move only
+        // once the pages are faulted in rather than when they are reserved.
+        let mut ballast = vec![0u8; BALLAST];
+        for page in ballast.chunks_mut(4096) {
+            page[0] = 1;
+        }
+
+        let after = probe.sample().expect("the probe just answered");
+        // Held live across the reading, so nothing can free or elide it first.
+        std::hint::black_box(&ballast);
+
+        // Half the ballast, not all of it: this only has to be the right order
+        // of magnitude to settle the unit, and the process is free to release
+        // other memory between the two readings.
         assert!(
-            bytes >= 1024 * 1024,
-            "{bytes} is too small to be this process' private memory in bytes"
+            after.saturating_sub(before) > BALLAST as u64 / 2,
+            "{before} -> {after} did not follow {BALLAST} bytes of ballast"
         );
     }
 }

--- a/crates/fps/src/memory.rs
+++ b/crates/fps/src/memory.rs
@@ -1,0 +1,73 @@
+//! How much memory this process is responsible for, as opposed to how many
+//! pages it happens to have mapped.
+//!
+//! `sysinfo` reports the resident set, and on every platform that counts the
+//! read-only pages of every shared library the process maps. The graphics stack
+//! alone is most of it: a window on a machine with a proprietary driver *and*
+//! Mesa loaded maps a shader compiler, a GL core and a handful of driver
+//! libraries, which is a few hundred megabytes of code the process neither
+//! allocated nor can release, and which every other window on the machine is
+//! mapping at the same time. A HUD that reports the sum tells the reader
+//! almost nothing about their own application — the number moves when a
+//! *different* program starts.
+//!
+//! So each platform reads the counter its own activity monitor shows: the
+//! private, dirty memory that exists because this process is running and would
+//! come back if it exited. The three are not byte-identical — they cannot be,
+//! since the platforms do not account for memory the same way — but they answer
+//! the same question, and each matches what the reader would see if they went
+//! looking in Activity Monitor, Task Manager or `top`.
+
+#[cfg_attr(target_os = "macos", path = "memory/macos.rs")]
+#[cfg_attr(target_os = "windows", path = "memory/windows.rs")]
+#[cfg_attr(target_os = "linux", path = "memory/linux.rs")]
+#[cfg_attr(
+    not(any(target_os = "macos", target_os = "windows", target_os = "linux")),
+    path = "memory/unsupported.rs"
+)]
+mod platform;
+
+/// Samples this process' private memory.
+///
+/// [`new`] returns `None` on a platform with no such counter, and the caller
+/// then falls back to the resident set — a worse number, but a present one.
+///
+/// [`new`]: MemoryProbe::new
+pub(crate) struct MemoryProbe(platform::Probe);
+
+impl MemoryProbe {
+    pub(crate) fn new() -> Option<Self> {
+        platform::Probe::new().map(Self)
+    }
+
+    /// Private memory, in bytes, or `None` for a reading that is momentarily
+    /// unavailable.
+    pub(crate) fn sample(&mut self) -> Option<u64> {
+        self.0.sample()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Whether a probe exists is the platform's answer; what must hold is that
+    /// one which does exist reports bytes rather than the kibibytes or pages
+    /// its counter is published in. A test process running the rest of this
+    /// suite owns megabytes, so a reading under one is a unit that never got
+    /// converted.
+    #[test]
+    fn a_reading_is_in_bytes() {
+        let Some(mut probe) = MemoryProbe::new() else {
+            return;
+        };
+        let Some(bytes) = probe.sample() else {
+            return;
+        };
+
+        assert!(
+            bytes >= 1024 * 1024,
+            "{bytes} is too small to be this process' private memory in bytes"
+        );
+    }
+}

--- a/crates/fps/src/memory/linux.rs
+++ b/crates/fps/src/memory/linux.rs
@@ -1,0 +1,84 @@
+//! Reads `RssAnon` out of `/proc/self/status`: the resident anonymous memory of
+//! this process — its heap, its thread stacks and every private mapping — and
+//! none of the files it maps.
+//!
+//! `RssAnon` rather than the `Private_Dirty` of `/proc/self/smaps_rollup`, which
+//! is the closer analogue of what macOS and Windows report here. `smaps_rollup`
+//! is computed by walking every mapping in the address space under its lock,
+//! and on a windowed application — a few hundred mappings once the graphics
+//! stack is up — that measures ~425us a read against ~5us for `status`. The
+//! difference between the two counters is the process' private *file* pages:
+//! relocations, `.data`, the GOT, single-digit megabytes that do not move. A
+//! performance HUD should not take the address space lock twice a second to
+//! account for them — least of all one whose whole job is to not perturb what
+//! it measures.
+
+use std::fs;
+
+/// Per-process counters, including the resident set split by kind. Reading it
+/// formats counters the kernel already holds, with no walk of the address space
+/// behind it.
+const STATUS: &str = "/proc/self/status";
+
+/// The line carrying resident anonymous memory, as in `RssAnon:    118016 kB`.
+/// Split out of `VmRSS` in 4.5, which is old enough not to need a fallback.
+const ANONYMOUS: &str = "RssAnon:";
+
+pub(super) struct Probe {
+    _private: (),
+}
+
+impl Probe {
+    pub(super) fn new() -> Option<Self> {
+        // Doubles as the support check: a kernel that does not publish the
+        // line leaves the HUD on the resident set rather than at zero.
+        read()?;
+        Some(Self { _private: () })
+    }
+
+    pub(super) fn sample(&mut self) -> Option<u64> {
+        read()
+    }
+}
+
+/// The kernel publishes the value in kibibytes, and the unit is part of the
+/// line; it is parsed as a fixed `kB` rather than read back, since every
+/// counter in this file is published in it.
+fn read() -> Option<u64> {
+    let status = fs::read_to_string(STATUS).ok()?;
+    let value = status
+        .lines()
+        .find_map(|line| line.strip_prefix(ANONYMOUS))?;
+    let kibibytes: u64 = value.split_whitespace().next()?.parse().ok()?;
+    Some(kibibytes * 1024)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole point of the counter: it leaves out the file pages that make
+    /// the resident set say more about the machine's graphics stack than about
+    /// the application. On Linux this is an identity — `RssAnon` is one of the
+    /// two halves `VmRSS` is the sum of — so it can be asserted rather than
+    /// merely expected.
+    #[test]
+    fn anonymous_memory_is_a_part_of_the_resident_set() {
+        let Some(anonymous) = read() else {
+            return;
+        };
+        let status = fs::read_to_string(STATUS).expect("`read` just parsed this file");
+        let resident: u64 = status
+            .lines()
+            .find_map(|line| line.strip_prefix("VmRSS:"))
+            .and_then(|value| value.split_whitespace().next()?.parse().ok())
+            .map(|kibibytes: u64| kibibytes * 1024)
+            .expect("every kernel publishes VmRSS");
+
+        assert!(anonymous > 0, "a live process owns anonymous memory");
+        assert!(
+            anonymous <= resident,
+            "{anonymous} bytes anonymous cannot exceed {resident} bytes resident"
+        );
+    }
+}

--- a/crates/fps/src/memory/macos.rs
+++ b/crates/fps/src/memory/macos.rs
@@ -1,0 +1,59 @@
+//! Reads `ri_phys_footprint` through `proc_pid_rusage`, the counter behind
+//! Activity Monitor's Memory column and the one the kernel judges a process
+//! against under memory pressure — the number that decides whether this
+//! application is the one that gets jetsammed.
+//!
+//! It is the dirty and compressed memory the task owns, so unlike its resident
+//! size it does not count the clean pages of the frameworks, the Metal stack
+//! and the drivers it maps, which every other application on the machine maps
+//! at the same time.
+//!
+//! `proc_pid_rusage` rather than `task_info(TASK_VM_INFO)`, which carries the
+//! same footprint: the rusage flavors are a stable public interface with a
+//! versioned layout, while `task_vm_info_data_t` is a Mach structure whose size
+//! is the version, so reading it means hard-coding a layout that has grown
+//! across releases.
+
+use std::mem::MaybeUninit;
+
+pub(super) struct Probe {
+    pid: libc::c_int,
+}
+
+impl Probe {
+    pub(super) fn new() -> Option<Self> {
+        let probe = Self {
+            pid: std::process::id() as libc::c_int,
+        };
+        // Doubles as the support check, though there is no macOS this call is
+        // absent from; it is here so a refusal shows up as a missing reading
+        // rather than as a HUD stuck at zero.
+        probe.read()?;
+        Some(probe)
+    }
+
+    pub(super) fn sample(&mut self) -> Option<u64> {
+        self.read()
+    }
+
+    /// `V2` is the oldest flavor carrying `ri_phys_footprint`, so it is the one
+    /// asked for: a later flavor would only add fields this does not read while
+    /// narrowing the range of systems that answer.
+    fn read(&self) -> Option<u64> {
+        let mut info = MaybeUninit::<libc::rusage_info_v2>::uninit();
+        // SAFETY: `info` is a live buffer of exactly the layout `RUSAGE_INFO_V2`
+        // names, which is the only thing the call writes through the pointer.
+        let status = unsafe {
+            libc::proc_pid_rusage(
+                self.pid,
+                libc::RUSAGE_INFO_V2,
+                info.as_mut_ptr().cast::<libc::rusage_info_t>(),
+            )
+        };
+        if status != 0 {
+            return None;
+        }
+        // SAFETY: a zero return means the call filled the buffer.
+        Some(unsafe { info.assume_init() }.ri_phys_footprint)
+    }
+}

--- a/crates/fps/src/memory/unsupported.rs
+++ b/crates/fps/src/memory/unsupported.rs
@@ -1,0 +1,14 @@
+//! Platforms that publish no private-memory counter to an ordinary process.
+//! Construction always fails, so the HUD falls back to the resident set.
+
+pub(super) struct Probe;
+
+impl Probe {
+    pub(super) fn new() -> Option<Self> {
+        None
+    }
+
+    pub(super) fn sample(&mut self) -> Option<u64> {
+        None
+    }
+}

--- a/crates/fps/src/memory/windows.rs
+++ b/crates/fps/src/memory/windows.rs
@@ -1,0 +1,58 @@
+//! Reads `PrivateUsage` through `GetProcessMemoryInfo`: this process' private
+//! commit, which is what Task Manager's Commit size column shows.
+//!
+//! It counts the pages the process itself asked the memory manager for, and not
+//! the image pages its working set holds in common with every other process
+//! mapping the same DLL — which on a windowed application is the whole graphics
+//! stack. Private commit rather than the private *working set*, which is closer
+//! to what the other platforms report but is only reachable per page through
+//! `QueryWorkingSetEx`, a walk of the whole address space; the difference is
+//! the process' own memory that has been paged out, which is memory it is still
+//! responsible for.
+
+use std::mem::size_of;
+
+use windows::Win32::System::{
+    ProcessStatus::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS, PROCESS_MEMORY_COUNTERS_EX},
+    Threading::GetCurrentProcess,
+};
+
+pub(super) struct Probe {
+    _private: (),
+}
+
+impl Probe {
+    pub(super) fn new() -> Option<Self> {
+        // Doubles as the support check: without `PROCESS_QUERY_INFORMATION` the
+        // call fails, and the HUD stays on the resident set rather than at zero.
+        read()?;
+        Some(Self { _private: () })
+    }
+
+    pub(super) fn sample(&mut self) -> Option<u64> {
+        read()
+    }
+}
+
+/// The call takes the shorter `PROCESS_MEMORY_COUNTERS`, and `cb` is what tells
+/// it the buffer is in fact the longer structure that carries `PrivateUsage`.
+/// The two share a prefix by definition, so the cast is the documented way to
+/// ask for the extended counters.
+fn read() -> Option<u64> {
+    let size = size_of::<PROCESS_MEMORY_COUNTERS_EX>() as u32;
+    let mut counters = PROCESS_MEMORY_COUNTERS_EX {
+        cb: size,
+        ..Default::default()
+    };
+    // SAFETY: the pseudo handle from `GetCurrentProcess` needs no release, and
+    // the buffer is live and described by the size passed alongside it.
+    let read = unsafe {
+        GetProcessMemoryInfo(
+            GetCurrentProcess(),
+            std::ptr::from_mut(&mut counters).cast::<PROCESS_MEMORY_COUNTERS>(),
+            size,
+        )
+    };
+    read.ok()?;
+    Some(counters.PrivateUsage as u64)
+}

--- a/crates/fps/src/monitor.rs
+++ b/crates/fps/src/monitor.rs
@@ -22,6 +22,17 @@ const DEFAULT_FRAME_BUDGET: Duration = Duration::from_nanos(16_666_667);
 const DEFAULT_CAPACITY: usize = 120;
 const DEFAULT_RESOURCE_INTERVAL: Duration = Duration::from_millis(500);
 
+/// How far back CPU, memory and GPU are averaged over. At the default interval
+/// that is six readings: long enough to settle the churn between one sample and
+/// the next, short enough that a real change reaches the HUD while the reader
+/// is still looking at what caused it.
+const RESOURCE_WINDOW: Duration = Duration::from_secs(3);
+
+/// Which frame the `P95` row reports. The 95th rather than the 99th: the chart
+/// keeps 120 frames by default, so the 99th is the second slowest of them — one
+/// frame, which moves the row on its own and reads as noise.
+const FRAME_PERCENTILE: f32 = 0.95;
+
 /// How fast the chart's y axis relaxes back down after a spike. Growth is
 /// immediate so a slow frame is never clipped, while the decay is gradual so
 /// the bars don't visibly rescale every frame.
@@ -99,7 +110,11 @@ const DEFAULT_FONT: &str = "monospace";
 struct Readout {
     fps: f32,
     frame_millis: f32,
+    /// The slow tail of the same frames `frame_millis` is the mean of.
+    percentile_millis: f32,
     dropped_percent: f32,
+    /// Mean invalidations coalesced into one frame; one means none were wasted.
+    invalidations: f32,
 }
 
 pub struct FpsMonitor {
@@ -204,7 +219,10 @@ impl FpsMonitor {
             // Probing walks the process table, so it never runs on the render
             // thread. The probe moves in and out of each background task rather
             // than living behind a lock.
-            let Some(mut probe) = executor.spawn(async { ResourceProbe::new() }).await else {
+            let Some(mut probe) = executor
+                .spawn(async { ResourceProbe::new(RESOURCE_WINDOW) })
+                .await
+            else {
                 return;
             };
 
@@ -251,7 +269,9 @@ impl FpsMonitor {
             // The mean over the interval rather than the latest frame, which
             // at this cadence would be an arbitrary sample.
             frame_millis: self.sampler.mean_draw().as_secs_f32() * 1000.,
+            percentile_millis: self.sampler.percentile_draw(FRAME_PERCENTILE).as_secs_f32() * 1000.,
             dropped_percent: self.sampler.over_budget_ratio(self.frame_budget) * 100.,
+            invalidations: self.sampler.mean_invalidations(),
         };
         self.readout_at = Some(now);
     }
@@ -399,7 +419,9 @@ impl Render for FpsMonitor {
         let Readout {
             fps,
             frame_millis,
+            percentile_millis,
             dropped_percent: dropped,
+            invalidations,
         } = self.readout;
         let fps_color = fps_color(fps, budget, style);
         let resources = self.resources.filter(|_| self.show_resources);
@@ -454,11 +476,46 @@ impl Render for FpsMonitor {
                             style,
                         ))
                         .child(reading(
-                            "DROP",
-                            format!("{dropped:.1}%"),
-                            style.level_color(if dropped > 0. { 1. } else { 0. }, 0.5),
+                            // Graded the same way, so the two millisecond rows
+                            // read as one measurement seen twice: what a frame
+                            // usually costs, and what its slow tail costs.
+                            "P95",
+                            format!("{percentile_millis:.1} ms"),
+                            style.level_color(percentile_millis / 1000., budget.as_secs_f32()),
                             style,
                         ))
+                        .child(
+                            // Dropped frames and wasted invalidations share a
+                            // row: both count redundant work rather than
+                            // measuring a duration, so neither belongs in the
+                            // millisecond column above.
+                            row()
+                                .child(pair(
+                                    "DROP",
+                                    format!("{dropped:.1}%"),
+                                    style.level_color(if dropped > 0. { 1. } else { 0. }, 0.5),
+                                    style,
+                                ))
+                                .child(pair(
+                                    "INV",
+                                    format!("{invalidations:.1}"),
+                                    // Ungraded, unlike every other reading in
+                                    // the HUD. One per frame is the ideal, but
+                                    // it is not the floor here: in continuous
+                                    // mode the monitor requests an animation
+                                    // frame of its own on every render, so an
+                                    // application invalidating once a frame
+                                    // measures two and a healthy HUD would sit
+                                    // permanently in the red. The baseline
+                                    // depends on that switch and on how the
+                                    // application drives its own redraws, which
+                                    // is not something the HUD can grade — so
+                                    // the number is reported and the reading is
+                                    // left to whoever knows what to expect.
+                                    style.foreground,
+                                    style,
+                                )),
+                        )
                         .when_some(
                             resources.and_then(|resources| resources.gpu_percent),
                             |this, gpu| {
@@ -475,20 +532,17 @@ impl Render for FpsMonitor {
                                 // CPU and memory share a row: both are coarse
                                 // background samples, unlike the per-frame
                                 // numbers.
-                                div()
-                                    .flex()
-                                    .w_full()
-                                    .justify_between()
-                                    .gap_2()
-                                    .py(px(1.))
+                                row()
                                     .child(pair(
                                         "CPU",
-                                        format!("{:.1}%", resources.cpu_percent),
+                                        format_cpu(resources.cpu_percent),
+                                        style.foreground,
                                         style,
                                     ))
                                     .child(pair(
                                         "MEM",
                                         format_bytes(resources.memory_bytes),
+                                        style.foreground,
                                         style,
                                     )),
                             )
@@ -521,14 +575,19 @@ fn fps_color(fps: f32, budget: Duration, style: FpsStyle) -> Hsla {
     }
 }
 
+/// A row carrying two [`pair`]s, pushed to either inner edge.
+fn row() -> Div {
+    div().flex().w_full().justify_between().gap_2().py(px(1.))
+}
+
 /// A `LABEL value` pair kept together, for rows that carry more than one
 /// reading. The label stays muted so it reads as a caption, not as data.
-fn pair(label: &'static str, value: String, style: FpsStyle) -> Div {
+fn pair(label: &'static str, value: String, value_color: Hsla, style: FpsStyle) -> Div {
     div()
         .flex()
         .gap_1()
         .child(div().text_color(style.muted).child(label))
-        .child(div().text_color(style.foreground).child(value))
+        .child(div().text_color(value_color).child(value))
 }
 
 /// One `LABEL … value` row. The value is right aligned against the HUD's inner
@@ -543,6 +602,22 @@ fn reading(label: &'static str, value: String, value_color: Hsla, style: FpsStyl
         .py(px(1.))
         .child(div().text_color(style.muted).child(label))
         .child(div().text_color(value_color).child(value))
+}
+
+/// A CPU reading on the single core scale, which passes 100 as soon as the
+/// process spreads over more than one core and reaches the core count times a
+/// hundred when it saturates the machine.
+///
+/// A tenth is worth showing while the reading is small, where it is the
+/// difference between idle and a busy timer; past ten the extra digit only
+/// churns, and dropping it also keeps the reading inside the row's share of the
+/// HUD on a machine with enough cores to reach four figures.
+fn format_cpu(percent: f32) -> String {
+    if percent < 10. {
+        format!("{percent:.1}%")
+    } else {
+        format!("{percent:.0}%")
+    }
 }
 
 fn format_bytes(bytes: u64) -> String {
@@ -612,5 +687,20 @@ mod tests {
     fn formats_memory_by_magnitude() {
         assert_eq!(format_bytes(184 * 1024 * 1024), "184 MB");
         assert_eq!(format_bytes(3 * 1024 * 1024 * 1024), "3.00 GB");
+    }
+
+    /// The reading is on the single core scale, so it passes 100 and keeps
+    /// going — the row must show that rather than round it away or clip it.
+    #[test]
+    fn formats_cpu_on_the_single_core_scale() {
+        // A process spread over a core and a half, which under a scale where
+        // 100 is the whole machine would have read 5.8% on a 24 core desktop.
+        assert_eq!(format_cpu(140.), "140%");
+        // Saturating every core of a big machine still has somewhere to go.
+        assert_eq!(format_cpu(2400.), "2400%");
+        // Small readings keep the tenth that distinguishes them.
+        assert_eq!(format_cpu(0.4), "0.4%");
+        assert_eq!(format_cpu(9.9), "9.9%");
+        assert_eq!(format_cpu(12.4), "12%");
     }
 }

--- a/crates/fps/src/sampler.rs
+++ b/crates/fps/src/sampler.rs
@@ -118,6 +118,45 @@ impl FrameSampler {
         total / self.samples.len() as u32
     }
 
+    /// The draw time `percentile` of the retained frames came in at or under,
+    /// as in `0.95` for the 95th.
+    ///
+    /// The mean beside it says what a typical frame costs; this says what the
+    /// slow tail costs, and the tail is what a stutter *is*. The two separate
+    /// exactly where it matters: a run of quick frames pulls the mean down over
+    /// a spike, so a HUD reporting only the mean reads comfortable through jank
+    /// the user can see. It is the same reason a benchmark quotes a 1% low
+    /// beside its average frame rate.
+    ///
+    /// The rank is the nearest one rather than an interpolation between two
+    /// frames, so every value the HUD shows is a frame that was really drawn.
+    pub(crate) fn percentile_draw(&self, percentile: f32) -> Duration {
+        if self.samples.is_empty() {
+            return Duration::ZERO;
+        }
+        let mut draws: Vec<Duration> = self.samples.iter().map(|sample| sample.draw).collect();
+        draws.sort_unstable();
+
+        let last = draws.len() - 1;
+        let rank = (percentile.clamp(0., 1.) * last as f32).round() as usize;
+        draws[rank.min(last)]
+    }
+
+    /// Mean number of invalidations coalesced into one retained frame.
+    ///
+    /// One means every redraw the window was asked for became a frame. Well
+    /// above one means it was asked far more often than it could answer, which
+    /// is work being thrown away — and unlike a slow frame it does not show up
+    /// in the draw times at all, since each frame that *does* get drawn may be
+    /// perfectly quick.
+    pub(crate) fn mean_invalidations(&self) -> f32 {
+        if self.samples.is_empty() {
+            return 0.;
+        }
+        let total: u64 = self.samples.iter().map(|sample| sample.invalidations).sum();
+        total as f32 / self.samples.len() as f32
+    }
+
     /// The slowest retained frame, used to scale the chart's y axis.
     pub(crate) fn peak_draw(&self) -> Duration {
         self.samples
@@ -156,15 +195,103 @@ impl FrameSampler {
 /// A sample of the resource usage shown beside the frame numbers.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub(crate) struct ResourceSample {
-    /// CPU used by this process, normalized so that 100 means every logical
-    /// core is saturated. `sysinfo` reports 100 per saturated core, so the raw
-    /// value is divided by the core count.
+    /// CPU used by this process, on the scale `top`, Activity Monitor and
+    /// Task Manager's per-process column all use: 100 is one saturated logical
+    /// core, so a process spread across a core and a half reads 140.
+    ///
+    /// Deliberately not divided by the core count. Normalizing so that 100 is
+    /// the whole machine makes the reading depend on hardware that has nothing
+    /// to do with the application — the same work reads 12% on a four core
+    /// laptop and 2% on a twenty-four core desktop — and it compresses every
+    /// interesting value into the bottom of the range, where a UI thread
+    /// pinning a core reads 4% and looks idle.
     pub cpu_percent: f32,
-    /// Resident memory of this process, in bytes.
+    /// Memory this process is responsible for, in bytes: private memory rather
+    /// than the resident set, which is mostly shared library pages. See
+    /// [`crate::memory`].
     pub memory_bytes: u64,
     /// The share of the GPU this process is using, and `None` on a platform
     /// that does not attribute GPU time per process. See [`crate::gpu`].
     pub gpu_percent: Option<f32>,
+}
+
+/// Averages the resource readings taken inside a trailing window.
+///
+/// Each of the three is a coarse sample of something that moves between one
+/// sample and the next: CPU is the share of a single interval, GPU the share of
+/// another, memory a snapshot of an allocator that grows and releases in steps.
+/// Published raw at the sampling cadence they jump by tens of percent between
+/// readings that describe the same steady workload, and the eye tracks the
+/// churn instead of the value. Averaging over a window a few samples long keeps
+/// the readings legible without hiding a real change for longer than the window.
+#[cfg(not(target_family = "wasm"))]
+#[derive(Debug)]
+pub(crate) struct ResourceHistory {
+    samples: VecDeque<(Instant, ResourceSample)>,
+    window: Duration,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl ResourceHistory {
+    pub(crate) fn new(window: Duration) -> Self {
+        Self {
+            samples: VecDeque::new(),
+            window,
+        }
+    }
+
+    pub(crate) fn push(&mut self, sample: ResourceSample, now: Instant) {
+        self.samples.push_back((now, sample));
+        while let Some((at, _)) = self.samples.front() {
+            if now.duration_since(*at) > self.window {
+                self.samples.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// The mean of the retained readings, or `None` before the first one has
+    /// landed.
+    ///
+    /// The GPU share is averaged over the readings that carried one rather than
+    /// over all of them: a momentary gap in a counter that is otherwise being
+    /// published would otherwise read as a dip towards zero.
+    pub(crate) fn mean(&self) -> Option<ResourceSample> {
+        if self.samples.is_empty() {
+            return None;
+        }
+
+        let count = self.samples.len() as f32;
+        let cpu_percent = self
+            .samples
+            .iter()
+            .map(|(_, sample)| sample.cpu_percent)
+            .sum::<f32>()
+            / count;
+        // Summed wide: the byte counts are large and the window is only bounded
+        // by time, so a fast sampling cadence must not be able to overflow it.
+        let memory_bytes = self
+            .samples
+            .iter()
+            .map(|(_, sample)| u128::from(sample.memory_bytes))
+            .sum::<u128>()
+            / self.samples.len() as u128;
+
+        let (gpu_total, readings) = self
+            .samples
+            .iter()
+            .filter_map(|(_, sample)| sample.gpu_percent)
+            .fold((0., 0u32), |(total, count), percent| {
+                (total + percent, count + 1)
+            });
+
+        Some(ResourceSample {
+            cpu_percent,
+            memory_bytes: memory_bytes as u64,
+            gpu_percent: (readings > 0).then(|| gpu_total / readings as f32),
+        })
+    }
 }
 
 /// Samples this process' CPU, memory and GPU usage.
@@ -175,27 +302,28 @@ pub(crate) struct ResourceSample {
 pub(crate) struct ResourceProbe {
     system: sysinfo::System,
     pid: sysinfo::Pid,
-    cores: f32,
     /// `None` when this platform publishes no per-process GPU counter, which
     /// the HUD shows by leaving the reading out rather than at a flat zero.
     gpu: Option<crate::gpu::GpuProbe>,
+    /// `None` when this platform publishes no private-memory counter, and the
+    /// reading falls back to the resident set `sysinfo` reports.
+    memory: Option<crate::memory::MemoryProbe>,
+    history: ResourceHistory,
 }
 
 #[cfg(not(target_family = "wasm"))]
 impl ResourceProbe {
     /// Returns `None` when the current process id cannot be determined, which
     /// is the only way sampling can be unavailable on a supported platform.
-    pub(crate) fn new() -> Option<Self> {
+    pub(crate) fn new(window: Duration) -> Option<Self> {
         let pid = sysinfo::get_current_pid().ok()?;
-        let cores = std::thread::available_parallelism()
-            .map(|cores| cores.get() as f32)
-            .unwrap_or(1.);
 
         let mut probe = Self {
             system: sysinfo::System::new(),
             pid,
-            cores,
             gpu: crate::gpu::GpuProbe::new(),
+            memory: crate::memory::MemoryProbe::new(),
+            history: ResourceHistory::new(window),
         };
         // The first refresh only establishes the baseline; `cpu_usage` is a
         // delta against the previous refresh and reads zero until then.
@@ -203,16 +331,32 @@ impl ResourceProbe {
         Some(probe)
     }
 
+    /// Takes a reading and returns the mean over the window, so the HUD is
+    /// handed a number that is already smoothed. Averaging belongs on this side
+    /// of the thread boundary: the probe is what knows the cadence the readings
+    /// arrive at, and the render thread should not be doing arithmetic over a
+    /// history it would otherwise have to keep.
     pub(crate) fn sample(&mut self) -> Option<ResourceSample> {
+        let reading = self.read()?;
+        self.history.push(reading, Instant::now());
+        self.history.mean()
+    }
+
+    fn read(&mut self) -> Option<ResourceSample> {
         self.refresh();
-        // Sampled before the process is borrowed out of `self.system`, so the
-        // two borrows of `self` do not overlap.
+        // Both are sampled before the process is borrowed out of `self.system`,
+        // so the borrows of `self` do not overlap.
         let gpu_percent = self.gpu.as_mut().and_then(crate::gpu::GpuProbe::sample);
+        let private = self
+            .memory
+            .as_mut()
+            .and_then(crate::memory::MemoryProbe::sample);
 
         let process = self.system.process(self.pid)?;
         Some(ResourceSample {
-            cpu_percent: (process.cpu_usage() / self.cores).min(100.),
-            memory_bytes: process.memory(),
+            // Left on `sysinfo`'s own scale, which is 100 per saturated core.
+            cpu_percent: process.cpu_usage(),
+            memory_bytes: private.unwrap_or_else(|| process.memory()),
             gpu_percent,
         })
     }
@@ -247,14 +391,30 @@ mod tests {
     // `std::time::Instant` off the web, so tests can build one without pulling
     // in the `scheduler` crate.
     fn timing(window_id: WindowId, draw: Duration) -> FrameTiming {
+        coalesced(window_id, draw, 1)
+    }
+
+    /// A frame that answered `invalidations` requests to redraw at once.
+    fn coalesced(window_id: WindowId, draw: Duration, invalidations: u64) -> FrameTiming {
         let start = std::time::Instant::now();
         FrameTiming {
             window_id,
             dirty_at: None,
-            invalidations: 1,
+            invalidations,
             draw_start: start,
             draw_end: start + draw,
         }
+    }
+
+    /// A sampler holding one frame per entry in `draws`, in milliseconds.
+    fn sampler_of(draws: &[u64]) -> FrameSampler {
+        let window_id = WindowId::from(1);
+        let mut sampler = FrameSampler::new(window_id, 256);
+        let now = Instant::now();
+        for millis in draws {
+            sampler.ingest(vec![timing(window_id, Duration::from_millis(*millis))], now);
+        }
+        sampler
     }
 
     #[test]
@@ -351,6 +511,97 @@ mod tests {
         assert!(measure_fps(2, Duration::from_millis(10)) > 0.);
     }
 
+    /// The resource history only exists off the web, where there is a process
+    /// to sample in the first place.
+    #[cfg(not(target_family = "wasm"))]
+    mod resource_history {
+        use super::*;
+
+        fn resources(
+            cpu_percent: f32,
+            memory_bytes: u64,
+            gpu_percent: Option<f32>,
+        ) -> ResourceSample {
+            ResourceSample {
+                cpu_percent,
+                memory_bytes,
+                gpu_percent,
+            }
+        }
+
+        #[test]
+        fn resource_readings_average_over_the_window() {
+            let mut history = ResourceHistory::new(Duration::from_secs(3));
+            let start = Instant::now();
+
+            // Four readings a second apart, all of them still inside a three
+            // second window: the oldest is exactly the window's age, and the
+            // window is inclusive of it.
+            for (second, cpu) in [(0, 400.), (1, 100.), (2, 200.), (3, 300.)] {
+                history.push(
+                    resources(cpu, 100 * 1024 * 1024, Some(cpu / 10.)),
+                    start + Duration::from_secs(second),
+                );
+            }
+
+            let mean = history.mean().expect("four readings have landed");
+            assert!((mean.cpu_percent - 250.).abs() < 0.01);
+            assert!((mean.gpu_percent.expect("every reading carried one") - 25.).abs() < 0.01);
+            assert_eq!(mean.memory_bytes, 100 * 1024 * 1024);
+
+            // A fifth a second later pushes the first out, so the reading that
+            // was four times the others stops weighing on the mean.
+            history.push(
+                resources(100., 100 * 1024 * 1024, Some(10.)),
+                start + Duration::from_secs(4),
+            );
+            let mean = history.mean().expect("the window still holds four");
+            assert!((mean.cpu_percent - 175.).abs() < 0.01);
+        }
+
+        /// The averaged CPU stays on the single core scale rather than being folded
+        /// back into `0..=100`: a process holding two cores busy reads 200 whether
+        /// it is averaged or not.
+        #[test]
+        fn averaging_does_not_cap_the_cpu_reading() {
+            let mut history = ResourceHistory::new(Duration::from_secs(3));
+            let now = Instant::now();
+
+            history.push(resources(150., 0, None), now);
+            history.push(resources(250., 0, None), now);
+
+            let mean = history.mean().expect("two readings have landed");
+            assert!((mean.cpu_percent - 200.).abs() < 0.01);
+        }
+
+        #[test]
+        fn a_gap_in_the_gpu_counter_does_not_read_as_a_dip() {
+            let mut history = ResourceHistory::new(Duration::from_secs(3));
+            let now = Instant::now();
+
+            // The middle reading missed the counter. Averaging it in as a zero
+            // would report 40%; the honest mean is over the two that carried one.
+            history.push(resources(0., 0, Some(60.)), now);
+            history.push(resources(0., 0, None), now);
+            history.push(resources(0., 0, Some(60.)), now);
+
+            let mean = history.mean().expect("three readings have landed");
+            assert_eq!(mean.gpu_percent, Some(60.));
+        }
+
+        #[test]
+        fn a_platform_with_no_gpu_counter_stays_without_one() {
+            let mut history = ResourceHistory::new(Duration::from_secs(3));
+            assert!(history.mean().is_none(), "nothing has been sampled yet");
+
+            history.push(resources(12., 0, None), Instant::now());
+            assert_eq!(
+                history.mean().expect("one reading has landed").gpu_percent,
+                None
+            );
+        }
+    }
+
     #[test]
     fn simultaneous_frames_do_not_divide_by_zero() {
         let window_id = WindowId::from(1);
@@ -369,6 +620,75 @@ mod tests {
         );
 
         assert_eq!(sampler.fps(), 0.);
+    }
+
+    #[test]
+    fn the_percentile_is_the_frame_at_the_nearest_rank() {
+        // Twenty frames, so the 95th percentile is rank 0.95 * 19 = 18.05,
+        // which rounds to the second slowest.
+        let mut draws: Vec<u64> = (1..=20).collect();
+        draws.reverse();
+        let sampler = sampler_of(&draws);
+
+        assert_eq!(sampler.percentile_draw(0.95), Duration::from_millis(19));
+        assert_eq!(sampler.percentile_draw(1.), Duration::from_millis(20));
+        assert_eq!(sampler.percentile_draw(0.), Duration::from_millis(1));
+    }
+
+    #[test]
+    fn the_percentile_separates_a_stutter_the_mean_absorbs() {
+        // Eighteen quick frames and two that took twenty times as long: the
+        // shape a stutter has. The mean stays inside a 60Hz budget while the
+        // tail is well past it, which is the whole reason the row exists.
+        let mut draws = vec![4; 18];
+        draws.extend([80, 80]);
+        let sampler = sampler_of(&draws);
+
+        assert!(sampler.mean_draw() < Duration::from_millis(12));
+        assert_eq!(sampler.percentile_draw(0.95), Duration::from_millis(80));
+    }
+
+    #[test]
+    fn one_slow_frame_in_twenty_does_not_move_the_percentile() {
+        // The complement of the test above, and the reason a percentile is
+        // worth having over `peak_draw`: a single frame is the top 5% of
+        // twenty, so it stays out of the 95th. The chart still shows it, and
+        // the axis is still scaled to it — the row is for the tail that
+        // *persists*, not for every outlier.
+        let mut draws = vec![4; 19];
+        draws.push(80);
+        let sampler = sampler_of(&draws);
+
+        assert_eq!(sampler.percentile_draw(0.95), Duration::from_millis(4));
+        assert_eq!(sampler.peak_draw(), Duration::from_millis(80));
+    }
+
+    #[test]
+    fn an_empty_sampler_has_no_percentile_rather_than_a_guess() {
+        let sampler = FrameSampler::new(WindowId::from(1), 8);
+        assert_eq!(sampler.percentile_draw(0.95), Duration::ZERO);
+        assert_eq!(sampler.mean_invalidations(), 0.);
+    }
+
+    #[test]
+    fn invalidations_average_over_the_retained_frames() {
+        let window_id = WindowId::from(1);
+        let mut sampler = FrameSampler::new(window_id, 8);
+        let now = Instant::now();
+
+        // A window asked to redraw five times for every three frames it drew.
+        for invalidations in [1, 3, 1] {
+            sampler.ingest(
+                vec![coalesced(
+                    window_id,
+                    Duration::from_millis(4),
+                    invalidations,
+                )],
+                now,
+            );
+        }
+
+        assert!((sampler.mean_invalidations() - 5. / 3.).abs() < f32::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Description

The HUD's two resource readings measured something other than what a reader
would take them for.

**CPU** was divided by the core count, so `100` meant the whole machine.
`sysinfo` already reports on the scale `top`, Activity Monitor and Task Manager
use — 100 per saturated core, documented as *"might be bigger than 100 … divide
by the number of CPUs if you want 0..100"* — so the division was this crate's.
It made the reading depend on hardware the application has nothing to do with
(the same work reads 12% on a four core laptop and 2% on a twenty-four core
desktop) and pushed every interesting value into the bottom of the range, where
a UI thread pinning a core shows 4% and looks idle. It is now on the single core
scale, with a tenth below ten and whole percent above.

**Memory** was `sysinfo`'s resident set, which counts the read-only pages of
every shared library the process maps. On a windowed application that is the
graphics stack: measured here, a HUD reported **345 MB** for a process whose own
anonymous memory was **66 MB** — the rest an LLVM shader compiler and a GPU
driver that every other window on the machine maps at the same time, so the
number moved when a *different* program started. Each platform now reads the
counter its own activity monitor shows, falling back to RSS where there is none:

| Platform | Counter | Shown by |
| --- | --- | --- |
| macOS | `ri_phys_footprint` via `proc_pid_rusage` | Activity Monitor's Memory column |
| Windows | `PrivateUsage` via `GetProcessMemoryInfo` | Task Manager's commit size |
| Linux | `RssAnon` from `/proc/self/status` | resident anonymous memory |

`Private_Dirty` from `smaps_rollup` is the closer analogue of the other two, but
it walks every mapping under the address space lock — measured at ~425µs a read
against ~5µs for `status` on a 600-mapping process — and a HUD should not perturb
what it measures to account for a few megabytes of relocations.

Two readings are added from data already being collected. **`P95`** is the draw
time 95% of the retained frames came in under: a run of quick frames pulls the
mean down over a spike, so `FRAME` alone reads comfortable through jank the user
can see. **`INV`** is the mean number of invalidations coalesced into one frame,
which never shows up in the frame times at all, since each frame that *is* drawn
may be perfectly quick. `INV` is the one reading left ungraded — in continuous
mode the monitor requests an animation frame of its own every render, so a
healthy application measures two and a fixed threshold would sit permanently in
the red.

Finally, CPU, memory and GPU are now the mean over a trailing three second
window. Each is a coarse sample of something that moves between one sample and
the next, and published raw at the sampling cadence they churn too fast to read.
The GPU share averages only over the readings that carried one, so a momentary
gap in the counter does not read as a dip towards zero.

No public API changes: `FpsMonitor`'s builder and `fps_monitor()` are untouched.

## Screenshot

Both HUDs captured from the same screen, the same moment — the new build on the
left, an application still on the old one on the right:

```
 new                                old
┌──────────────────────────┐      ┌──────────────────────────┐
│         23  FPS          │      │         28  FPS          │
│ FRAME             4.0 ms │      │ FRAME             8.4 ms │
│ P95               5.1 ms │      │ DROP                0.0% │
│ DROP 0.0%       INV  2.1 │      │ CPU 1.2%     MEM  345 MB │
│ CPU 16%       MEM  47 MB │      └──────────────────────────┘
└──────────────────────────┘
```

The right-hand process was using ~29% of one core and owned 66 MB of anonymous
memory at the time.

## How to Test

```bash
cargo run -p fps_monitor
```

Press `+ load` until the frame rate drops, and compare `CPU` against `top -p
<pid>` (same scale now) and `MEM` against `RssAnon` in `/proc/<pid>/status`.
`P95` should separate from `FRAME` as the load rises, while `INV` sits near two.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific) — **Linux only.** The macOS and Windows memory backends are checked against the `libc` and `windows` 0.58 signatures but were not compiled locally; they need CI or a reviewer on those platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sMNPGLdymZJN2hzFovcyd
