### PR TITLE
scroll: a scroll area used as a flex item can shrink again

### DIFF
--- a/crates/base/src/styled.rs
+++ b/crates/base/src/styled.rs
@@ -31,9 +31,18 @@ impl From<Option<Role>> for RoleOverride {
     }
 }
 
+/// A row that centers its children on the cross axis.
+///
+/// See [`StyledExt::h_flex`] for the cross-axis rule, which is not symmetric
+/// with [`v_flex`].
 pub fn h_flex() -> Div {
     div().h_flex()
 }
+
+/// A column whose children stretch across the cross axis.
+///
+/// See [`StyledExt::v_flex`] for the cross-axis rule, which is not symmetric
+/// with [`h_flex`].
 pub fn v_flex() -> Div {
     div().v_flex()
 }
@@ -72,10 +81,35 @@ pub trait StyledExt: Styled + Sized {
         self
     }
 
+    /// Lays children out in a row, centered on the cross axis.
+    ///
+    /// The centering is the desktop default for a row of controls — an icon
+    /// beside its label lines up without either side asking for it — but it is
+    /// **not** the mirror image of [`Self::v_flex`], which leaves the cross axis
+    /// stretching. A column placed in a row therefore does not take the row's
+    /// height: it takes its content's height and is centered inside the row.
+    /// When its content is taller than the row, it overflows equally above and
+    /// below, so the column's header is pushed off the top edge and clipped.
+    ///
+    /// Give a full-height column `h_full()` (or the row `items_start()` /
+    /// `items_stretch()`) whenever the child owns a header, a footer, or a
+    /// scroll region that has to resolve against the row's height.
+    ///
+    /// ```
+    /// use gpui_base::StyledExt as _;
+    /// use gpui::{ParentElement as _, Styled as _, div};
+    ///
+    /// // A sidebar beside a detail pane, both spanning the full height.
+    /// div().h_flex().size_full().child(div().w_64().h_full());
+    /// ```
     fn h_flex(self) -> Self {
         self.flex().flex_row().items_center()
     }
 
+    /// Lays children out in a column, stretching them across the cross axis.
+    ///
+    /// Unlike [`Self::h_flex`] this installs no cross-axis alignment, so a child
+    /// without a width fills the column. See `h_flex` for the asymmetry.
     fn v_flex(self) -> Self {
         self.flex().flex_col()
     }
@@ -178,4 +212,74 @@ pub fn styled_ext_reflection_methods<T: Styled + 'static>()
 
 fn hsl(hue: f32, saturation: f32, lightness: f32) -> Hsla {
     hsla(hue / 360., saturation / 100., lightness / 100., 1.)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{
+        Context, InteractiveElement as _, IntoElement, ParentElement as _, Render, TestAppContext,
+        px,
+    };
+
+    fn column(selector: &'static str, height: f32) -> Div {
+        div()
+            .w(px(20.))
+            .h(px(height))
+            .flex_shrink_0()
+            .debug_selector(move || selector.to_string())
+    }
+
+    struct CrossAxisTest;
+
+    impl Render for CrossAxisTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .w(px(200.))
+                .h(px(100.))
+                .child(
+                    h_flex()
+                        .size_full()
+                        .child(column("row-child", 40.))
+                        .child(column("row-overflowing-child", 140.))
+                        .child(
+                            div()
+                                .w(px(20.))
+                                .debug_selector(|| "row-stretch".to_string()),
+                        ),
+                )
+                .child(
+                    v_flex().size_full().child(
+                        div()
+                            .h(px(20.))
+                            .debug_selector(|| "col-stretch".to_string()),
+                    ),
+                )
+        }
+    }
+
+    /// `h_flex` centers on the cross axis while `v_flex` leaves the default
+    /// stretch. The asymmetry is deliberate but easy to trip over, so lock it.
+    #[gpui::test]
+    fn h_flex_centers_and_v_flex_stretches_on_the_cross_axis(cx: &mut TestAppContext) {
+        let (_, cx) = cx.add_window_view(|_, _| CrossAxisTest);
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        // A shorter child of a 100px row sits at (100 - 40) / 2, not at the top,
+        // and a height-less child keeps its content height instead of filling.
+        let child = cx.debug_bounds("row-child").unwrap();
+        assert_eq!(child.top(), px(30.));
+        assert_eq!(cx.debug_bounds("row-stretch").unwrap().size.height, px(0.));
+
+        // And a child taller than the row is centered too, so its top — a
+        // column's header, in a real layout — is pushed off the top edge.
+        let overflowing = cx.debug_bounds("row-overflowing-child").unwrap();
+        assert_eq!(overflowing.top(), px(-20.));
+
+        // A width-less child of a column does fill the cross axis.
+        assert_eq!(cx.debug_bounds("col-stretch").unwrap().size.width, px(200.));
+    }
 }

