### PR TITLE
shell: rebuild a script overlay from the state it closes over

### DIFF
--- a/crates/shell/src/engine/quickjs/overlay.rs
+++ b/crates/shell/src/engine/quickjs/overlay.rs
@@ -78,6 +78,12 @@
 //! belong to the wrong pass. The function is called when the dialog renders, and
 //! again whenever it re-renders, which is the same contract a view's `render`
 //! has. Whatever it closes over is the dialog's state.
+//!
+//! What it closes over is usually another view's state, and this call answers a
+//! depth rather than a handle — so there is nothing for a script to notify when
+//! that state moves. `window.refresh()` is the call for it: the root redraws,
+//! and an overlay built from a script rebuilds with it rather than
+//! re-materializing the description it was opened with.
 
 use std::time::Duration;
 

--- a/crates/shell/src/root.rs
+++ b/crates/shell/src/root.rs
@@ -531,6 +531,7 @@ impl ShellRoot {
             .map(|(index, dialog)| {
                 let topmost = index == topmost_index;
                 let root = root.clone();
+                rebuild_script_overlay(&dialog.content, cx);
 
                 Dialog::new(cx)
                     .focus_handle(dialog.focus_handle.clone())
@@ -582,6 +583,7 @@ impl ShellRoot {
         let sheet = self.sheet.as_ref()?;
         let root = cx.entity();
         let placement = sheet.placement;
+        rebuild_script_overlay(&sheet.content, cx);
 
         Some(
             Sheet::new(cx)
@@ -1002,6 +1004,29 @@ fn install_key_bindings(cx: &mut App) {
 /// test — there is nothing to check. A `Render` or `Layout` scope is a script
 /// bug: it is reported and ignored rather than panicked on, because a script
 /// error must not take the window down (`docs/gpui-shell.md` §5.8).
+/// Rebuilds a script overlay's description before it draws.
+///
+/// An overlay's content is a function, and what it closes over is somebody
+/// else's state -- that is the contract `open_dialog` and `open_sheet`
+/// document, and the only one they can have: neither answers a view handle, so
+/// there is nothing for a script to notify when the state behind the closure
+/// moves. Without this, an overlay materializes the description it was built
+/// with, once, for as long as it is open: a dialog that looks up what someone
+/// typed shows the answer to nothing.
+///
+/// So the root rebuilds it whenever the root itself draws, which is what
+/// `window.refresh()` -- the call whose whole purpose is "there is no view to
+/// notify" -- now reaches. Marking it dirty schedules no frame of its own: the
+/// overlay is about to render as part of this one, and it renders from the
+/// script rather than from the cache.
+///
+/// A non-script overlay owns its own state and is left alone.
+fn rebuild_script_overlay(content: &AnyView, cx: &mut App) {
+    if let Ok(view) = content.clone().downcast::<ScriptView>() {
+        view.update(cx, |view, _| view.invalidate());
+    }
+}
+
 fn overlay_mutation_allowed(operation: &str) -> bool {
     match scope::current_phase() {
         None => true,

--- a/crates/shell/src/tests/render.rs
+++ b/crates/shell/src/tests/render.rs
@@ -7959,7 +7959,7 @@ export default class Probe extends View {
         .load_source("dialog-rebuild.js", source)
         .expect("load");
     let runtime_for_view = Rc::clone(&runtime);
-    let (root, mut context) = cx.add_window_view(move |window, cx| {
+    let (root, context) = cx.add_window_view(move |window, cx| {
         let object = runtime_for_view
             .instantiate(&view_type, window, cx)
             .expect("instantiate");

--- a/crates/shell/src/tests/render.rs
+++ b/crates/shell/src/tests/render.rs
@@ -7924,6 +7924,89 @@ export default class LargeLists extends View {
     );
 }
 
+/// An overlay's content is a function, and what it closes over is another
+/// view's state -- the only contract `open_dialog` can have, since it answers a
+/// depth and not a handle. So the overlay has to rebuild from the script, not
+/// from the description it was opened with: a dialog that looks up what
+/// somebody typed would otherwise show the answer to nothing for as long as it
+/// is open.
+#[gpui::test]
+fn a_dialog_rebuilds_from_the_state_it_closes_over(cx: &mut TestAppContext) {
+    cx.update(|cx| crate::init(cx));
+    let runtime = ShellRuntime::new_isolated().expect("runtime");
+    cx.update(|cx| runtime.set_global(cx));
+    let source = r#"
+import { View } from "gpui";
+import { v_flex } from "gpui-base";
+
+export default class Probe extends View {
+  init(_props, cx) {
+    this.answer = "pending";
+    cx.timer.after(5, () => {
+      window.open_dialog(() => v_flex().child(`dialog:${this.answer}`), {});
+    });
+    cx.timer.after(30, () => {
+      this.answer = "settled";
+      window.refresh();
+    });
+  }
+  render() {
+    return v_flex().child(`view:${this.answer}`);
+  }
+}
+"#;
+    let view_type = runtime
+        .load_source("dialog-rebuild.js", source)
+        .expect("load");
+    let runtime_for_view = Rc::clone(&runtime);
+    let (root, mut context) = cx.add_window_view(move |window, cx| {
+        let object = runtime_for_view
+            .instantiate(&view_type, window, cx)
+            .expect("instantiate");
+        let view = cx.new(|_| ScriptView::new(runtime_for_view, object));
+        crate::root::ShellRoot::new(view.into(), window, cx)
+    });
+    context
+        .executor()
+        .advance_clock(std::time::Duration::from_millis(10));
+    context.run_until_parked();
+    context.update(|window, cx| window.draw(cx).clear(cx));
+
+    let dialog = context
+        .update(|_, cx| root.read(cx).topmost_dialog().cloned())
+        .expect("the dialog the script opened")
+        .downcast::<ScriptView>()
+        .expect("a script dialog");
+    let opened = context.update(|_, cx| {
+        dialog
+            .read(cx)
+            .snapshot()
+            .map(crate::RenderSnapshot::debug_tree)
+            .unwrap_or_default()
+    });
+    assert!(opened.contains("dialog:pending"), "{opened}");
+
+    // The state the closure reads moves, and nothing here is the dialog's own
+    // view to notify -- `window.refresh()` is the call for exactly that.
+    context
+        .executor()
+        .advance_clock(std::time::Duration::from_millis(20));
+    context.run_until_parked();
+    context.update(|window, cx| window.draw(cx).clear(cx));
+
+    let refreshed = context.update(|_, cx| {
+        dialog
+            .read(cx)
+            .snapshot()
+            .map(crate::RenderSnapshot::debug_tree)
+            .unwrap_or_default()
+    });
+    assert!(
+        refreshed.contains("dialog:settled"),
+        "the dialog must rebuild from the state it closes over:\n{refreshed}"
+    );
+}
+
 #[gpui::test]
 fn a_virtual_list_rejects_a_sparse_item_size_array_without_allocating_it(cx: &mut TestAppContext) {
     cx.update(|cx| crate::init(cx));


### PR DESCRIPTION
## Summary

An overlay's content is a function, and `open_dialog`/`open_sheet` document that "whatever it closes over is the dialog's state". In practice what it closes over is *another view's* state — these calls answer a depth, not a handle, so there is nothing for a script to notify when that state moves.

`ScriptView::render` rebuilds only when its own dirty flag is set, so an overlay materialized the description it was opened with for as long as it stayed open. A dialog that takes a symbol, looks it up and previews the answer showed "nothing typed yet" for ever — the state changed, the workspace redrew, and the dialog did not.

The root now rebuilds a script overlay whenever the root itself draws, which is what `window.refresh()` — the call whose entire documented purpose is "there is no view to notify" — reaches. Marking it dirty schedules no frame of its own: the overlay is about to render as part of this one, and it renders from the script rather than from the cache. A non-script overlay owns its own state and is left alone.

## Changes

- `crates/shell/src/root.rs` — `rebuild_script_overlay` invalidates a `ScriptView` overlay from `dialog_layer` and `sheet_layer`.
- `crates/shell/src/engine/quickjs/overlay.rs` — the module docs say which call updates an open overlay.

## Verification

- `cargo test -p gpui-shell` — 574 passed, 0 failed.
- New: `a_dialog_rebuilds_from_the_state_it_closes_over` opens a dialog over a script field, moves the field, calls `window.refresh()`, and asserts the dialog's own published description changed. It fails on `main` — the dialog still reads `dialog:pending` — and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LC39hSS7Pr4Jo8PWT2hGZJ