### PR TITLE
shell: Expose modifier change events

### DIFF
--- a/crates/shell/src/engine/quickjs/mod.rs
+++ b/crates/shell/src/engine/quickjs/mod.rs
@@ -2338,12 +2338,7 @@ impl ShellRuntime {
             let payload = Object::new(ctx.clone())?;
             payload.set("click_count", click_count)?;
 
-            let flags = Object::new(ctx.clone())?;
-            flags.set("shift", modifiers.shift)?;
-            flags.set("control", modifiers.control)?;
-            flags.set("alt", modifiers.alt)?;
-            flags.set("platform", modifiers.platform)?;
-            payload.set("modifiers", flags)?;
+            payload.set("modifiers", modifiers_object(&ctx, modifiers)?)?;
 
             handler.call::<_, ()>((
                 payload,
@@ -2644,12 +2639,7 @@ impl ShellRuntime {
             event_bounds.set("width", f32::from(bounds.size.width))?;
             event_bounds.set("height", f32::from(bounds.size.height))?;
             payload.set("bounds", event_bounds)?;
-            let modifiers = Object::new(ctx.clone())?;
-            modifiers.set("shift", event.modifiers.shift)?;
-            modifiers.set("control", event.modifiers.control)?;
-            modifiers.set("alt", event.modifiers.alt)?;
-            modifiers.set("platform", event.modifiers.platform)?;
-            payload.set("modifiers", modifiers)?;
+            payload.set("modifiers", modifiers_object(&ctx, event.modifiers)?)?;
             handler.call::<_, ()>((
                 payload,
                 context_object(ctx, ContextBinding::Call(generation))?,
@@ -2825,6 +2815,25 @@ impl ShellRuntime {
         scheduler::drain_runtime_jobs(self, window, cx);
     }
 
+    pub(crate) fn dispatch_modifiers_changed(
+        self: &Rc<Self>,
+        id: CallbackId,
+        event: &gpui::ModifiersChangedEvent,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let modifiers = event.modifiers;
+        let capslock = event.capslock;
+        self.dispatch_simple_event(id, "modifiers changed", window, cx, move |ctx| {
+            let payload = Object::new(ctx.clone())?;
+            payload.set("modifiers", modifiers_object(ctx, modifiers)?)?;
+            let capslock_object = Object::new(ctx.clone())?;
+            capslock_object.set("on", capslock.on)?;
+            payload.set("capslock", capslock_object)?;
+            Ok(payload)
+        });
+    }
+
     /// Delivers one key press or release to a script handler.
     ///
     /// `is_held` distinguishes the two events rather than a second method
@@ -2887,12 +2896,7 @@ impl ShellRuntime {
             if let Some(is_held) = is_held {
                 payload.set("is_held", is_held)?;
             }
-            let modifiers = Object::new(ctx.clone())?;
-            modifiers.set("shift", keystroke.modifiers.shift)?;
-            modifiers.set("control", keystroke.modifiers.control)?;
-            modifiers.set("alt", keystroke.modifiers.alt)?;
-            modifiers.set("platform", keystroke.modifiers.platform)?;
-            payload.set("modifiers", modifiers)?;
+            payload.set("modifiers", modifiers_object(ctx, keystroke.modifiers)?)?;
             handler.call::<_, ()>((
                 payload,
                 context_object(ctx, ContextBinding::Call(generation))?,
@@ -5020,6 +5024,7 @@ impl ShellRuntime {
                 "on_hover",
                 "on_key_down",
                 "on_key_up",
+                "on_modifiers_changed",
                 "on_mouse_down",
                 "on_mouse_up",
                 "on_mouse_down_out",
@@ -5781,6 +5786,7 @@ impl ShellRuntime {
             | "on_hover"
             | "on_key_down"
             | "on_key_up"
+            | "on_modifiers_changed"
             | "on_mouse_down_out"
             | "on_scroll_wheel"
             | "tab_bar"
@@ -6580,6 +6586,7 @@ fn modifiers_object<'js>(ctx: &Ctx<'js>, modifiers: gpui::Modifiers) -> JsResult
     object.set("control", modifiers.control)?;
     object.set("alt", modifiers.alt)?;
     object.set("platform", modifiers.platform)?;
+    object.set("function", modifiers.function)?;
     Ok(object)
 }
 
@@ -6929,6 +6936,7 @@ fn callback_op_name(method: &str) -> Option<&'static str> {
         "on_hover" => "on_hover",
         "on_key_down" => "on_key_down",
         "on_key_up" => "on_key_up",
+        "on_modifiers_changed" => "on_modifiers_changed",
         "on_mouse_down_out" => "on_mouse_down_out",
         "on_scroll_wheel" => "on_scroll_wheel",
         "on_item_click" => "on_item_click",

--- a/crates/shell/src/materialize.rs
+++ b/crates/shell/src/materialize.rs
@@ -255,6 +255,8 @@ struct Behavior {
     /// Reports the release of a key, on the same focus path as
     /// [`Behavior::on_key_down`].
     on_key_up: Option<CallbackId>,
+    /// Reports modifier-only changes on the keyboard focus path.
+    on_modifiers_changed: Option<CallbackId>,
     /// Presses on this element, one entry per button listened for.
     ///
     /// A list rather than one field, because GPUI takes the button as an
@@ -486,6 +488,7 @@ impl Behavior {
             || self.on_hover.is_some()
             || self.on_key_down.is_some()
             || self.on_key_up.is_some()
+            || self.on_modifiers_changed.is_some()
             || !self.on_mouse_down.is_empty()
             || !self.on_mouse_up.is_empty()
             || self.on_mouse_down_out.is_some()
@@ -1369,6 +1372,14 @@ where
             }
         });
     }
+    if let Some(callback) = behavior.on_modifiers_changed {
+        let runtime = Rc::downgrade(runtime);
+        element = element.on_modifiers_changed(move |event, window, cx| {
+            if let Some(runtime) = runtime.upgrade() {
+                runtime.dispatch_modifiers_changed(callback, event, window, cx);
+            }
+        });
+    }
     // The pointer half. It needs the element's box for `local_position`, and
     // captures it only when something asked.
     if behavior.wants_pointer_geometry() {
@@ -1556,6 +1567,10 @@ fn warn_unhonoured_input(component: &Component, behavior: &Behavior) {
     let asked = [
         ("on_key_down", behavior.on_key_down.is_some()),
         ("on_key_up", behavior.on_key_up.is_some()),
+        (
+            "on_modifiers_changed",
+            behavior.on_modifiers_changed.is_some(),
+        ),
         ("on_mouse_down", !behavior.on_mouse_down.is_empty()),
         ("on_mouse_up", !behavior.on_mouse_up.is_empty()),
         ("on_mouse_down_out", behavior.on_mouse_down_out.is_some()),
@@ -1678,6 +1693,7 @@ fn flex_element(
         && behavior.on_hover.is_none()
         && behavior.on_key_down.is_none()
         && behavior.on_key_up.is_none()
+        && behavior.on_modifiers_changed.is_none()
         && behavior.on_mouse_down.is_empty()
         && behavior.on_mouse_up.is_empty()
         && behavior.on_mouse_down_out.is_none()
@@ -2123,6 +2139,7 @@ pub(in crate::materialize) fn resolve_ops(
                 "on_hover" => behavior.on_hover = Some(*id),
                 "on_key_down" => behavior.on_key_down = Some(*id),
                 "on_key_up" => behavior.on_key_up = Some(*id),
+                "on_modifiers_changed" => behavior.on_modifiers_changed = Some(*id),
                 // The button is carried in the op name rather than beside it:
                 // `SpecOp::Callback` is a `&'static str` and a handle, and
                 // three fixed names cost nothing next to widening every op to

--- a/crates/shell/src/tests/render.rs
+++ b/crates/shell/src/tests/render.rs
@@ -165,7 +165,14 @@ import { View, div } from "gpui";
 import { v_flex, Button } from "gpui-base";
 
 export default class PointerRebuild extends View {
-  init() { this.moves = 0; this.clicks = 0; this.hovered = false; this.hoverEvents = 0; }
+  init() {
+    this.moves = 0;
+    this.clicks = 0;
+    this.hovered = false;
+    this.hoverEvents = 0;
+    this.moveFunction = null;
+    this.clickFunction = null;
+  }
   render(cx) {
     return v_flex()
       .w(300)
@@ -175,8 +182,9 @@ export default class PointerRebuild extends View {
           .id("plot")
           .w(300)
           .h(80)
-          .on_mouse_move((_event, cx) => {
+          .on_mouse_move((event, cx) => {
             this.moves += 1;
+            this.moveFunction = event.modifiers.function;
             cx.notify();
           })
           .on_hover((hovered, cx) => {
@@ -185,17 +193,18 @@ export default class PointerRebuild extends View {
             this.hovered = hovered;
             cx.notify();
           })
-          .child(`Moves: ${this.moves}; Hovered: ${this.hovered}; Hover events: ${this.hoverEvents}`),
+          .child(`Moves: ${this.moves}; Move function: ${this.moveFunction}; Hovered: ${this.hovered}; Hover events: ${this.hoverEvents}`),
       )
       .child(
         Button.new("after-hover")
           .w(300)
           .h(80)
-          .on_click((_event, cx) => {
+          .on_click((event, cx) => {
             this.clicks += 1;
+            this.clickFunction = event.modifiers.function;
             cx.notify();
           })
-          .child(`Clicks: ${this.clicks}`),
+          .child(`Clicks: ${this.clicks}; Click function: ${this.clickFunction}`),
       );
   }
 }
@@ -226,6 +235,7 @@ export default class PointerRebuild extends View {
     context.run_until_parked();
     context.update(|window, cx| window.draw(cx).clear(cx));
     assert!(tree(&mut context).contains("Moves: 1"));
+    assert!(tree(&mut context).contains("Move function: false"));
     assert!(tree(&mut context).contains("Hovered: true"));
     assert!(
         tree(&mut context).contains("Hover events: 1"),
@@ -244,6 +254,7 @@ export default class PointerRebuild extends View {
     context.simulate_click(point(px(20.), px(120.)), Modifiers::default());
     context.run_until_parked();
     assert!(tree(&mut context).contains("Clicks: 1"));
+    assert!(tree(&mut context).contains("Click function: false"));
 }
 
 #[gpui::test]
@@ -4849,6 +4860,93 @@ export default class Keys extends View {
     assert!(
         tree.contains("up=escape"),
         "a release must arrive on the same focus path as a press: {tree}"
+    );
+}
+
+#[gpui::test]
+fn a_script_hears_modifier_changes_at_a_focused_element(cx: &mut TestAppContext) {
+    cx.update(|cx| crate::init(cx));
+
+    let runtime = ShellRuntime::new_isolated().expect("runtime");
+    cx.update(|cx| runtime.set_global(cx));
+    let source = r#"
+import { View, div } from "gpui";
+import { v_flex } from "gpui-base";
+
+export default class Modifiers extends View {
+  init(_props, cx) {
+    this.handle = cx.focus_handle();
+    this.changes = [];
+  }
+
+  render(_cx) {
+    return v_flex()
+      .w(200)
+      .h(100)
+      .child(
+        div()
+          .id("surface")
+          .w(200)
+          .h(60)
+          .tab_index(1)
+          .track_focus(this.handle)
+          .on_modifiers_changed((event, cx) => {
+            this.changes.push([
+              event.modifiers.shift,
+              event.modifiers.control,
+              event.modifiers.alt,
+              event.modifiers.platform,
+              event.modifiers.function,
+              event.capslock.on,
+            ].join("/"));
+            cx.notify();
+          }),
+      )
+      .child(div().child(this.changes.join(" ")));
+  }
+}
+"#;
+    let view_type = runtime.load_source("modifiers", source).expect("load");
+    let runtime_for_view = Rc::clone(&runtime);
+    let window = cx.add_window(move |window, cx| {
+        let view = runtime_for_view
+            .instantiate_view(&view_type, window, cx)
+            .expect("instantiate");
+        RootedScriptView(view)
+    });
+    let mut context = VisualTestContext::from_window(*window.deref(), cx);
+    context.update(|window, cx| window.draw(cx).clear(cx));
+    let view = window
+        .root(&mut context)
+        .expect("root view")
+        .read_with(&context, |root, _| root.0.clone());
+
+    let handles = runtime.entities().focus_handles();
+    assert_eq!(handles.len(), 1, "the script created one focus handle");
+    context.update(|window, cx| handles[0].focus(window, cx));
+    context.update(|window, cx| window.draw(cx).clear(cx));
+
+    context.simulate_event(gpui::ModifiersChangedEvent {
+        modifiers: gpui::Modifiers {
+            control: true,
+            function: true,
+            ..Default::default()
+        },
+        capslock: gpui::Capslock { on: true },
+    });
+    context.simulate_event(gpui::ModifiersChangedEvent::default());
+    context.run_until_parked();
+    context.update(|window, cx| window.draw(cx).clear(cx));
+
+    let tree = context.update(|_, cx| {
+        view.read(cx)
+            .snapshot()
+            .map(crate::RenderSnapshot::debug_tree)
+            .unwrap_or_default()
+    });
+    assert!(
+        tree.contains("false/true/false/false/true/true false/false/false/false/false/false"),
+        "modifier press and release must preserve GPUI's complete event payload: {tree}"
     );
 }
 

--- a/crates/shell/src/typings.rs
+++ b/crates/shell/src/typings.rs
@@ -801,6 +801,19 @@ const CONTEXT_AND_VIEW: &str = r#"  /**
     alt: boolean;
     /** Command on macOS, Windows key elsewhere. */
     platform: boolean;
+    /** The Function key. */
+    function: boolean;
+  }
+
+  /** The Caps Lock state carried by GPUI modifier-change events. */
+  export interface Capslock {
+    on: boolean;
+  }
+
+  /** What an `on_modifiers_changed` handler receives. */
+  export interface ModifiersChangedEvent {
+    modifiers: Modifiers;
+    capslock: Capslock;
   }
 
   /** What an `on_click` handler receives. Keyboard activation counts as one. */
@@ -1101,6 +1114,10 @@ const ELEMENT_METHODS: &str = r#"    /**
     on_key_down(handler: (event: KeyEvent, cx: Context) => void): Element;
     /** GPUI `InteractiveElement::on_key_up`, on the same focus path as `on_key_down`. */
     on_key_up(handler: (event: KeyEvent, cx: Context) => void): Element;
+    /** GPUI `InteractiveElement::on_modifiers_changed`, on the keyboard focus path. */
+    on_modifiers_changed(
+      handler: (event: ModifiersChangedEvent, cx: Context) => void,
+    ): Element;
     /**
      * GPUI `InteractiveElement::on_mouse_down`, for one button.
      *
@@ -3396,6 +3413,7 @@ mod tests {
         "on_hover",
         "on_key_down",
         "on_key_up",
+        "on_modifiers_changed",
         "on_mouse_down",
         "on_mouse_up",
         "on_mouse_down_out",

--- a/docs/gpui-shell.md
+++ b/docs/gpui-shell.md
@@ -1413,9 +1413,10 @@ available to a script; the script re-derives them with `when`.
 
 ### 10.5 Input events
 
-`on_key_down`, `on_key_up`, `on_mouse_down(button, …)`, `on_mouse_up`,
-`on_mouse_down_out` and `on_scroll_wheel` are GPUI's own `InteractiveElement`
-builders, installed together by `materialize::with_input_handlers`.
+`on_key_down`, `on_key_up`, `on_modifiers_changed`,
+`on_mouse_down(button, …)`, `on_mouse_up`, `on_mouse_down_out` and
+`on_scroll_wheel` are GPUI's own `InteractiveElement` builders, installed
+together by `materialize::with_input_handlers`.
 
 ```js
 div()
@@ -1427,6 +1428,23 @@ div()
     }
   });
 ```
+
+Modifier-only presses and releases use GPUI's native event rather than a
+synthetic key event:
+
+```js
+div()
+  .track_focus(this.handle)
+  .on_modifiers_changed((event, cx) => {
+    this.primaryModifierDown = event.modifiers.control;
+    this.capslockOn = event.capslock.on;
+    cx.notify();
+  });
+```
+
+The event preserves GPUI's `ModifiersChangedEvent` shape. Its `modifiers`
+object contains `shift`, `control`, `alt`, `platform`, and `function`; its
+`capslock` object contains `on`. Like key events, it travels the focus path.
 
 **Where they are installed.** `div`, `h_flex`, `v_flex`, `Button`, `Link`,
 `Checkbox`, `Switch`, `Radio`, `Toggle`, `Tabs` and `Tab`. Every other


### PR DESCRIPTION
## Description

Expose GPUI's native `on_modifiers_changed` event to gpui-shell scripts so applications can react to modifier-only press and release transitions. The JavaScript payload preserves GPUI naming and shape, including `function` and `capslock.on`. Existing key, click, mouse-move, and pointer modifier payloads now share the complete modifier serializer.

Public typings and gpui-shell documentation are updated. The implementation and tests were AI-assisted, then reviewed against the existing shell architecture and verified with the complete shell test suite.

## How to Test

```sh
cargo test -p gpui-shell
```

Expected: 558 passed, 0 failed, 1 ignored; 12 CLI tests passed; 4 doctests passed and 2 ignored.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (if any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes (not applicable: gpui-shell event bridge has focused interaction coverage).
- [ ] Tested macOS, Windows and Linux platforms performance (not platform-specific).