--- a/crates/shell/src/scroll.rs
+++ b/crates/shell/src/scroll.rs
@@ -12,9 +12,9 @@
 use std::panic::Location;
 
 use gpui::{
-    App, Div, Element, ElementId, InteractiveElement, IntoElement, ParentElement, RenderOnce,
-    ScrollHandle, StatefulInteractiveElement, StyleRefinement, Styled, Window, div,
-    prelude::FluentBuilder,
+    App, Div, Element, ElementId, InteractiveElement, IntoElement, Overflow, ParentElement,
+    PointRefinement, RenderOnce, ScrollHandle, StatefulInteractiveElement, StyleRefinement, Styled,
+    Window, div, prelude::FluentBuilder,
 };
 use gpui_base::{InteractiveElementExt as _, Scrollbar, ScrollbarAxis, StyledExt as _};
 
@@ -85,7 +85,7 @@ where
 
         // Preserve the caller-requested size on the wrapper, while keeping the
         // caller's element as the actual scroll-tracked layout container.
-        let root_style = root_style_from(&mut self.element);
+        let root_style = root_style_from(&mut self.element, self.axis);
 
         let root_id = self.id.clone();
         let area_id = (self.id.clone(), "area");
@@ -153,8 +153,15 @@ fn scroll_handle_for(id: &ElementId, window: &mut Window, cx: &mut App) -> Scrol
 
 /// Copies the outer layout styles from the element, so the wrapper can
 /// participate in the parent's layout the same way the source element would.
+///
+/// The scrolled axis is marked clipped here for the same reason as in
+/// `gpui_component::scroll::scrollable`: a flex item only drops its
+/// content-based automatic minimum size when its own overflow is not
+/// [`Overflow::Visible`], and the scrolled overflow lives on the inner scroll
+/// area. Without it a scroll region used as a flex item pushes its siblings out
+/// of the container instead of scrolling.
 #[inline]
-fn root_style_from<E>(element: &mut E) -> StyleRefinement
+fn root_style_from<E>(element: &mut E, axis: ScrollbarAxis) -> StyleRefinement
 where
     E: Styled,
 {
@@ -167,6 +174,10 @@ where
         flex_shrink: style.flex_shrink,
         flex_basis: style.flex_basis,
         align_self: style.align_self,
+        overflow: PointRefinement {
+            x: axis.has_horizontal().then_some(Overflow::Hidden),
+            y: axis.has_vertical().then_some(Overflow::Hidden),
+        },
         ..Default::default()
     }
 }
@@ -196,4 +207,56 @@ fn render_scrollbar(
                 .axis(axis)
                 .viewport_from_layout(),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{Context, Render, TestAppContext, VisualTestContext, px};
+
+    struct FlexItemScrollableTest;
+
+    impl Render for FlexItemScrollableTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            // A fixed-height column of header, flexible scroll area, footer.
+            // The content is far taller than the room left for the area, so
+            // the area must shrink into the remaining 60px and scroll.
+            gpui_base::v_flex()
+                .w(px(100.))
+                .h(px(100.))
+                .child(
+                    div()
+                        .h(px(20.))
+                        .flex_shrink_0()
+                        .debug_selector(|| "shell-header".to_string()),
+                )
+                .child(Scrollable::new(
+                    gpui_base::v_flex()
+                        .flex_1()
+                        .children((0..6).map(|_| div().h(px(50.)).flex_shrink_0())),
+                    ScrollbarAxis::Vertical,
+                ))
+                .child(
+                    div()
+                        .h(px(20.))
+                        .flex_shrink_0()
+                        .debug_selector(|| "shell-footer".to_string()),
+                )
+        }
+    }
+
+    #[gpui::test]
+    fn scrollable_flex_item_shrinks_below_its_content(cx: &mut TestAppContext) {
+        let (_, cx) = cx.add_window_view(|_, _| FlexItemScrollableTest);
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            _ = window.draw(cx);
+        });
+
+        // Header and footer stay inside the 100px column, so the area took the
+        // 60px left over instead of its content height.
+        assert_eq!(cx.debug_bounds("shell-header").unwrap().top(), px(0.));
+        assert_eq!(cx.debug_bounds("shell-footer").unwrap().top(), px(80.));
+    }
 }

