### PR TITLE
shell: let fetch name any HTTP method

### DIFF
--- a/crates/shell/src/engine/quickjs/standard/fetch.rs
+++ b/crates/shell/src/engine/quickjs/standard/fetch.rs
@@ -89,15 +89,25 @@ impl<'js> FromJs<'js> for FetchOptions {
     }
 }
 
+/// Any method the capability policy is willing to grant.
+///
+/// This is a token check rather than a list. What may be sent, to which host,
+/// on which path, is `Capabilities::may_request`'s decision and it already
+/// takes the method -- a second list here would be a second policy to keep in
+/// step with the first, and the way that goes wrong is a grant that cannot be
+/// exercised. So a method that is a method is parsed, and refusing it stays
+/// where refusing belongs.
+///
+/// What is refused here is a string that is not an HTTP method at all: an
+/// empty field, a space, a quote. `Method::from_bytes` is exactly that judge.
+/// Known methods are upper-cased on the way through, as `fetch` does.
 fn parse_method(ctx: &Ctx<'_>, method: &str) -> Result<reqwest::Method> {
-    match method.to_ascii_uppercase().as_str() {
-        "GET" => Ok(reqwest::Method::GET),
-        "POST" => Ok(reqwest::Method::POST),
-        _ => Err(Exception::throw_type(
+    reqwest::Method::from_bytes(method.to_ascii_uppercase().as_bytes()).map_err(|_| {
+        Exception::throw_type(
             ctx,
-            "fetch(url, options).method supports GET or POST",
-        )),
-    }
+            &format!("fetch(url, options).method `{method}` is not an HTTP method"),
+        )
+    })
 }
 
 fn parse_headers<'js>(ctx: &Ctx<'js>, value: Value<'js>) -> Result<reqwest::header::HeaderMap> {

--- a/crates/shell/src/tests/http_request.rs
+++ b/crates/shell/src/tests/http_request.rs
@@ -39,6 +39,52 @@ export default class Probe extends View {
 }
 "#;
 
+const PUT_PROBE: &str = r#"
+import { div, View } from "gpui";
+import { v_flex } from "gpui-base";
+
+export default class Probe extends View {
+  init(_props, cx) {
+    this.state = "pending";
+    cx.spawn(async (cx) => {
+      try {
+        const response = await fetch("__URL__", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: 7, mode: "add" }),
+        });
+        this.state = `${response.status}|${await response.text()}`;
+      } catch (error) {
+        this.state = `rejected:${error.message}`;
+      }
+      cx.notify();
+    });
+  }
+  render() { return v_flex().child(this.state); }
+}
+"#;
+
+const BAD_METHOD_PROBE: &str = r#"
+import { div, View } from "gpui";
+import { v_flex } from "gpui-base";
+
+export default class Probe extends View {
+  init(_props, cx) {
+    this.state = "pending";
+    cx.spawn(async (cx) => {
+      try {
+        await fetch("__URL__", { method: "not a method" });
+        this.state = "sent";
+      } catch (error) {
+        this.state = `rejected:${error.message}`;
+      }
+      cx.notify();
+    });
+  }
+  render() { return v_flex().child(this.state); }
+}
+"#;
+
 const JSON_PROBE: &str = r#"
 import { div, View } from "gpui";
 import { v_flex } from "gpui-base";
