### PR TITLE
table: a mouse click on a cell no longer scrolls it

### DIFF
--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -486,13 +486,33 @@ where
     /// });
     /// ```
     pub fn set_selected_cell(&mut self, row_ix: usize, col_ix: usize, cx: &mut Context<Self>) {
+        self.set_selected_cell_with_scroll(row_ix, col_ix, true, cx);
+    }
+
+    /// [`Self::set_selected_cell`], with the scroll made optional.
+    ///
+    /// A mouse click can only land on a cell the user can already see, so
+    /// forcing it to the centre of the viewport moves content out from under
+    /// the pointer for no reason — `on_cell_click` selects with `scroll:
+    /// false` for exactly that case. Keyboard and programmatic selection
+    /// keep `scroll: true`, since either can land on a cell that is off
+    /// screen.
+    fn set_selected_cell_with_scroll(
+        &mut self,
+        row_ix: usize,
+        col_ix: usize,
+        scroll: bool,
+        cx: &mut Context<Self>,
+    ) {
         self.selection_mode = SelectionMode::Cell;
         self.selected_cell = Some((row_ix, col_ix));
 
-        // Scroll to the cell
-        self.vertical_scroll_handle
-            .scroll_to_item(row_ix, ScrollStrategy::Center);
-        self.scroll_to_col(col_ix, cx);
+        if scroll {
+            // Scroll to the cell
+            self.vertical_scroll_handle
+                .scroll_to_item(row_ix, ScrollStrategy::Center);
+            self.scroll_to_col(col_ix, cx);
+        }
 
         cx.emit(TableEvent::SelectCell(row_ix, col_ix));
         cx.notify();
@@ -726,7 +746,8 @@ where
             return;
         }
 
-        self.set_selected_cell(row_ix, col_ix, cx);
+        // `scroll: false` -- see `set_selected_cell_with_scroll`'s own note.
+        self.set_selected_cell_with_scroll(row_ix, col_ix, false, cx);
 
         if is_double_click {
             cx.emit(TableEvent::DoubleClickedCell(row_ix, col_ix));


### PR DESCRIPTION
## Summary

`Table::on_cell_click` selects the clicked cell via `set_selected_cell`, which unconditionally calls `vertical_scroll_handle.scroll_to_item(row_ix, ScrollStrategy::Center)`. A mouse click can only land on a cell the user can already see, so forcing it to the centre of the viewport on every click recentres the table under the pointer for no reason. This is most noticeable on a short/medium table, where the clicked row visibly jumps.

Keyboard and programmatic selection are unaffected: `set_selected_cell`'s default behaviour (`scroll: true`) is unchanged, since either can legitimately land on a cell that's off screen and does need scrolling into view.

## Change

- Extracted `set_selected_cell`'s body into `set_selected_cell_with_scroll(row_ix, col_ix, scroll, cx)`, with `set_selected_cell` calling it with `scroll: true` (unchanged public behaviour).
- `on_cell_click` now calls `set_selected_cell_with_scroll(row_ix, col_ix, false, cx)`.

## Test plan

- [x] `cargo check -p gpui-component` passes
- [x] Verified in a downstream app: clicking rows in a table (including the very first, already-visible row) no longer scrolls the viewport; keyboard navigation (arrow keys, Home/End, PageUp/PageDown) still scrolls correctly when moving to an off-screen row.