--- a/crates/ui/src/scroll/scrollable.rs
+++ b/crates/ui/src/scroll/scrollable.rs
@@ -4,9 +4,9 @@ use crate::{InteractiveElementExt as _, StyledExt};
 
 use super::{Scrollbar, ScrollbarAxis, ScrollbarHandle};
 use gpui::{
-    App, Div, Element, ElementId, InteractiveElement, IntoElement, ParentElement, RenderOnce,
-    ScrollHandle, Stateful, StatefulInteractiveElement, StyleRefinement, Styled, Window, div,
-    prelude::FluentBuilder,
+    App, Div, Element, ElementId, InteractiveElement, IntoElement, Overflow, ParentElement,
+    PointRefinement, RenderOnce, ScrollHandle, Stateful, StatefulInteractiveElement,
+    StyleRefinement, Styled, Window, div, prelude::FluentBuilder,
 };
 
 /// A trait for elements that can be made scrollable with scrollbars.
@@ -129,7 +129,7 @@ where
 
         // Preserve the caller-requested size on the wrapper, while keeping the
         // caller's element as the actual scroll-tracked layout container.
-        let root_style = root_style_from(&mut self.element);
+        let root_style = root_style_from(&mut self.element, self.axis);
 
         let root_id = self.id.clone();
         let area_id = (self.id.clone(), "area");
@@ -221,8 +221,22 @@ fn scroll_handle_for(id: &ElementId, window: &mut Window, cx: &mut App) -> Scrol
 
 /// Copies the outer layout styles from the element, so the wrapper can
 /// participate in the parent's layout the same way the source element would.
+///
+/// A flex item only drops its content-based automatic minimum size when its own
+/// overflow is not [`Overflow::Visible`]; otherwise the item refuses to shrink
+/// around its content. The scrolled overflow lives on the inner scroll area, so
+/// the wrapper has to declare the scrolled axis clipped itself — without it a
+/// scroll region used as a flex item pushes its siblings out of the container
+/// instead of scrolling, and every call site has to remember `min_h_0()` /
+/// `min_w_0()`.
+///
+/// [`Overflow::Hidden`] rather than a zero minimum: it is the axis' real
+/// behavior, it leaves an explicit `min_size` from the caller in charge, and it
+/// keeps the region's content size contributing to an auto-sized ancestor such
+/// as a Dialog that grows with its body. The mask it installs matches the inner
+/// scroll area's own mask, so nothing new is clipped.
 #[inline]
-fn root_style_from<E>(element: &mut E) -> StyleRefinement
+fn root_style_from<E>(element: &mut E, axis: ScrollbarAxis) -> StyleRefinement
 where
     E: Styled,
 {
@@ -235,6 +249,10 @@ where
         flex_shrink: style.flex_shrink,
         flex_basis: style.flex_basis,
         align_self: style.align_self,
+        overflow: PointRefinement {
+            x: axis.has_horizontal().then_some(Overflow::Hidden),
+            y: axis.has_vertical().then_some(Overflow::Hidden),
+        },
         ..Default::default()
     }
 }