@@ -96,6 +142,52 @@ fn fetch_posts_string_bodies_with_custom_headers(cx: &mut TestAppContext) {
     let rendered = snapshot(&mut context, &view);
     assert!(rendered.contains("200|true|ok"), "{rendered}");
     server.join().expect("HTTP server");
+}
+
+/// A method is not a short list. Which methods may reach which host is the
+/// capability policy's decision, and it already takes the method -- so `fetch`
+/// parses one rather than choosing from two, and a REST API that updates with
+/// `PUT` is reachable without a second policy to keep in step with the first.
+#[gpui::test]
+fn fetch_sends_any_http_method(cx: &mut TestAppContext) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("HTTP listener");
+    let address = listener.local_addr().expect("listener address");
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("HTTP connection");
+        let request = read_request(&mut stream);
+        assert!(request.starts_with("PUT /groups HTTP/1.1\r\n"), "{request}");
+        assert!(
+            request.contains("content-type: application/json\r\n"),
+            "{request}"
+        );
+        assert!(request.ends_with(r#"{"id":7,"mode":"add"}"#), "{request}");
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+            .expect("HTTP response");
+    });
+
+    let source = PUT_PROBE.replace("__URL__", &format!("http://{address}/groups"));
+    let (_runtime, view, mut context) = probe(cx, &source);
+    context.run_until_parked();
+    draw(&mut context, &view);
+    let rendered = snapshot(&mut context, &view);
+    assert!(rendered.contains("200|ok"), "{rendered}");
+    server.join().expect("HTTP server");
+}
+
+/// What is refused is a string that is not a method at all, and it is refused
+/// before anything reaches the network.
+#[gpui::test]
+fn fetch_refuses_a_method_that_is_not_one(cx: &mut TestAppContext) {
+    let source = BAD_METHOD_PROBE.replace("__URL__", "http://127.0.0.1:9/groups");
+    let (_runtime, view, mut context) = probe(cx, &source);
+    context.run_until_parked();
+    draw(&mut context, &view);
+    let rendered = snapshot(&mut context, &view);
+    assert!(
+        rendered.contains("rejected:") && rendered.contains("is not an HTTP method"),
+        "{rendered}"
+    );
 }
 
 #[gpui::test]

--- a/crates/shell/src/typings.rs
+++ b/crates/shell/src/typings.rs
@@ -3310,8 +3310,12 @@ interface ShellFetchResponse {
   json(): Promise<unknown>;
 }
 interface ShellFetchOptions {
-  /** GET by default; POST is available for OAuth-style form exchanges. */
-  method?: "GET" | "POST";
+  /**
+   * GET by default. Any HTTP method may be named; which of them may reach a
+   * given host and path is the plugin's `capabilities.network` policy, not
+   * this field.
+   */
+  method?: string;
   /** Client-managed framing headers such as Host and Content-Length are refused. */
   headers?: Record<string, string>;
   body?: string | Uint8Array;

--- a/docs/gpui-shell.md
+++ b/docs/gpui-shell.md
@@ -2446,7 +2446,8 @@ flush barriers may wait for durability at once.
 ### 17.2 Network
 
 Three experimental surfaces are implemented. Global `fetch(url, options?)`
-supports bounded GET and POST requests, string or `Uint8Array` bodies, safe
+supports bounded requests of any HTTP method -- which methods actually reach a
+host is the capability policy's decision -- string or `Uint8Array` bodies, safe
 request headers, and resolves to `{ status, ok, url, , json() }`; both
 body readers return promises. The `gpui` module exports
 `WebSocket.connect(url, { headers }?)`, returning a socket with asynchronous


### PR DESCRIPTION
## Summary

`fetch(url, { method })` chose between `GET` and `POST`. That made a manifest grant unusable: a plugin could be granted `PUT https://host/path` under `capabilities.network.http` and still not be able to send it — the grant was there and the call site refused it. Two policies, and only one of them was the policy.

`parse_method` is a token check now. Which method may reach which host on which path stays `Capabilities::may_request`'s decision — it already takes the method — and what is refused here is a string that is not an HTTP method at all: an empty field, a space, a quote. Known methods are upper-cased on the way through, as `fetch` does.

Found while writing a plugin against a REST API whose update endpoint is `PUT`, which no manifest could reach.

## Changes

- `crates/shell/src/engine/quickjs/standard/fetch.rs` — `parse_method` parses with `reqwest::Method::from_bytes` instead of matching two names.
- `crates/shell/src/typings.rs` — `ShellFetchOptions.method` is `string`, and says that the policy, not the field, decides what may be sent.
- `docs/gpui-shell.md` — §17.2 no longer says GET and POST.

## Verification

- `cargo test -p gpui-shell` — 573 passed, 0 failed.
- New: `fetch_sends_any_http_method` puts a JSON body to a local server and asserts the request line, header and body arrive as sent; `fetch_refuses_a_method_that_is_not_one` asserts a non-method is rejected before anything reaches the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LC39hSS7Pr4Jo8PWT2hGZJ