### PR TITLE
plot: Deduplicate the ScaleBand domain

### DIFF
--- a/crates/ui/src/plot/scale/band.rs
+++ b/crates/ui/src/plot/scale/band.rs
@@ -15,7 +15,19 @@ pub struct ScaleBand<T> {
 }
 
 impl<T> ScaleBand<T> {
-    pub fn new(domain: Vec<T>, range: Vec<f32>) -> Self {
+    pub fn new(domain: Vec<T>, range: Vec<f32>) -> Self
+    where
+        T: PartialEq,
+    {
+        // Keep the first occurrence of each value, matching D3's scaleBand.
+        let mut unique = Vec::with_capacity(domain.len());
+        for value in domain {
+            if !unique.contains(&value) {
+                unique.push(value);
+            }
+        }
+        let domain = unique;
+
         let len = domain.len() as f32;
         let range_diff = range
             .iter()
@@ -107,6 +119,17 @@ mod tests {
     #[test]
     fn test_scale_band() {
         let scale = ScaleBand::new(vec![1, 2, 3], vec![0., 90.]);
+        assert_eq!(scale.tick(&1), Some(0.));
+        assert_eq!(scale.tick(&2), Some(30.));
+        assert_eq!(scale.tick(&3), Some(60.));
+        assert_eq!(scale.band_width(), 30.);
+    }
+
+    #[test]
+    fn test_scale_band_dedup() {
+        // Simulates grouped bar chart: 2 series × 3 categories = 6 entries, 3 unique.
+        let scale = ScaleBand::new(vec![1, 2, 3, 1, 2, 3], vec![0., 90.]);
+        assert_eq!(scale.domain.len(), 3);
         assert_eq!(scale.tick(&1), Some(0.));
         assert_eq!(scale.tick(&2), Some(30.));
         assert_eq!(scale.tick(&3), Some(60.));


### PR DESCRIPTION
## Description

`ScaleBand::new` keeps duplicate domain values, which makes the bands too narrow
and bunches them into part of the range.

`band.rs` references https://d3js.org/d3-scale/band, and D3's `scaleBand` dedupes
its domain, so this looks like an oversight rather than a deliberate difference.

A grouped bar chart passes one entry per data point, so 2 series across 3
categories arrives as 6 entries with 3 unique values:

```rust
let scale = ScaleBand::new(vec![1, 2, 3, 1, 2, 3], vec![0., 90.]);
```

Two things go wrong. `avg_width = range_diff / len` divides by 6 instead of 3,
so bands are half width. And because `tick()` looks a value up with `position()`
— first match — the duplicate slots at indices 3–5 are never addressable, so the
bars sit in `0..45` of a `0..90` range and the right half is empty.

This dedupes in `new`, keeping insertion order so category order still follows
the caller's data.

## Screenshot

Not a visual change on its own — this is the scale arithmetic behind it, for the
domain above:

| Before | After |
| ------ | ----- |
| `domain.len()` 6, `band_width()` 15, ticks at 0 / 15 / 30 (bars fill `0..45` of `0..90`) | `domain.len()` 3, `band_width()` 30, ticks at 0 / 30 / 60 (bars fill `0..90`) |

## Break Changes

- `ScaleBand::new` gains a `T: PartialEq` bound.

```diff
-    pub fn new(domain: Vec<T>, range: Vec<f32>) -> Self {
+    pub fn new(domain: Vec<T>, range: Vec<f32>) -> Self
+    where
+        T: PartialEq,
+    {
```

In practice this requires nothing new: `impl Scale<T> for ScaleBand<T>` is
already `where T: PartialEq`, so a `ScaleBand` whose `T` isn't `PartialEq` can be
constructed but has no `tick()` and can't be used as a scale.

I kept the bound at `PartialEq` to match what `Scale` already asks for, and wrote
the dedupe as a plain loop rather than reaching for anything clever. `band.rs`
already imports `Itertools`, so `domain.into_iter().unique().collect()` is a
one-line alternative if you'd rather — it costs `T: Clone + Eq + Hash` instead.
Happy to switch, or to just document that callers pre-dedupe.

## How to Test

Adds `test_scale_band_dedup` alongside the existing band tests:

```bash
cargo test -p gpui-component --lib plot::scale::band
```

I also ran the checks from CI against this branch, all clean:

```bash
cargo test -p gpui-component --lib          # 479 passed
cargo clippy -p gpui-component -- --deny warnings
cargo check -p gpui-component --no-default-features
```

Also ran the story app on the chart story and confirmed it renders unchanged:

```bash
cargo run -- chart
```

`ScaleBand` has five callers — `chart/bar_chart.rs`, `chart/candlestick_chart.rs`,
and three in `story/.../chart_story/stacked_bar_chart.rs`. All build their domain
as one entry per data point, and the story's data is one record per date with the
series as fields, so those domains are already unique and this change is a no-op
for them. The charts look identical before and after; only a genuinely repeating
domain changes behaviour.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific) — not platform-specific; this is scale arithmetic with no rendering or platform code involved.

---

Written with AI assistance. I reviewed and tested it, checked the behaviour
against the current implementation, and confirmed the `tick()` / `position()`
reasoning and the existing `PartialEq` bound by reading the surrounding code.