@@ -413,6 +431,151 @@ mod tests {
         let last_initial_y = cx.debug_bounds("max-height-last-row").unwrap().origin.y;
         scroll(cx, 10., 10., 0., -50.);
         assert!(cx.debug_bounds("max-height-last-row").unwrap().origin.y < last_initial_y);
+    }
+
+    struct FlexItemScrollableTest;
+
+    impl Render for FlexItemScrollableTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            // A fixed-height column of header, flexible scroll area, footer.
+            // The content is far taller than the room left for the area, so
+            // the area must shrink into the remaining 60px and scroll.
+            crate::v_flex()
+                .w(px(100.))
+                .h(px(100.))
+                .child(row("flex-item-header", 20.))
+                .child(
+                    crate::v_flex()
+                        .flex_1()
+                        .overflow_y_scrollbar()
+                        .children((0..6).map(|ix| {
+                            div().h(px(50.)).flex_shrink_0().when(ix == 0, |this| {
+                                this.debug_selector(|| "flex-item-first-row".to_string())
+                            })
+                        })),
+                )
+                .child(row("flex-item-footer", 20.))
+        }
+    }
+
+    #[gpui::test]
+    fn scrollable_flex_item_shrinks_below_its_content(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| FlexItemScrollableTest);
+        let cx: &mut VisualTestContext = cx;
+        draw(cx);
+
+        // Header and footer stay inside the 100px column, so the area took
+        // the 60px left over instead of its content height.
+        assert_eq!(cx.debug_bounds("flex-item-header").unwrap().top(), px(0.));
+        assert_eq!(cx.debug_bounds("flex-item-footer").unwrap().top(), px(80.));
+
+        // And the shrunken area really scrolls.
+        let initial_y = cx.debug_bounds("flex-item-first-row").unwrap().origin.y;
+        scroll(cx, 10., 50., 0., -50.);
+        assert!(cx.debug_bounds("flex-item-first-row").unwrap().origin.y < initial_y);
+    }
+
+    struct HorizontalFlexItemScrollableTest;
+
+    impl Render for HorizontalFlexItemScrollableTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            crate::h_flex()
+                .w(px(100.))
+                .h(px(40.))
+                .child(item("horizontal-flex-item-leading", 20.))
+                .child(
+                    crate::h_flex()
+                        .flex_1()
+                        .overflow_x_scrollbar()
+                        .children((0..6).map(|ix| {
+                            div()
+                                .w(px(50.))
+                                .h(px(20.))
+                                .flex_shrink_0()
+                                .when(ix == 0, |this| {
+                                    this.debug_selector(|| {
+                                        "horizontal-flex-item-first-item".to_string()
+                                    })
+                                })
+                        })),
+                )
+                .child(item("horizontal-flex-item-trailing", 20.))
+        }
+    }
+
+    #[gpui::test]
+    fn horizontal_scrollable_flex_item_shrinks_below_its_content(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| HorizontalFlexItemScrollableTest);
+        let cx: &mut VisualTestContext = cx;
+        draw(cx);
+
+        assert_eq!(
+            cx.debug_bounds("horizontal-flex-item-leading")
+                .unwrap()
+                .left(),
+            px(0.)
+        );
+        assert_eq!(
+            cx.debug_bounds("horizontal-flex-item-trailing")
+                .unwrap()
+                .left(),
+            px(80.)
+        );
+
+        let initial_x = cx
+            .debug_bounds("horizontal-flex-item-first-item")
+            .unwrap()
+            .origin
+            .x;
+        scroll(cx, 50., 10., -50., 0.);
+        assert!(
+            cx.debug_bounds("horizontal-flex-item-first-item")
+                .unwrap()
+                .origin
+                .x
+                < initial_x
+        );
+    }
+
+    struct ExplicitMinHeightScrollableTest;
+
+    impl Render for ExplicitMinHeightScrollableTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            // An explicit `min_h` is the caller's decision and must survive.
+            crate::v_flex()
+                .w(px(100.))
+                .h(px(100.))
+                .child(row("explicit-min-header", 20.))
+                .child(
+                    crate::v_flex()
+                        .flex_1()
+                        .min_h(px(70.))
+                        .overflow_y_scrollbar()
+                        .children((0..6).map(|_| plain_row(50.))),
+                )
+                .child(row("explicit-min-footer", 20.))
+        }
+    }
+
+    #[gpui::test]
+    fn explicit_min_size_survives_the_scrollable_wrapper(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let (_, cx) = cx.add_window_view(|_, _| ExplicitMinHeightScrollableTest);
+        let cx: &mut VisualTestContext = cx;
+        draw(cx);
+
+        // The area cannot shrink past the requested 70px, so the footer is
+        // pushed to 20 + 70 instead of being clamped into the column.
+        assert_eq!(
+            cx.debug_bounds("explicit-min-header").unwrap().top(),
+            px(0.)
+        );
+        assert_eq!(
+            cx.debug_bounds("explicit-min-footer").unwrap().top(),
+            px(90.)
+        );
     }
 
     struct GapLayoutTest;

--- a/skills/gpui-component/references/coding-guides.md
+++ b/skills/gpui-component/references/coding-guides.md
@@ -535,10 +535,22 @@ measured correction as a raw `px(...)` nudge. Trace the mismatch to duplicated
 padding, nested insets, border ownership, font metrics, or rounding, then fix
 the structural owner.
 
+`h_flex()` and `v_flex()` are not mirror images: `h_flex()` centers its
+children on the cross axis, `v_flex()` leaves them stretching. A column placed
+in a row therefore takes its content's height, not the row's, and a column
+taller than the row is centered — its header is pushed off the top edge and
+clipped. Give a full-height column `h_full()`, or give the row `items_start()`
+or `items_stretch()`, whenever the child owns a header, a footer, or a scroll
+region that must resolve against the row's height.
+
 Every scrollable region must have one owner. In flex layouts, apply
 `min_w_0()` or `min_h_0()` to the flexible child that is allowed to shrink.
-Avoid accidental nested scrolling; route wheel input to the intended axis and
-preserve platform/wasm differences when an API is not portable.
+A flex item only drops its content-based automatic minimum size when its own
+overflow is not visible, so an ordinary flexible child refuses to shrink around
+long content until you say so. `Scrollable` handles this for its own wrapper,
+but a plain `div` between it and the flex container still needs the minimum
+released. Avoid accidental nested scrolling; route wheel input to the intended
+axis and preserve platform/wasm differences when an API is not portable.
 
 Attach `Scrollable` to the element that owns the full panel, editor, or window
 viewport so its scrollbar resolves against the region edge. Put content inset

--- a/website/docs/coding-guides.md
+++ b/website/docs/coding-guides.md
@@ -535,10 +535,22 @@ measured correction as a raw `px(...)` nudge. Trace the mismatch to duplicated
 padding, nested insets, border ownership, font metrics, or rounding, then fix
 the structural owner.
 
+`h_flex()` and `v_flex()` are not mirror images: `h_flex()` centers its
+children on the cross axis, `v_flex()` leaves them stretching. A column placed
+in a row therefore takes its content's height, not the row's, and a column
+taller than the row is centered — its header is pushed off the top edge and
+clipped. Give a full-height column `h_full()`, or give the row `items_start()`
+or `items_stretch()`, whenever the child owns a header, a footer, or a scroll
+region that must resolve against the row's height.
+
 Every scrollable region must have one owner. In flex layouts, apply
 `min_w_0()` or `min_h_0()` to the flexible child that is allowed to shrink.
-Avoid accidental nested scrolling; route wheel input to the intended axis and
-preserve platform/wasm differences when an API is not portable.
+A flex item only drops its content-based automatic minimum size when its own
+overflow is not visible, so an ordinary flexible child refuses to shrink around
+long content until you say so. `Scrollable` handles this for its own wrapper,
+but a plain `div` between it and the flex container still needs the minimum
+released. Avoid accidental nested scrolling; route wheel input to the intended
+axis and preserve platform/wasm differences when an API is not portable.
 
 Attach `Scrollable` to the element that owns the full panel, editor, or window
 viewport so its scrollbar resolves against the region edge. Put content inset

--- a/website/zh-CN/docs/coding-guides.md
+++ b/website/zh-CN/docs/coding-guides.md
@@ -336,7 +336,9 @@ Alignment invariant 应通过构造保证，而不是事后校正：sibling regi
 
 精度评审要测量 resolved result，但不能把测得的差值写成 raw `px(...)` 微调。应继续追踪到重复 padding、nested inset、border ownership、font metric 或 rounding，并修复结构 owner。
 
-每个 scrollable region 只有一个 owner。Flex layout 中，可收缩 child 使用 `min_w_0()` /`min_h_0()`。避免意外 nested scroll；wheel input 应进入目标 axis，并在 API 不可移植时保留 platform/wasm 差异。
+`h_flex()` 与 `v_flex()` 并不对称：`h_flex()` 会把 child 在 cross axis 上居中，`v_flex()` 则保持拉伸。因此 row 里的 column 拿到的是自身内容高度，而不是 row 的高度；内容比 row 高时会被居中，header 被挤出上边缘并裁掉。只要 child 拥有 header、footer 或需要按 row 高度解析的 scroll region，就给这个 column 加 `h_full()`，或给 row 加 `items_start()` / `items_stretch()`。
+
+每个 scrollable region 只有一个 owner。Flex layout 中，可收缩 child 使用 `min_w_0()` /`min_h_0()`。Flex item 只有在自身 overflow 不是 visible 时才会放弃基于内容的 automatic minimum size，所以普通的可伸缩 child 在被明确要求之前不会围绕长内容收缩。`Scrollable` 已经为自己的 wrapper 处理了这一点，但夹在它与 flex container 之间的普通 `div` 仍需自行释放该最小值。避免意外 nested scroll；wheel input 应进入目标 axis，并在 API 不可移植时保留 platform/wasm 差异。
 
 `Scrollable` 应附着在拥有完整面板、编辑器或窗口 viewport 的 element 上，使滚动条解析到区域边缘。内容内边距放在 scroll owner 内部，不能用带内边距的容器包住 scroll owner。滚动条悬在内容与面板边界中间，通常说明 scroll owner 错误或内边距放错了层。
 


### PR DESCRIPTION
## Description

Two symptoms that look unrelated and are hard to attribute: a column inside a
row loses its header off the top of the window, and a scroll area refuses to
shrink — its siblings get pushed out of the container instead. They have two
independent causes. **This PR fixes the second one** and documents the first.

### The rule behind both

Flexbox gives an item an *automatic minimum size* based on its content, so a
flexible child does not shrink around long content by default. The escape hatch
is the item's own overflow. GPUI states it in the `Overflow` docs
(`crates/gpui/src/style.rs`):

> The automatic minimum size Flexbox/CSS Grid items with non-`Visible` overflow
> is `0` rather than being content based

### Cause 1 — `h_flex()` centers on the cross axis (documented, not changed)

```rust
fn h_flex(self) -> Self { self.flex().flex_row().items_center() }
fn v_flex(self) -> Self { self.flex().flex_col() }
```

`h_flex` sets `align-items: center`; `v_flex` leaves the default `stretch`.
Nothing in the names says so, and the two are not mirror images. A column placed
in a row therefore takes its *content's* height, not the row's — and when that
content is taller than the row it is centered, so its top overflows above the
viewport and is clipped. Verified: in a 100px row, a 140px child lands at
`y = -20`.

Changing `h_flex` would re-lay-out every row in the library and every downstream
consumer (364 `h_flex()` call sites in this repo alone), for a symptom whose fix
at each real call site is one `h_full()`. So this PR **documents** the asymmetry
— on `h_flex`/`v_flex` themselves and in the coding guides — and locks it with a
test. Changing the default would be a separate proposal with its own visual
review.

### Cause 2 — `Scrollable` dropped `overflow` from the flex item (fixed)

`overflow_*_scrollbar()` wraps the caller's element: the node that actually
sits in the parent's flex layout is a new outer `div`, and the scrolled
overflow ends up on an inner node. `root_style_from` hoisted the caller's
sizing onto that wrapper but not its overflow, and the wrapper never set any —
so the wrapper stayed `Overflow::Visible`, the rule above never fired, and the
scroll region kept a content-based minimum. Every caller had to remember
`min_h_0()` / `min_w_0()`, and nothing said so.

The wrapper now declares the scrolled axis clipped. `Overflow::Hidden` rather
than a zero `min_size`, deliberately:

- an explicit `min_size` from the caller still wins;
- the region's content size still contributes to an auto-sized ancestor — a
  Dialog that grows with its body keeps working, which a zero `min_size` breaks
  (`auto_height_parent_gets_content_height` fails with a styled minimum and
  passes with `Hidden`);
- `Overflow::Scroll` would make GPUI install a second scroll offset and wheel
  listener on the wrapper, double-scrolling the region;
- the mask `Hidden` installs is the same rect as the inner scroll area's own
  mask, so nothing new is clipped.

`crates/shell` keeps its own copy of the wrapper for the script runtime — that
is the copy behind the `js_story` reproduction — and had the identical bug. Both
are fixed and both are covered. The `min_h_0()` calls now in `js_story` are no
longer required; they are left alone rather than churned here.

## Verification

- New tests, each confirmed failing before the fix (footer at 120px instead of
  80px) and passing after: a scroll region as a flex item shrinks and scrolls on
  the vertical axis and on the horizontal axis, an explicit `min_size` survives
  the wrapper, and the same shrink case for the `crates/shell` copy.
- A test locking the `h_flex`/`v_flex` cross-axis contract, including the
  negative top offset that is the reported symptom.
- The existing `Scrollable` suite still passes unchanged — auto-height parent,
  `max_h` clamping, gap preservation, padded scrollbar overlay, both axes,
  independent scroll state.
- `cargo build`, `cargo clippy --workspace --all-targets -- -D warnings`,
  `cargo fmt --check`, `typos`, `cargo test --workspace` (2047 passed, 0
  failed), `cargo test -p gpui-base --doc`.
- `cargo run` (Story gallery) and `gpui-component-shell examples/js_story` both
  launch and run clean. I could **not** capture before/after screenshots — the
  compositor's screencopy is wedged on this machine and every `grim` invocation
  times out — so the visual claim rests on the layout tests, not on my eyes.

No public API of `crates/ui` changes: `root_style_from` is private.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

The code, tests, and this description were AI-generated (Claude Opus 5) and
reviewed by a person.

https://claude.ai/code/session_016st77RNyz7Sgyo2CiPo3Xf
