### PR TITLE
shell: support Git-backed dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2840,6 +2840,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3668,6 +3678,7 @@ dependencies = [
  "async-channel",
  "cap-std",
  "chrono",
+ "fs2",
  "gpui",
  "gpui-base",
  "gpui-fps",
@@ -3684,9 +3695,11 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "smallvec",
  "tracing",
  "tungstenite",
+ "wait-timeout",
  "windows 0.58.0",
  "zed-reqwest 0.12.15-zed (git+https://github.com/zed-industries/reqwest.git?rev=c15662463bda39148ba154100dd44d3fba5873a4)",
 ]

--- a/crates/shell/Cargo.toml
+++ b/crates/shell/Cargo.toml
@@ -57,6 +57,9 @@ llrt_zlib = { git = "https://github.com/awslabs/llrt", rev = "7b95c82a9b15e7ddfb
 chrono = "0.4.38"
 cap-std = "4.0.3"
 async-channel = "2.5"
+fs2 = "0.4"
+sha2 = "0.10"
+wait-timeout = "0.2"
 reqwest = { workspace = true, features = ["blocking"], optional = true }
 tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots", "url"], optional = true }
 

--- a/crates/shell/README.md
+++ b/crates/shell/README.md
@@ -304,10 +304,7 @@ grant the CLI installs in `gpui-shell.json`:
   "shell-version": "0.1.0",
   "entry": "main.js",
   "dependencies": {
-    "omarchy-ui": {
-      "git": "https://github.com/example/omarchy-ui.git",
-      "tag": "v1.2.0"
-    }
+    "omarchy-ui": "huacnlee/omarchy-ui"
   },
   "capabilities": {
     "fs": { "read": ["${pluginDir}"], "write": ["${dataDir}"] },
@@ -327,23 +324,49 @@ grant the CLI installs in `gpui-shell.json`:
 }
 ```
 
-Git dependencies are fetched before the entry module is evaluated and cached in
-`~/.gpui-shell/cache/dependencies/`. No `node_modules` directory participates.
-Import the map key as a bare module:
+Git dependencies are fetched before the entry module is evaluated. Import the
+map key as a bare module:
 
 ```js
 import { label, style } from "omarchy-ui";
 ```
 
-Each dependency selects exactly one `tag` or `branch`. A branch is fetched on
-every application load so a restart sees its current remote head; a tag is
-resolved to its tagged commit. Downloads are non-interactive and bounded to 30
-seconds per Git command. A locked local mirror feeds immutable, commit-addressed
-checkouts, so concurrent launches and older hot-reload generations cannot
-rewrite one another. The repository root must contain `index.js`, or
-the dependency may declare a repository-relative `entry`. Relative imports
-inside the package stay confined to that package checkout. Fetching requires
-`git` on the host and happens before script capabilities apply.
+A string value may be strict GitHub shorthand (`"owner/repository"` or
+`"owner/repository#ref"`) or a full Git URL
+(`"https://github.com/owner/repository#ref"`). GitHub shorthand without a
+fragment selects `main`; a full URL without one selects the remote's HEAD. A
+fragment may name a branch, tag, or commit-ish such as a commit ID. Moving
+references are fetched on every application load, while a commit ID keeps
+selecting the same commit.
+
+For string dependencies, gpui-shell reads the root `package.json` after the
+immutable checkout is ready. A string `main` selects the package entry; a
+missing file or missing `main` defaults to `index.js`. Malformed metadata, a
+non-string `main`, or an entry that is missing, not a file, or escapes the
+checkout fails the application load before its JavaScript entry executes.
+
+The legacy object form remains supported without changes. It requires exactly
+one explicit `branch` or `tag`, and its repository-relative `entry` still
+defaults to `index.js`:
+
+```json
+{
+  "omarchy-ui": {
+    "git": "https://github.com/huacnlee/omarchy-ui",
+    "tag": "v1.2.0",
+    "entry": "src/public.js"
+  }
+}
+```
+
+Dependencies live below `~/.gpui-shell/cache/dependencies/`. A per-remote lock
+serializes updates to the local mirror; immutable commit-addressed checkouts
+keep concurrent launches and older hot-reload generations isolated. The exact
+fragment-free URL is the cache and remote identity. Its raw configured origin
+is verified even when Git's `url.*.insteadOf` changes the effective fetch URL.
+Git commands are non-interactive and bounded to 30 seconds. Relative imports
+inside a package remain confined to its checkout. Fetching requires `git` on
+the host and happens before script capabilities apply.
 
 `network.hosts` grants the host to HTTP, raw TCP, and WebSocket clients;
 `network.http` narrows HTTP to a scheme, effective port, listed methods and

--- a/crates/shell/README.md
+++ b/crates/shell/README.md
@@ -303,6 +303,12 @@ grant the CLI installs in `gpui-shell.json`:
   "version": "1.0.0",
   "shell-version": "0.1.0",
   "entry": "main.js",
+  "dependencies": {
+    "omarchy-ui": {
+      "git": "https://github.com/example/omarchy-ui.git",
+      "tag": "v1.2.0"
+    }
+  },
   "capabilities": {
     "fs": { "read": ["${pluginDir}"], "write": ["${dataDir}"] },
     "network": {
@@ -320,6 +326,23 @@ grant the CLI installs in `gpui-shell.json`:
   }
 }
 ```
+
+Git dependencies are fetched before the entry module is evaluated and cached
+under the user's gpui-shell data directory. Import the map key as a bare module:
+
+```js
+import { label, style } from "omarchy-ui";
+```
+
+Each dependency selects exactly one `tag` or `branch`. A branch is fetched on
+every application load so a restart sees its current remote head; a tag is
+resolved to its tagged commit. Downloads are non-interactive and bounded to 30
+seconds per Git command. A locked local mirror feeds immutable, commit-addressed
+checkouts, so concurrent launches and older hot-reload generations cannot
+rewrite one another. The repository root must contain `index.js`, or
+the dependency may declare a repository-relative `entry`. Relative imports
+inside the package stay confined to that package checkout. Fetching requires
+`git` on the host and happens before script capabilities apply.
 
 `network.hosts` grants the host to HTTP, raw TCP, and WebSocket clients;
 `network.http` narrows HTTP to a scheme, effective port, listed methods and

--- a/crates/shell/README.md
+++ b/crates/shell/README.md
@@ -327,8 +327,9 @@ grant the CLI installs in `gpui-shell.json`:
 }
 ```
 
-Git dependencies are fetched before the entry module is evaluated and cached
-under the user's gpui-shell data directory. Import the map key as a bare module:
+Git dependencies are fetched before the entry module is evaluated and cached in
+`~/.gpui-shell/cache/dependencies/`. No `node_modules` directory participates.
+Import the map key as a bare module:
 
 ```js
 import { label, style } from "omarchy-ui";

--- a/crates/shell/src/dependencies.rs
+++ b/crates/shell/src/dependencies.rs
@@ -26,12 +26,11 @@ pub(crate) struct MaterializedDependency {
 
 impl GitDependencyStore {
     pub(crate) fn for_user() -> Self {
-        Self::new(
-            crate::runtime::data_home()
-                .join("gpui-shell")
-                .join("dependencies")
-                .join("git"),
-        )
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from)
+            .unwrap_or_else(std::env::temp_dir);
+        Self::new(dependency_cache_root(&home))
     }
 
     pub(crate) fn new(root: PathBuf) -> Self {
@@ -163,6 +162,10 @@ impl GitDependencyStore {
     }
 }
 
+fn dependency_cache_root(home: &Path) -> PathBuf {
+    home.join(".gpui-shell").join("cache").join("dependencies")
+}
+
 const GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const LOCK_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
@@ -267,7 +270,7 @@ impl Drop for CacheLock {
 
 #[cfg(test)]
 mod tests {
-    use super::GitDependencyStore;
+    use super::{GitDependencyStore, dependency_cache_root};
     use crate::plugin::PluginManifest;
     use std::{
         path::{Path, PathBuf},
@@ -279,6 +282,14 @@ mod tests {
     };
 
     static NEXT: AtomicU64 = AtomicU64::new(1);
+
+    #[test]
+    fn a_user_dependency_cache_lives_in_the_shell_cache() {
+        assert_eq!(
+            dependency_cache_root(Path::new("/home/example")),
+            PathBuf::from("/home/example/.gpui-shell/cache/dependencies")
+        );
+    }
 
     struct GitFixture {
         root: PathBuf,

--- a/crates/shell/src/dependencies.rs
+++ b/crates/shell/src/dependencies.rs
@@ -92,14 +92,11 @@ impl GitDependencyStore {
             }
         }
 
-        let mut origin = git_command();
-        origin.args(["remote", "get-url", "origin"]);
-        origin.current_dir(&mirror);
-        let configured = output_text(name, "inspect cached origin", origin)?;
-        if configured.trim() != dependency.git() {
+        let configured = configured_origin(name, &mirror)?;
+        if configured != dependency.git() {
             bail!(
                 "Git dependency `{name}` cache origin is `{}`, expected `{}`; remove {} and retry",
-                configured.trim(),
+                configured,
                 dependency.git(),
                 mirror.display()
             );
@@ -230,6 +227,29 @@ fn output_text(name: &str, operation: &str, command: Command) -> Result<String> 
     })
 }
 
+fn configured_origin(name: &str, mirror: &Path) -> Result<String> {
+    let mut command = git_command();
+    command
+        .args(["config", "--null", "--get-all", "remote.origin.url"])
+        .current_dir(mirror);
+    let output = run_command(name, "inspect cached origin", command)?;
+    let Some(origin) = output.stdout.strip_suffix(&[0]) else {
+        bail!(
+            "Git dependency `{name}` cache origin config is malformed; remove {} and retry",
+            mirror.display()
+        );
+    };
+    if origin.is_empty() || origin.contains(&0) {
+        bail!(
+            "Git dependency `{name}` cache origin config must contain exactly one non-empty URL; remove {} and retry",
+            mirror.display()
+        );
+    }
+    String::from_utf8(origin.to_vec()).with_context(|| {
+        format!("git returned a non-UTF-8 cached origin URL while inspecting `{name}`")
+    })
+}
+
 fn digest(fields: &[(&str, &str)]) -> String {
     let mut digest = Sha256::new();
     for (kind, value) in fields {
@@ -287,7 +307,7 @@ impl Drop for CacheLock {
 
 #[cfg(test)]
 mod tests {
-    use super::{GitDependencyStore, dependency_cache_root};
+    use super::{GitDependencyStore, dependency_cache_root, digest};
     use crate::plugin::PluginManifest;
     use std::{
         ffi::OsString,
@@ -421,6 +441,10 @@ mod tests {
         }
 
         fn dependency(&self, selector: &str) -> crate::plugin::GitDependency {
+            self.dependency_at(&self.remote.to_string_lossy(), selector)
+        }
+
+        fn dependency_at(&self, git_url: &str, selector: &str) -> crate::plugin::GitDependency {
             let manifest = format!(
                 r#"{{
                     "id": "com.example.fixture",
@@ -433,7 +457,7 @@ mod tests {
                         }}
                     }}
                 }}"#,
-                serde_json::to_string(&self.remote).expect("remote path as JSON")
+                serde_json::to_string(git_url).expect("remote URL as JSON")
             );
             PluginManifest::parse(&manifest)
                 .expect("fixture manifest")
@@ -563,5 +587,41 @@ mod tests {
             .materialize("omarchy-ui", &dependency)
             .expect_err("a cache may not silently change repository identity");
         assert!(error.to_string().contains("cache origin"), "{error:#}");
+    }
+
+    #[test]
+    fn a_cached_mirror_accepts_its_raw_origin_when_git_rewrites_the_effective_url() {
+        let fixture = GitFixture::new();
+        fixture.commit("export const version = 1;", "first");
+        let raw_origin = "https://github.com/huacnlee/omarchy-ui";
+        let dependency = fixture.dependency_at(raw_origin, r#""branch": "main""#);
+        let store = GitDependencyStore::new(fixture.cache.clone());
+        let remote_key = digest(&[("git", raw_origin)]);
+        let mirror = fixture
+            .cache
+            .join("mirrors")
+            .join(format!("{remote_key}.git"));
+        std::fs::create_dir_all(mirror.parent().expect("mirror parent")).expect("mirror parent");
+        git(
+            mirror.parent().expect("mirror parent"),
+            &[
+                "clone",
+                "--mirror",
+                "--",
+                fixture.remote.to_str().expect("UTF-8 fixture remote"),
+                mirror.to_str().expect("UTF-8 mirror path"),
+            ],
+        );
+        git(&mirror, &["remote", "set-url", "origin", raw_origin]);
+        let rewrite_key = format!("url.{}.insteadOf", fixture.remote.display());
+        git(&mirror, &["config", &rewrite_key, raw_origin]);
+
+        let package = store
+            .materialize("omarchy-ui", &dependency)
+            .expect("a URL rewrite must not change the configured origin identity");
+        assert_eq!(
+            std::fs::read_to_string(package.entry).unwrap(),
+            "export const version = 1;"
+        );
     }
 }

--- a/crates/shell/src/dependencies.rs
+++ b/crates/shell/src/dependencies.rs
@@ -26,9 +26,17 @@ pub(crate) struct MaterializedDependency {
 
 impl GitDependencyStore {
     pub(crate) fn for_user() -> Self {
-        let home = std::env::var_os("HOME")
-            .or_else(|| std::env::var_os("USERPROFILE"))
-            .map(PathBuf::from)
+        Self::for_user_with_environment(|variable| std::env::var_os(variable))
+    }
+
+    fn for_user_with_environment(environment: impl Fn(&str) -> Option<std::ffi::OsString>) -> Self {
+        let home = ["HOME", "USERPROFILE"]
+            .into_iter()
+            .find_map(|variable| {
+                environment(variable)
+                    .filter(|value| !value.is_empty())
+                    .map(PathBuf::from)
+            })
             .unwrap_or_else(std::env::temp_dir);
         Self::new(dependency_cache_root(&home))
     }
@@ -273,6 +281,7 @@ mod tests {
     use super::{GitDependencyStore, dependency_cache_root};
     use crate::plugin::PluginManifest;
     use std::{
+        ffi::OsString,
         path::{Path, PathBuf},
         process::Command,
         sync::{
@@ -288,6 +297,46 @@ mod tests {
         assert_eq!(
             dependency_cache_root(Path::new("/home/example")),
             PathBuf::from("/home/example/.gpui-shell/cache/dependencies")
+        );
+    }
+
+    #[test]
+    fn for_user_wires_home_to_the_shell_cache_root() {
+        let store = GitDependencyStore::for_user_with_environment(|variable| match variable {
+            "HOME" => Some(OsString::from("/home/example")),
+            _ => None,
+        });
+
+        assert_eq!(
+            store.root,
+            PathBuf::from("/home/example/.gpui-shell/cache/dependencies")
+        );
+    }
+
+    #[test]
+    fn for_user_uses_userprofile_when_home_is_missing() {
+        let store = GitDependencyStore::for_user_with_environment(|variable| match variable {
+            "USERPROFILE" => Some(OsString::from("C:\\Users\\example")),
+            _ => None,
+        });
+
+        assert_eq!(
+            store.root,
+            PathBuf::from("C:\\Users\\example/.gpui-shell/cache/dependencies")
+        );
+    }
+
+    #[test]
+    fn for_user_ignores_an_empty_home_before_userprofile() {
+        let store = GitDependencyStore::for_user_with_environment(|variable| match variable {
+            "HOME" => Some(OsString::new()),
+            "USERPROFILE" => Some(OsString::from("/profiles/example")),
+            _ => None,
+        });
+
+        assert_eq!(
+            store.root,
+            PathBuf::from("/profiles/example/.gpui-shell/cache/dependencies")
         );
     }
 

--- a/crates/shell/src/dependencies.rs
+++ b/crates/shell/src/dependencies.rs
@@ -25,20 +25,29 @@ pub(crate) struct MaterializedDependency {
 }
 
 impl GitDependencyStore {
-    pub(crate) fn for_user() -> Self {
+    pub(crate) fn for_user() -> Result<Self> {
         Self::for_user_with_environment(|variable| std::env::var_os(variable))
     }
 
-    fn for_user_with_environment(environment: impl Fn(&str) -> Option<std::ffi::OsString>) -> Self {
-        let home = ["HOME", "USERPROFILE"]
-            .into_iter()
-            .find_map(|variable| {
-                environment(variable)
-                    .filter(|value| !value.is_empty())
-                    .map(PathBuf::from)
-            })
-            .unwrap_or_else(std::env::temp_dir);
-        Self::new(dependency_cache_root(&home))
+    fn for_user_with_environment(
+        environment: impl Fn(&str) -> Option<std::ffi::OsString>,
+    ) -> Result<Self> {
+        let Some((variable, home)) = ["HOME", "USERPROFILE"].into_iter().find_map(|variable| {
+            environment(variable)
+                .filter(|value| !value.is_empty())
+                .map(|value| (variable, PathBuf::from(value)))
+        }) else {
+            bail!(
+                "cannot locate the Git dependency cache: HOME or USERPROFILE must name an absolute user directory"
+            );
+        };
+        if !home.is_absolute() {
+            bail!(
+                "cannot locate the Git dependency cache: {variable} must be an absolute path, got `{}`",
+                home.display()
+            );
+        }
+        Ok(Self::new(dependency_cache_root(&home)))
     }
 
     pub(crate) fn new(root: PathBuf) -> Self {
@@ -305,7 +314,8 @@ mod tests {
         let store = GitDependencyStore::for_user_with_environment(|variable| match variable {
             "HOME" => Some(OsString::from("/home/example")),
             _ => None,
-        });
+        })
+        .expect("an absolute HOME should select a private cache root");
 
         assert_eq!(
             store.root,
@@ -316,13 +326,14 @@ mod tests {
     #[test]
     fn for_user_uses_userprofile_when_home_is_missing() {
         let store = GitDependencyStore::for_user_with_environment(|variable| match variable {
-            "USERPROFILE" => Some(OsString::from("C:\\Users\\example")),
+            "USERPROFILE" => Some(OsString::from("/profiles/example")),
             _ => None,
-        });
+        })
+        .expect("an absolute USERPROFILE should select a private cache root");
 
         assert_eq!(
             store.root,
-            PathBuf::from("C:\\Users\\example/.gpui-shell/cache/dependencies")
+            PathBuf::from("/profiles/example/.gpui-shell/cache/dependencies")
         );
     }
 
@@ -332,12 +343,46 @@ mod tests {
             "HOME" => Some(OsString::new()),
             "USERPROFILE" => Some(OsString::from("/profiles/example")),
             _ => None,
-        });
+        })
+        .expect("an empty HOME should allow an absolute USERPROFILE");
 
         assert_eq!(
             store.root,
             PathBuf::from("/profiles/example/.gpui-shell/cache/dependencies")
         );
+    }
+
+    #[test]
+    fn for_user_rejects_missing_or_empty_home_variables() {
+        for (home, userprofile) in [(None, None), (Some(OsString::new()), Some(OsString::new()))] {
+            let result = GitDependencyStore::for_user_with_environment(|variable| match variable {
+                "HOME" => home.clone(),
+                "USERPROFILE" => userprofile.clone(),
+                _ => None,
+            });
+            let error = result.err().expect("a private home directory is required");
+
+            assert!(
+                error.to_string().contains("HOME or USERPROFILE"),
+                "{error:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn for_user_rejects_a_relative_selected_home() {
+        let result = GitDependencyStore::for_user_with_environment(|variable| match variable {
+            "HOME" => Some(OsString::from("relative/home")),
+            "USERPROFILE" => Some(OsString::from("/profiles/example")),
+            _ => None,
+        });
+        let error = result
+            .err()
+            .expect("a relative HOME must not select a shared working-directory cache");
+
+        assert!(error.to_string().contains("HOME"), "{error:#}");
+        assert!(error.to_string().contains("absolute"), "{error:#}");
+        assert!(error.to_string().contains("relative/home"), "{error:#}");
     }
 
     struct GitFixture {

--- a/crates/shell/src/dependencies.rs
+++ b/crates/shell/src/dependencies.rs
@@ -1,0 +1,462 @@
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+    process::{Command, Output, Stdio},
+    sync::atomic::{AtomicU64, Ordering},
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context as _, Result, bail};
+use fs2::FileExt as _;
+use sha2::{Digest as _, Sha256};
+use wait_timeout::ChildExt as _;
+
+use crate::plugin::GitDependency;
+
+/// Materializes Git-backed JavaScript packages in gpui-shell's user cache.
+pub(crate) struct GitDependencyStore {
+    root: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MaterializedDependency {
+    pub(crate) root: PathBuf,
+    pub(crate) entry: PathBuf,
+}
+
+impl GitDependencyStore {
+    pub(crate) fn for_user() -> Self {
+        Self::new(
+            crate::runtime::data_home()
+                .join("gpui-shell")
+                .join("dependencies")
+                .join("git"),
+        )
+    }
+
+    pub(crate) fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    pub(crate) fn materialize(
+        &self,
+        name: &str,
+        dependency: &GitDependency,
+    ) -> Result<MaterializedDependency> {
+        std::fs::create_dir_all(&self.root)
+            .with_context(|| format!("creating Git dependency cache {}", self.root.display()))?;
+        let remote_key = digest(&[("git", dependency.git())]);
+        let locks = self.root.join("locks");
+        let mirrors = self.root.join("mirrors");
+        let checkouts = self.root.join("checkouts").join(&remote_key);
+        std::fs::create_dir_all(&locks)?;
+        std::fs::create_dir_all(&mirrors)?;
+        std::fs::create_dir_all(&checkouts)?;
+        let _lock = CacheLock::acquire(&locks.join(format!("{remote_key}.lock")), name)?;
+
+        let mirror = mirrors.join(format!("{remote_key}.git"));
+        if !mirror.is_dir() {
+            let temporary = temporary_path(&mirrors, &remote_key);
+            let mut command = git_command();
+            command
+                .args(["clone", "--mirror", "--"])
+                .arg(dependency.git())
+                .arg(&temporary);
+            if let Err(error) = run_command(name, "clone", command) {
+                let _ = std::fs::remove_dir_all(&temporary);
+                return Err(error);
+            }
+            match std::fs::rename(&temporary, &mirror) {
+                Ok(()) => {}
+                Err(error) if mirror.is_dir() => {
+                    let _ = std::fs::remove_dir_all(&temporary);
+                    tracing::debug!("another process published {}: {error}", mirror.display());
+                }
+                Err(error) => return Err(error).context("publishing Git dependency mirror"),
+            }
+        }
+
+        let mut origin = git_command();
+        origin.args(["remote", "get-url", "origin"]);
+        origin.current_dir(&mirror);
+        let configured = output_text(name, "inspect cached origin", origin)?;
+        if configured.trim() != dependency.git() {
+            bail!(
+                "Git dependency `{name}` cache origin is `{}`, expected `{}`; remove {} and retry",
+                configured.trim(),
+                dependency.git(),
+                mirror.display()
+            );
+        }
+
+        let reference = match (dependency.branch(), dependency.tag()) {
+            (Some(branch), None) => format!("refs/heads/{branch}"),
+            (None, Some(tag)) => format!("refs/tags/{tag}"),
+            _ => unreachable!("manifest validation requires exactly one Git ref"),
+        };
+        let mut fetch = git_command();
+        fetch.args(["fetch", "--force", "--depth", "1", "origin", &reference]);
+        fetch.current_dir(&mirror);
+        run_command(name, "fetch", fetch)?;
+
+        let mut rev_parse = git_command();
+        rev_parse.args(["rev-parse", "FETCH_HEAD"]);
+        rev_parse.current_dir(&mirror);
+        let commit = output_text(name, "resolve fetched commit", rev_parse)?;
+        let commit = commit.trim();
+        if !(commit.len() == 40 || commit.len() == 64)
+            || !commit.bytes().all(|byte| byte.is_ascii_hexdigit())
+        {
+            bail!("Git dependency `{name}` resolved an invalid commit id `{commit}`");
+        }
+
+        let checkout = checkouts.join(commit);
+        if !checkout.join(".git").is_dir() {
+            let temporary = temporary_path(&checkouts, commit);
+            let mut clone = git_command();
+            clone
+                .args(["clone", "--no-checkout", "--"])
+                .arg(&mirror)
+                .arg(&temporary);
+            if let Err(error) = run_command(name, "create immutable checkout", clone) {
+                let _ = std::fs::remove_dir_all(&temporary);
+                return Err(error);
+            }
+            let mut checkout_commit = git_command();
+            checkout_commit
+                .args(["checkout", "--force", "--detach", commit])
+                .current_dir(&temporary);
+            if let Err(error) = run_command(name, "checkout fetched commit", checkout_commit) {
+                let _ = std::fs::remove_dir_all(&temporary);
+                return Err(error);
+            }
+            match std::fs::rename(&temporary, &checkout) {
+                Ok(()) => {}
+                Err(error) if checkout.join(".git").is_dir() => {
+                    let _ = std::fs::remove_dir_all(&temporary);
+                    tracing::debug!("another process published {}: {error}", checkout.display());
+                }
+                Err(error) => return Err(error).context("publishing Git dependency checkout"),
+            }
+        }
+
+        let root = checkout
+            .canonicalize()
+            .with_context(|| format!("resolving dependency checkout {}", checkout.display()))?;
+        let entry = root
+            .join(dependency.entry())
+            .canonicalize()
+            .with_context(|| {
+                format!(
+                    "Git dependency `{name}` has no entry `{}`",
+                    dependency.entry()
+                )
+            })?;
+        if !entry.starts_with(&root) || !entry.is_file() {
+            bail!(
+                "Git dependency `{name}` entry `{}` is not a file inside its checkout",
+                dependency.entry()
+            );
+        }
+
+        Ok(MaterializedDependency { root, entry })
+    }
+}
+
+const GIT_TIMEOUT: Duration = Duration::from_secs(30);
+const LOCK_TIMEOUT: Duration = Duration::from_secs(2 * 60);
+
+fn git_command() -> Command {
+    let mut command = Command::new("git");
+    command
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GCM_INTERACTIVE", "Never")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command
+}
+
+fn run_command(name: &str, operation: &str, mut command: Command) -> Result<Output> {
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("starting git to {operation} dependency `{name}`"))?;
+    let status = child
+        .wait_timeout(GIT_TIMEOUT)
+        .with_context(|| format!("waiting for git to {operation} dependency `{name}`"))?;
+    if status.is_none() {
+        let _ = child.kill();
+        let _ = child.wait();
+        bail!(
+            "git timed out after {} seconds while trying to {operation} dependency `{name}`",
+            GIT_TIMEOUT.as_secs()
+        );
+    }
+    let output = child.wait_with_output()?;
+    if output.status.success() {
+        return Ok(output);
+    }
+    let detail = String::from_utf8_lossy(&output.stderr);
+    bail!(
+        "could not {operation} Git dependency `{name}`: {}",
+        detail.trim()
+    )
+}
+
+fn output_text(name: &str, operation: &str, command: Command) -> Result<String> {
+    let output = run_command(name, operation, command)?;
+    String::from_utf8(output.stdout).with_context(|| {
+        format!("git returned non-UTF-8 output while trying to {operation} `{name}`")
+    })
+}
+
+fn digest(fields: &[(&str, &str)]) -> String {
+    let mut digest = Sha256::new();
+    for (kind, value) in fields {
+        digest.update(kind.len().to_le_bytes());
+        digest.update(kind.as_bytes());
+        digest.update(value.len().to_le_bytes());
+        digest.update(value.as_bytes());
+    }
+    format!("{:x}", digest.finalize())
+}
+
+fn temporary_path(parent: &Path, label: &str) -> PathBuf {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    parent.join(format!(
+        ".{label}.tmp-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+struct CacheLock(File);
+
+impl CacheLock {
+    fn acquire(path: &Path, name: &str) -> Result<Self> {
+        let file = File::options()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(path)
+            .with_context(|| format!("opening Git dependency cache lock {}", path.display()))?;
+        let started = Instant::now();
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(()) => return Ok(Self(file)),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    if started.elapsed() >= LOCK_TIMEOUT {
+                        bail!(
+                            "timed out waiting for another process to finish Git dependency `{name}`"
+                        );
+                    }
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                Err(error) => return Err(error).context("locking Git dependency cache"),
+            }
+        }
+    }
+}
+
+impl Drop for CacheLock {
+    fn drop(&mut self) {
+        let _ = self.0.unlock();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GitDependencyStore;
+    use crate::plugin::PluginManifest;
+    use std::{
+        path::{Path, PathBuf},
+        process::Command,
+        sync::{
+            Arc, Barrier,
+            atomic::{AtomicU64, Ordering},
+        },
+    };
+
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+
+    struct GitFixture {
+        root: PathBuf,
+        remote: PathBuf,
+        cache: PathBuf,
+    }
+
+    impl GitFixture {
+        fn new() -> Self {
+            let unique = NEXT.fetch_add(1, Ordering::Relaxed);
+            let root = std::env::temp_dir().join(format!(
+                "gpui-shell-git-dependency-{}-{unique}",
+                std::process::id()
+            ));
+            let remote = root.join("remote");
+            let cache = root.join("cache");
+            std::fs::create_dir_all(&remote).expect("fixture directory");
+            git(&remote, &["init", "--initial-branch=main"]);
+            git(&remote, &["config", "user.name", "gpui-shell test"]);
+            git(
+                &remote,
+                &["config", "user.email", "gpui-shell@example.invalid"],
+            );
+            Self {
+                root,
+                remote,
+                cache,
+            }
+        }
+
+        fn commit(&self, source: &str, message: &str) {
+            std::fs::write(self.remote.join("index.js"), source).expect("dependency source");
+            git(&self.remote, &["add", "index.js"]);
+            git(&self.remote, &["commit", "-m", message]);
+        }
+
+        fn dependency(&self, selector: &str) -> crate::plugin::GitDependency {
+            let manifest = format!(
+                r#"{{
+                    "id": "com.example.fixture",
+                    "name": "Fixture",
+                    "entry": "main.js",
+                    "dependencies": {{
+                        "omarchy-ui": {{
+                            "git": {},
+                            {selector}
+                        }}
+                    }}
+                }}"#,
+                serde_json::to_string(&self.remote).expect("remote path as JSON")
+            );
+            PluginManifest::parse(&manifest)
+                .expect("fixture manifest")
+                .dependencies()["omarchy-ui"]
+                .clone()
+        }
+    }
+
+    impl Drop for GitFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn git(directory: &Path, arguments: &[&str]) {
+        let output = Command::new("git")
+            .args(arguments)
+            .current_dir(directory)
+            .output()
+            .expect("git must be installed for the test");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            arguments.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn a_branch_dependency_refreshes_to_the_remote_head_on_each_materialization() {
+        let fixture = GitFixture::new();
+        fixture.commit("export const version = 1;", "first");
+        let dependency = fixture.dependency(r#""branch": "main""#);
+        let store = GitDependencyStore::new(fixture.cache.clone());
+
+        let first = store
+            .materialize("omarchy-ui", &dependency)
+            .expect("first checkout");
+        assert_eq!(
+            std::fs::read_to_string(&first.entry).unwrap(),
+            "export const version = 1;"
+        );
+
+        fixture.commit("export const version = 2;", "second");
+        let second = store
+            .materialize("omarchy-ui", &dependency)
+            .expect("updated checkout");
+        assert_eq!(
+            std::fs::read_to_string(&second.entry).unwrap(),
+            "export const version = 2;"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&first.entry).unwrap(),
+            "export const version = 1;",
+            "a refresh must not mutate a checkout retained by an older module generation"
+        );
+    }
+
+    #[test]
+    fn a_tag_dependency_stays_at_the_tagged_commit() {
+        let fixture = GitFixture::new();
+        fixture.commit("export const version = 1;", "tagged");
+        git(&fixture.remote, &["tag", "v1"]);
+        fixture.commit("export const version = 2;", "later");
+        let dependency = fixture.dependency(r#""tag": "v1""#);
+        let store = GitDependencyStore::new(fixture.cache.clone());
+
+        let package = store
+            .materialize("omarchy-ui", &dependency)
+            .expect("tag checkout");
+        assert_eq!(
+            std::fs::read_to_string(&package.entry).unwrap(),
+            "export const version = 1;"
+        );
+    }
+
+    #[test]
+    fn concurrent_materializations_publish_one_valid_checkout() {
+        let fixture = GitFixture::new();
+        fixture.commit("export const version = 1;", "first");
+        let dependency = fixture.dependency(r#""branch": "main""#);
+        let barrier = Arc::new(Barrier::new(2));
+
+        let workers: Vec<_> = (0..2)
+            .map(|_| {
+                let cache = fixture.cache.clone();
+                let dependency = dependency.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    GitDependencyStore::new(cache)
+                        .materialize("omarchy-ui", &dependency)
+                        .expect("concurrent checkout")
+                })
+            })
+            .collect();
+        let packages: Vec<_> = workers
+            .into_iter()
+            .map(|worker| worker.join().expect("materialization worker"))
+            .collect();
+
+        assert_eq!(packages[0].root, packages[1].root);
+        assert_eq!(
+            std::fs::read_to_string(&packages[0].entry).unwrap(),
+            "export const version = 1;"
+        );
+    }
+
+    #[test]
+    fn a_cached_mirror_with_the_wrong_origin_is_refused() {
+        let fixture = GitFixture::new();
+        fixture.commit("export const version = 1;", "first");
+        let dependency = fixture.dependency(r#""branch": "main""#);
+        let store = GitDependencyStore::new(fixture.cache.clone());
+        store
+            .materialize("omarchy-ui", &dependency)
+            .expect("initial checkout");
+        let mirror = std::fs::read_dir(fixture.cache.join("mirrors"))
+            .expect("mirror directory")
+            .next()
+            .expect("one mirror")
+            .expect("mirror entry")
+            .path();
+        git(&mirror, &["remote", "set-url", "origin", "/wrong/remote"]);
+
+        let error = store
+            .materialize("omarchy-ui", &dependency)
+            .expect_err("a cache may not silently change repository identity");
+        assert!(error.to_string().contains("cache origin"), "{error:#}");
+    }
+}

--- a/crates/shell/src/dependencies.rs
+++ b/crates/shell/src/dependencies.rs
@@ -102,10 +102,17 @@ impl GitDependencyStore {
             );
         }
 
-        let reference = match (dependency.branch(), dependency.tag()) {
-            (Some(branch), None) => format!("refs/heads/{branch}"),
-            (None, Some(tag)) => format!("refs/tags/{tag}"),
-            _ => unreachable!("manifest validation requires exactly one Git ref"),
+        let reference = match (
+            dependency.uses_package_entry(),
+            dependency.reference(),
+            dependency.branch(),
+            dependency.tag(),
+        ) {
+            (true, Some(reference), None, None) => reference.to_owned(),
+            (true, None, None, None) => "HEAD".to_owned(),
+            (false, None, Some(branch), None) => format!("refs/heads/{branch}"),
+            (false, None, None, Some(tag)) => format!("refs/tags/{tag}"),
+            _ => unreachable!("manifest validation requires one supported Git selector"),
         };
         let mut fetch = git_command();
         fetch.args(["fetch", "--force", "--depth", "1", "origin", &reference]);
@@ -156,24 +163,79 @@ impl GitDependencyStore {
         let root = checkout
             .canonicalize()
             .with_context(|| format!("resolving dependency checkout {}", checkout.display()))?;
+        let entry_name = dependency_entry_name(name, dependency, &root)?;
         let entry = root
-            .join(dependency.entry())
+            .join(&entry_name)
             .canonicalize()
-            .with_context(|| {
-                format!(
-                    "Git dependency `{name}` has no entry `{}`",
-                    dependency.entry()
-                )
-            })?;
+            .with_context(|| format!("Git dependency `{name}` has no entry `{}`", entry_name))?;
         if !entry.starts_with(&root) || !entry.is_file() {
             bail!(
                 "Git dependency `{name}` entry `{}` is not a file inside its checkout",
-                dependency.entry()
+                entry_name
             );
         }
 
         Ok(MaterializedDependency { root, entry })
     }
+}
+
+fn dependency_entry_name(name: &str, dependency: &GitDependency, root: &Path) -> Result<String> {
+    if !dependency.uses_package_entry() {
+        return Ok(dependency.entry().to_owned());
+    }
+
+    let manifest = root.join("package.json");
+    let manifest = match manifest.symlink_metadata() {
+        Ok(_) => {
+            let manifest = manifest
+                .canonicalize()
+                .with_context(|| format!("resolving package.json for Git dependency `{name}`"))?;
+            if !manifest.starts_with(root) || !manifest.is_file() {
+                bail!("Git dependency `{name}` package.json is not a file inside its checkout");
+            }
+            Some(manifest)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspecting package.json for Git dependency `{name}`"));
+        }
+    };
+    let Some(manifest) = manifest else {
+        return Ok(default_package_entry());
+    };
+    let source = std::fs::read_to_string(&manifest)
+        .with_context(|| format!("reading package.json for Git dependency `{name}`"))?;
+    let value: serde_json::Value = serde_json::from_str(&source).map_err(|error| {
+        anyhow::anyhow!("Git dependency `{name}` package.json must contain valid JSON: {error}")
+    })?;
+    let object = value.as_object().ok_or_else(|| {
+        anyhow::anyhow!("Git dependency `{name}` package.json must contain a JSON object")
+    })?;
+    let entry = match object.get("main") {
+        None => default_package_entry(),
+        Some(serde_json::Value::String(entry)) => entry.clone(),
+        Some(_) => {
+            bail!("Git dependency `{name}` package.json `main` must be a string");
+        }
+    };
+    let path = Path::new(&entry);
+    if entry.is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir))
+        || entry.contains(['\\', ':'])
+    {
+        bail!(
+            "Git dependency `{name}` package.json `main` `{entry}` must be a path inside its checkout"
+        );
+    }
+    Ok(entry)
+}
+
+fn default_package_entry() -> String {
+    "index.js".to_owned()
 }
 
 fn dependency_cache_root(home: &Path) -> PathBuf {
@@ -464,6 +526,44 @@ mod tests {
                 .dependencies()["omarchy-ui"]
                 .clone()
         }
+
+        fn package_dependency(&self, reference: Option<&str>) -> crate::plugin::GitDependency {
+            let remote = format!("file://{}", self.remote.display());
+            let source = match reference {
+                Some(reference) => format!("{remote}#{reference}"),
+                None => remote,
+            };
+            let manifest = format!(
+                r#"{{
+                    "id": "com.example.fixture",
+                    "name": "Fixture",
+                    "entry": "main.js",
+                    "dependencies": {{ "omarchy-ui": {} }}
+                }}"#,
+                serde_json::to_string(&source).expect("dependency as JSON")
+            );
+            PluginManifest::parse(&manifest)
+                .expect("fixture package dependency")
+                .dependencies()["omarchy-ui"]
+                .clone()
+        }
+
+        fn write(&self, path: &str, source: &str) {
+            let path = self.remote.join(path);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("dependency source parent");
+            }
+            std::fs::write(path, source).expect("dependency source");
+        }
+
+        fn commit_all(&self, message: &str) {
+            git(&self.remote, &["add", "."]);
+            git(&self.remote, &["commit", "-m", message]);
+        }
+
+        fn head(&self) -> String {
+            git_output(&self.remote, &["rev-parse", "HEAD"])
+        }
     }
 
     impl Drop for GitFixture {
@@ -484,6 +584,113 @@ mod tests {
             arguments.join(" "),
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    fn git_output(directory: &Path, arguments: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(arguments)
+            .current_dir(directory)
+            .output()
+            .expect("git must be installed for the test");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            arguments.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout)
+            .expect("git fixture output should be UTF-8")
+            .trim()
+            .to_owned()
+    }
+
+    #[test]
+    fn package_dependencies_resolve_branch_tag_commit_ish_and_remote_head() {
+        let fixture = GitFixture::new();
+        fixture.commit("export const version = 1;", "tagged");
+        let tagged_commit = fixture.head();
+        git(&fixture.remote, &["tag", "v1"]);
+        fixture.commit("export const version = 2;", "current");
+        let store = GitDependencyStore::new(fixture.cache.clone());
+
+        for (reference, expected) in [
+            (Some("main"), "export const version = 2;"),
+            (Some("v1"), "export const version = 1;"),
+            (Some(tagged_commit.as_str()), "export const version = 1;"),
+            (None, "export const version = 2;"),
+        ] {
+            let dependency = fixture.package_dependency(reference);
+            let package = store
+                .materialize("omarchy-ui", &dependency)
+                .expect("the Git reference should resolve");
+            assert_eq!(std::fs::read_to_string(package.entry).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn package_dependencies_read_package_main_or_default_to_index_js() {
+        let custom = GitFixture::new();
+        custom.write("dist/public.js", "export const entry = 'package main';");
+        custom.write("package.json", r#"{ "main": "dist/public.js" }"#);
+        custom.commit_all("custom package entry");
+        let package = GitDependencyStore::new(custom.cache.clone())
+            .materialize("omarchy-ui", &custom.package_dependency(Some("main")))
+            .expect("package.json main should select the entry");
+        assert_eq!(
+            std::fs::read_to_string(package.entry).unwrap(),
+            "export const entry = 'package main';"
+        );
+
+        let defaulted = GitFixture::new();
+        defaulted.commit(
+            "export const entry = 'index default';",
+            "default package entry",
+        );
+        let package = GitDependencyStore::new(defaulted.cache.clone())
+            .materialize("omarchy-ui", &defaulted.package_dependency(Some("main")))
+            .expect("a missing package.json should default to index.js");
+        assert_eq!(
+            std::fs::read_to_string(package.entry).unwrap(),
+            "export const entry = 'index default';"
+        );
+    }
+
+    #[test]
+    fn malformed_or_non_string_package_main_is_rejected() {
+        for (package_json, expected) in [
+            ("{ not JSON", "valid JSON"),
+            (r#"{ "main": 42 }"#, "string"),
+            (r#"{ "main": null }"#, "string"),
+        ] {
+            let fixture = GitFixture::new();
+            fixture.write("index.js", "export const executed = true;");
+            fixture.write("package.json", package_json);
+            fixture.commit_all("invalid package manifest");
+
+            let error = GitDependencyStore::new(fixture.cache.clone())
+                .materialize("omarchy-ui", &fixture.package_dependency(Some("main")))
+                .expect_err("an invalid package manifest must fail before execution");
+            assert!(error.to_string().contains("package.json"), "{error:#}");
+            assert!(error.to_string().contains(expected), "{error:#}");
+        }
+    }
+
+    #[test]
+    fn package_main_must_name_a_file_confined_to_the_checkout() {
+        for (main, expected) in [("../private.js", "inside"), ("dist", "file")] {
+            let fixture = GitFixture::new();
+            fixture.write("dist/nested.js", "export const nested = true;");
+            fixture.write(
+                "package.json",
+                &serde_json::json!({ "main": main }).to_string(),
+            );
+            fixture.commit_all("unsafe package entry");
+
+            let error = GitDependencyStore::new(fixture.cache.clone())
+                .materialize("omarchy-ui", &fixture.package_dependency(Some("main")))
+                .expect_err("package main must resolve to an in-checkout file");
+            assert!(error.to_string().contains(expected), "{error:#}");
+        }
     }
 
     #[test]

--- a/crates/shell/src/engine/quickjs/mod.rs
+++ b/crates/shell/src/engine/quickjs/mod.rs
@@ -7386,12 +7386,18 @@ mod module_lifecycle_tests {
         git(&["init", "--initial-branch=main"]);
         git(&["config", "user.name", "gpui-shell test"]);
         git(&["config", "user.email", "gpui-shell@example.invalid"]);
+        std::fs::create_dir_all(remote.join("dist")).expect("dependency dist directory");
         std::fs::write(
-            remote.join("index.js"),
-            "export const label = 'downloaded';",
+            remote.join("dist/public.js"),
+            "export const label = 'downloaded from package main';",
         )
         .expect("dependency source");
-        git(&["add", "index.js"]);
+        std::fs::write(
+            remote.join("package.json"),
+            r#"{ "main": "dist/public.js" }"#,
+        )
+        .expect("dependency package manifest");
+        git(&["add", "."]);
         git(&["commit", "-m", "dependency"]);
 
         std::fs::write(
@@ -7401,11 +7407,10 @@ mod module_lifecycle_tests {
                     "id": "com.example.fetch",
                     "name": "Fetch",
                     "entry": "main.js",
-                    "dependencies": {{
-                        "omarchy-ui": {{ "git": {}, "branch": "main" }}
-                    }}
+                    "dependencies": {{ "omarchy-ui": {} }}
                 }}"#,
-                serde_json::to_string(&remote).expect("remote path")
+                serde_json::to_string(&format!("file://{}#main", remote.display()))
+                    .expect("remote URL")
             ),
         )
         .expect("application manifest");
@@ -7428,7 +7433,7 @@ mod module_lifecycle_tests {
                 label.call::<_, String>(())
             })
             .expect("dependency export");
-        assert_eq!(label, "downloaded");
+        assert_eq!(label, "downloaded from package main");
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/shell/src/engine/quickjs/mod.rs
+++ b/crates/shell/src/engine/quickjs/mod.rs
@@ -16,7 +16,7 @@
 
 use std::{
     cell::{Cell, RefCell, RefMut},
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     path::Path,
     rc::{Rc, Weak},
 };
@@ -34,6 +34,7 @@ use rquickjs::{
 use smallvec::SmallVec;
 
 use crate::{
+    dependencies::{GitDependencyStore, MaterializedDependency},
     entities::{EntityHandle, EntityStore},
     metrics::Metrics,
     policy::Policy,
@@ -520,6 +521,7 @@ pub struct ShellRuntime {
     /// Incremented per `load_app`, so a reload re-reads every module rather
     /// than serving the first version from QuickJS's module cache.
     app_modules: AppModules,
+    dependency_store: GitDependencyStore,
     next_application_generation: Cell<u64>,
     /// Held so the context stays alive, and so the module loader can be scoped
     /// to an application directory when one is loaded.
@@ -575,6 +577,12 @@ impl ShellRuntime {
     /// call frame rather than in runtime-global state. Use this only when a host
     /// deliberately owns multiple isolated runtimes.
     pub fn new_isolated() -> Result<Rc<Self>> {
+        Self::new_isolated_with_dependency_store(GitDependencyStore::for_user())
+    }
+
+    fn new_isolated_with_dependency_store(
+        dependency_store: GitDependencyStore,
+    ) -> Result<Rc<Self>> {
         let entities = EntityStore::try_new()
             .ok_or_else(|| anyhow!("gpui-shell entity store id space is exhausted"))?;
         let js_runtime = JsRuntime::new().map_err(js_setup_error)?;
@@ -630,6 +638,7 @@ impl ShellRuntime {
             test_http_client: RefCell::new(None),
             context,
             app_modules,
+            dependency_store,
             next_application_generation: Cell::new(1),
             js_runtime,
         });
@@ -806,9 +815,26 @@ impl ShellRuntime {
             );
         }
 
+        let dependencies = if root.join(crate::plugin::MANIFEST_FILE).is_file() {
+            let manifest = crate::plugin::PluginManifest::read(&root)?;
+            manifest
+                .dependencies()
+                .iter()
+                .map(|(name, dependency)| {
+                    self.dependency_store
+                        .materialize(name, dependency)
+                        .map(|materialized| (name.clone(), materialized))
+                })
+                .collect::<Result<BTreeMap<_, _>>>()?
+        } else {
+            BTreeMap::new()
+        };
+
         // Every load is a new generation, which is what makes a reload pick up
         // a change in an imported module rather than only in the entry point.
-        let module_lease = self.app_modules.register(root.clone());
+        let module_lease = self
+            .app_modules
+            .register_with_dependencies(root.clone(), dependencies);
         let generation = module_lease.generation();
         let application = ApplicationGeneration::new(self.next_application_generation.get());
         self.next_application_generation.set(
@@ -3296,6 +3322,7 @@ struct AppModules {
 struct ApplicationModules {
     root: std::path::PathBuf,
     generation: u32,
+    dependencies: BTreeMap<String, MaterializedDependency>,
 }
 
 #[derive(Clone)]
@@ -3322,12 +3349,22 @@ impl Drop for ApplicationModuleRegistration {
 }
 
 impl AppModules {
+    #[cfg(test)]
     fn register(&self, root: std::path::PathBuf) -> ApplicationModuleLease {
+        self.register_with_dependencies(root, BTreeMap::new())
+    }
+
+    fn register_with_dependencies(
+        &self,
+        root: std::path::PathBuf,
+        dependencies: BTreeMap<String, MaterializedDependency>,
+    ) -> ApplicationModuleLease {
         let generation = self.next_generation.get().wrapping_add(1);
         self.next_generation.set(generation);
         self.applications.borrow_mut().push(ApplicationModules {
             root: root.clone(),
             generation,
+            dependencies,
         });
         ApplicationModuleLease(Rc::new(ApplicationModuleRegistration {
             applications: self.applications.clone(),
@@ -3348,7 +3385,12 @@ impl AppModules {
             .borrow()
             .iter()
             .filter(|application| {
-                application.generation == generation && base.starts_with(&application.root)
+                application.generation == generation
+                    && (base.starts_with(&application.root)
+                        || application
+                            .dependencies
+                            .values()
+                            .any(|dependency| base.starts_with(&dependency.root)))
             })
             .max_by_key(|application| application.root.components().count())
             .cloned()
@@ -3368,17 +3410,42 @@ impl AppModules {
         application: &ApplicationModules,
         base: &str,
         name: &str,
-    ) -> Option<std::path::PathBuf> {
-        let start = if name.starts_with('.') {
-            Path::new(Self::untag(base)).parent()?.to_path_buf()
+    ) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+        let base_path = Path::new(Self::untag(base));
+        let importing_dependency = application
+            .dependencies
+            .values()
+            .find(|dependency| base_path.starts_with(&dependency.root));
+        let (joined, boundary) = if name.starts_with('.') {
+            let boundary = importing_dependency
+                .map(|dependency| dependency.root.clone())
+                .unwrap_or_else(|| application.root.clone());
+            (base_path.parent()?.join(name), boundary)
+        } else if let Some((dependency_name, dependency)) = application
+            .dependencies
+            .iter()
+            .filter(|(dependency_name, _)| {
+                name == dependency_name.as_str()
+                    || name
+                        .strip_prefix(dependency_name.as_str())
+                        .is_some_and(|tail| tail.starts_with('/'))
+            })
+            .max_by_key(|(dependency_name, _)| dependency_name.len())
+        {
+            if name == dependency_name {
+                return Some((dependency.entry.clone(), dependency.root.clone()));
+            }
+            let subpath = name.strip_prefix(dependency_name)?.strip_prefix('/')?;
+            (dependency.root.join(subpath), dependency.root.clone())
+        } else if importing_dependency.is_some() {
+            return None;
         } else {
-            application.root.clone()
+            (application.root.join(name), application.root.clone())
         };
 
-        let joined = start.join(name);
         for candidate in [joined.clone(), joined.with_extension("js")] {
             if candidate.is_file() {
-                return candidate.canonicalize().ok();
+                return candidate.canonicalize().ok().map(|path| (path, boundary));
             }
         }
         None
@@ -3399,7 +3466,7 @@ impl Resolver for AppModules {
                 &format!("cannot identify the application importing `{name}` from `{base}`"),
             ));
         };
-        let Some(path) = self.candidate(&application, base, name) else {
+        let Some((path, boundary)) = self.candidate(&application, base, name) else {
             // A bare specifier reached the last resolver in the chain, so it is
             // neither a built-in nor a file. Saying which built-ins this
             // runtime does have is the difference between "you typed it wrong"
@@ -3423,12 +3490,12 @@ impl Resolver for AppModules {
             ));
         };
 
-        if !path.starts_with(&application.root) {
+        if !path.starts_with(&boundary) {
             return Err(Exception::throw_message(
                 ctx,
                 &format!(
                     "module `{name}` resolves outside the application directory `{}`",
-                    application.root.display()
+                    boundary.display()
                 ),
             ));
         }
@@ -7073,6 +7140,9 @@ mod keystroke_tests {
 #[cfg(test)]
 mod module_lifecycle_tests {
     use super::{AppModules, ShellRuntime};
+    use crate::dependencies::{GitDependencyStore, MaterializedDependency};
+    use std::collections::BTreeMap;
+    use std::process::Command;
 
     #[test]
     fn registrations_for_the_same_root_are_generation_scoped_and_leased() {
@@ -7183,6 +7253,182 @@ mod module_lifecycle_tests {
             .load_app(&root, "main.js")
             .expect_err("missing import must reject the load");
         assert_eq!(runtime.app_modules.registration_count(), 0);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_bare_dependency_import_loads_its_entry_and_relative_modules() {
+        let runtime = ShellRuntime::new_isolated().expect("runtime");
+        let root = std::env::temp_dir().join(format!(
+            "gpui-shell-third-party-module-{}",
+            std::process::id()
+        ));
+        let application = root.join("application");
+        let dependency = root.join("dependency");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&application).expect("application directory");
+        std::fs::create_dir_all(&dependency).expect("dependency directory");
+        std::fs::write(
+            dependency.join("index.js"),
+            "export { label } from './theme.js';",
+        )
+        .expect("dependency entry");
+        std::fs::write(
+            dependency.join("theme.js"),
+            "export const label = 'third party'; export const tone = 'dark';",
+        )
+        .expect("dependency relative module");
+
+        let application = application.canonicalize().expect("application root");
+        let dependency = dependency.canonicalize().expect("dependency root");
+        let mut dependencies = BTreeMap::new();
+        dependencies.insert(
+            "omarchy-ui".to_owned(),
+            MaterializedDependency {
+                entry: dependency.join("index.js"),
+                root: dependency,
+            },
+        );
+        let lease = runtime
+            .app_modules
+            .register_with_dependencies(application.clone(), dependencies);
+        let generation = lease.generation();
+        let view_type = runtime
+            .load_source_with_lease(
+                &format!("{}/main.js?v={generation}", application.display()),
+                "import { label } from 'omarchy-ui'; import { tone } from 'omarchy-ui/theme.js'; export default class Panel { static label() { return `${label}:${tone}`; } }",
+                Some(lease),
+                None,
+            )
+            .expect("third-party module graph");
+
+        let label = runtime
+            .with_js(|ctx| {
+                let class = view_type.value.clone().restore(ctx)?;
+                let label: rquickjs::Function = class.get("label")?;
+                label.call::<_, String>(())
+            })
+            .expect("dependency export");
+        assert_eq!(label, "third party:dark");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_dependency_relative_import_cannot_escape_its_checkout() {
+        let runtime = ShellRuntime::new_isolated().expect("runtime");
+        let root = std::env::temp_dir().join(format!(
+            "gpui-shell-third-party-escape-{}",
+            std::process::id()
+        ));
+        let application = root.join("application");
+        let dependency = root.join("dependency");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&application).expect("application directory");
+        std::fs::create_dir_all(&dependency).expect("dependency directory");
+        std::fs::write(root.join("secret.js"), "export const secret = true;")
+            .expect("outside module");
+        std::fs::write(
+            dependency.join("index.js"),
+            "export { secret } from '../secret.js';",
+        )
+        .expect("dependency entry");
+
+        let application = application.canonicalize().expect("application root");
+        let dependency = dependency.canonicalize().expect("dependency root");
+        let mut dependencies = BTreeMap::new();
+        dependencies.insert(
+            "third-party".to_owned(),
+            MaterializedDependency {
+                entry: dependency.join("index.js"),
+                root: dependency,
+            },
+        );
+        let lease = runtime
+            .app_modules
+            .register_with_dependencies(application.clone(), dependencies);
+        let generation = lease.generation();
+        let error = runtime
+            .load_source_with_lease(
+                &format!("{}/main.js?v={generation}", application.display()),
+                "import 'third-party'; export default class Panel {}",
+                Some(lease),
+                None,
+            )
+            .expect_err("dependency traversal must be refused");
+
+        assert!(error.to_string().contains("outside"), "{error:#}");
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn loading_an_application_fetches_its_manifest_git_dependencies() {
+        let root =
+            std::env::temp_dir().join(format!("gpui-shell-fetch-module-{}", std::process::id()));
+        let application = root.join("application");
+        let remote = root.join("remote");
+        let cache = root.join("cache");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&application).expect("application directory");
+        std::fs::create_dir_all(&remote).expect("remote directory");
+        let git = |arguments: &[&str]| {
+            let output = Command::new("git")
+                .args(arguments)
+                .current_dir(&remote)
+                .output()
+                .expect("git fixture command");
+            assert!(
+                output.status.success(),
+                "git {} failed: {}",
+                arguments.join(" "),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&["init", "--initial-branch=main"]);
+        git(&["config", "user.name", "gpui-shell test"]);
+        git(&["config", "user.email", "gpui-shell@example.invalid"]);
+        std::fs::write(
+            remote.join("index.js"),
+            "export const label = 'downloaded';",
+        )
+        .expect("dependency source");
+        git(&["add", "index.js"]);
+        git(&["commit", "-m", "dependency"]);
+
+        std::fs::write(
+            application.join(crate::plugin::MANIFEST_FILE),
+            format!(
+                r#"{{
+                    "id": "com.example.fetch",
+                    "name": "Fetch",
+                    "entry": "main.js",
+                    "dependencies": {{
+                        "omarchy-ui": {{ "git": {}, "branch": "main" }}
+                    }}
+                }}"#,
+                serde_json::to_string(&remote).expect("remote path")
+            ),
+        )
+        .expect("application manifest");
+        std::fs::write(
+            application.join("main.js"),
+            "import { label } from 'omarchy-ui'; export default class Panel { static label() { return label; } }",
+        )
+        .expect("application source");
+
+        let runtime =
+            ShellRuntime::new_isolated_with_dependency_store(GitDependencyStore::new(cache))
+                .expect("runtime");
+        let view_type = runtime
+            .load_app(&application, "main.js")
+            .expect("application load");
+        let label = runtime
+            .with_js(|ctx| {
+                let class = view_type.value.clone().restore(ctx)?;
+                let label: rquickjs::Function = class.get("label")?;
+                label.call::<_, String>(())
+            })
+            .expect("dependency export");
+        assert_eq!(label, "downloaded");
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/crates/shell/src/engine/quickjs/mod.rs
+++ b/crates/shell/src/engine/quickjs/mod.rs
@@ -577,7 +577,7 @@ impl ShellRuntime {
     /// call frame rather than in runtime-global state. Use this only when a host
     /// deliberately owns multiple isolated runtimes.
     pub fn new_isolated() -> Result<Rc<Self>> {
-        Self::new_isolated_with_dependency_store(GitDependencyStore::for_user())
+        Self::new_isolated_with_dependency_store(GitDependencyStore::for_user()?)
     }
 
     fn new_isolated_with_dependency_store(

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -56,6 +56,7 @@ pub(crate) mod a11y;
 pub mod action;
 pub(crate) mod assets;
 pub(crate) mod capability;
+pub(crate) mod dependencies;
 pub mod dock;
 pub(crate) mod engine;
 pub(crate) mod entities;

--- a/crates/shell/src/plugin.rs
+++ b/crates/shell/src/plugin.rs
@@ -2029,14 +2029,14 @@ mod tests {
     }
 
     #[test]
-    fn a_manifest_accepts_a_git_dependency_pinned_to_a_branch() {
+    fn a_manifest_accepts_the_omarchy_ui_https_remote_without_dot_git() {
         let source = r#"{
             "id": "com.example.third-party-ui",
             "name": "Third-party UI",
             "entry": "main.js",
             "dependencies": {
                 "omarchy-ui": {
-                    "git": "https://github.com/example/omarchy-ui.git",
+                    "git": "https://github.com/huacnlee/omarchy-ui",
                     "branch": "main"
                 }
             }
@@ -2045,10 +2045,7 @@ mod tests {
         let manifest =
             PluginManifest::parse(source).expect("a branch-pinned Git dependency should parse");
         let dependency = &manifest.dependencies()["omarchy-ui"];
-        assert_eq!(
-            dependency.git(),
-            "https://github.com/example/omarchy-ui.git"
-        );
+        assert_eq!(dependency.git(), "https://github.com/huacnlee/omarchy-ui");
         assert_eq!(dependency.branch(), Some("main"));
         assert_eq!(dependency.tag(), None);
         assert_eq!(dependency.entry(), "index.js");

--- a/crates/shell/src/plugin.rs
+++ b/crates/shell/src/plugin.rs
@@ -8,8 +8,9 @@
 //! answerable **before** the plugin's code runs.
 //!
 //! That is the whole reason a manifest exists, and it is why the manifest has
-//! six recognized fields: `id`, `name`, `version`, `shell-version`, `entry`,
-//! and `capabilities`. `version`, `shell-version`, and `capabilities` are
+//! seven recognized fields: `id`, `name`, `version`, `shell-version`, `entry`,
+//! `dependencies`, and `capabilities`. `version`, `shell-version`,
+//! `dependencies`, and `capabilities` are
 //! optional. Commands, panels, keybindings, settings and themes are
 //! registered from script instead of being declared here a second time —
 //! *capabilities are permission, contributions are behavior*. A permission has
@@ -82,7 +83,43 @@ pub struct PluginManifest {
     version: String,
     shell_version: String,
     entry: String,
+    dependencies: BTreeMap<String, GitDependency>,
     capabilities: CapabilitiesFile,
+}
+
+/// One JavaScript package fetched from Git before an application starts.
+#[derive(Clone, Debug, PartialEq, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GitDependency {
+    git: String,
+    #[serde(default)]
+    branch: Option<String>,
+    #[serde(default)]
+    tag: Option<String>,
+    #[serde(default = "default_dependency_entry")]
+    entry: String,
+}
+
+fn default_dependency_entry() -> String {
+    "index.js".to_owned()
+}
+
+impl GitDependency {
+    pub fn git(&self) -> &str {
+        &self.git
+    }
+
+    pub fn branch(&self) -> Option<&str> {
+        self.branch.as_deref()
+    }
+
+    pub fn tag(&self) -> Option<&str> {
+        self.tag.as_deref()
+    }
+
+    pub fn entry(&self) -> &str {
+        &self.entry
+    }
 }
 
 impl PluginManifest {
@@ -156,6 +193,12 @@ impl PluginManifest {
         };
         let entry = string_field(&fields, "entry")?;
         validate_entry(&entry)?;
+        let dependencies = match fields.get("dependencies") {
+            None | Some(serde_json::Value::Null) => BTreeMap::new(),
+            Some(value) => serde_json::from_value::<BTreeMap<String, GitDependency>>(value.clone())
+                .map_err(|error| ManifestProblem::Dependencies(error.to_string()))?,
+        };
+        validate_dependencies(&dependencies)?;
 
         // An omitted `capabilities` has the one permission default that cannot
         // be an accident: absent means the empty grant
@@ -176,6 +219,7 @@ impl PluginManifest {
             version,
             shell_version,
             entry,
+            dependencies,
             capabilities,
         })
     }
@@ -209,6 +253,11 @@ impl PluginManifest {
         &self.entry
     }
 
+    /// Git-backed packages available to JavaScript as bare module imports.
+    pub fn dependencies(&self) -> &BTreeMap<String, GitDependency> {
+        &self.dependencies
+    }
+
     /// The grant this manifest asks for, resolved against the two directories
     /// only the host knows.
     ///
@@ -225,14 +274,83 @@ impl PluginManifest {
     }
 }
 
-const FIELDS: [&str; 6] = [
+const FIELDS: [&str; 7] = [
     "id",
     "name",
     "version",
     "shell-version",
     "entry",
+    "dependencies",
     "capabilities",
 ];
+
+fn validate_dependencies(
+    dependencies: &BTreeMap<String, GitDependency>,
+) -> Result<(), ManifestProblem> {
+    for (name, dependency) in dependencies {
+        if name.is_empty()
+            || name.starts_with(['.', '/'])
+            || name.contains(['\\', ':'])
+            || name.split('/').any(|part| part.is_empty() || part == "..")
+        {
+            return Err(ManifestProblem::Dependencies(format!(
+                "`{name}` is not a valid bare module name"
+            )));
+        }
+        if crate::host_modules::RESERVED_SPECIFIERS.contains(&name.as_str()) {
+            return Err(ManifestProblem::Dependencies(format!(
+                "`{name}` is reserved by gpui-shell and cannot name a Git dependency"
+            )));
+        }
+        if dependency.git.trim().is_empty() {
+            return Err(ManifestProblem::Dependencies(format!(
+                "`{name}.git` must not be empty"
+            )));
+        }
+        let reference = match (&dependency.branch, &dependency.tag) {
+            (Some(branch), None) if !branch.trim().is_empty() => branch,
+            (None, Some(tag)) if !tag.trim().is_empty() => tag,
+            (Some(_), Some(_)) => {
+                return Err(ManifestProblem::Dependencies(format!(
+                    "`{name}` must select either `branch` or `tag`, not both"
+                )));
+            }
+            _ => {
+                return Err(ManifestProblem::Dependencies(format!(
+                    "`{name}` must select one non-empty `branch` or `tag`"
+                )));
+            }
+        };
+        if !valid_git_ref_name(reference) {
+            return Err(ManifestProblem::Dependencies(format!(
+                "`{name}` selector `{reference}` is not a valid Git ref name"
+            )));
+        }
+        validate_entry(&dependency.entry).map_err(|_| {
+            ManifestProblem::Dependencies(format!(
+                "`{name}.entry` must be a path inside the Git repository"
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn valid_git_ref_name(reference: &str) -> bool {
+    reference != "@"
+        && !reference.starts_with(['.', '/'])
+        && !reference.ends_with(['.', '/'])
+        && !reference.contains("..")
+        && !reference.contains("@{")
+        && !reference.contains("//")
+        && !reference.chars().any(|character| {
+            character.is_control()
+                || character.is_whitespace()
+                || matches!(character, '~' | '^' | ':' | '?' | '*' | '[' | '\\')
+        })
+        && reference.split('/').all(|component| {
+            !component.is_empty() && !component.starts_with('.') && !component.ends_with(".lock")
+        })
+}
 
 fn string_field(
     fields: &serde_json::Map<String, serde_json::Value>,
@@ -403,6 +521,9 @@ struct ManifestFile {
     shell_version: Option<String>,
     /// The module evaluated at load, relative to the plugin directory.
     entry: String,
+    /// Git-backed packages imported by their map key from JavaScript.
+    #[serde(default)]
+    dependencies: BTreeMap<String, GitDependency>,
     /// What the plugin is allowed to do. Absent means nothing but its own
     /// storage — see [`CapabilitiesFile::storage`].
     #[serde(default)]
@@ -773,6 +894,7 @@ pub enum ManifestProblem {
         placeholder: String,
     },
     Capabilities(String),
+    Dependencies(String),
 }
 
 /// What each field is for, in one line, appended to the error that reports it
@@ -867,6 +989,10 @@ impl std::fmt::Display for ManifestProblem {
             ManifestProblem::Capabilities(error) => write!(
                 f,
                 "invalid `capabilities`: {error}. The block accepts fs (read, write, execute), network (hosts, http), storage, clipboard (read, write) and process (exit)"
+            ),
+            ManifestProblem::Dependencies(error) => write!(
+                f,
+                "invalid `dependencies`: {error}. Each package needs a Git URL, exactly one non-empty `branch` or `tag`, and an optional repository-relative `entry`"
             ),
         }
     }
@@ -1903,6 +2029,129 @@ mod tests {
     }
 
     #[test]
+    fn a_manifest_accepts_a_git_dependency_pinned_to_a_branch() {
+        let source = r#"{
+            "id": "com.example.third-party-ui",
+            "name": "Third-party UI",
+            "entry": "main.js",
+            "dependencies": {
+                "omarchy-ui": {
+                    "git": "https://github.com/example/omarchy-ui.git",
+                    "branch": "main"
+                }
+            }
+        }"#;
+
+        let manifest =
+            PluginManifest::parse(source).expect("a branch-pinned Git dependency should parse");
+        let dependency = &manifest.dependencies()["omarchy-ui"];
+        assert_eq!(
+            dependency.git(),
+            "https://github.com/example/omarchy-ui.git"
+        );
+        assert_eq!(dependency.branch(), Some("main"));
+        assert_eq!(dependency.tag(), None);
+        assert_eq!(dependency.entry(), "index.js");
+    }
+
+    #[test]
+    fn a_manifest_accepts_a_git_dependency_pinned_to_a_tag() {
+        let source = r#"{
+            "id": "com.example.third-party-ui",
+            "name": "Third-party UI",
+            "entry": "main.js",
+            "dependencies": {
+                "omarchy-ui": {
+                    "git": "ssh://git@example.com/omarchy-ui.git",
+                    "tag": "v1.2.0",
+                    "entry": "src/public.js"
+                }
+            }
+        }"#;
+
+        let manifest =
+            PluginManifest::parse(source).expect("a tag-pinned Git dependency should parse");
+        let dependency = &manifest.dependencies()["omarchy-ui"];
+        assert_eq!(dependency.branch(), None);
+        assert_eq!(dependency.tag(), Some("v1.2.0"));
+        assert_eq!(dependency.entry(), "src/public.js");
+    }
+
+    #[test]
+    fn a_git_dependency_cannot_select_a_branch_and_a_tag() {
+        let source = r#"{
+            "id": "com.example.third-party-ui",
+            "name": "Third-party UI",
+            "entry": "main.js",
+            "dependencies": {
+                "omarchy-ui": {
+                    "git": "https://github.com/example/omarchy-ui.git",
+                    "branch": "main",
+                    "tag": "v1.2.0"
+                }
+            }
+        }"#;
+
+        let error = PluginManifest::parse(source).expect_err("the ref is ambiguous");
+        assert!(error.to_string().contains("either `branch` or `tag`"));
+    }
+
+    #[test]
+    fn a_git_dependency_entry_cannot_escape_its_checkout() {
+        let source = r#"{
+            "id": "com.example.third-party-ui",
+            "name": "Third-party UI",
+            "entry": "main.js",
+            "dependencies": {
+                "omarchy-ui": {
+                    "git": "https://github.com/example/omarchy-ui.git",
+                    "tag": "v1.2.0",
+                    "entry": "../private.js"
+                }
+            }
+        }"#;
+
+        let error = PluginManifest::parse(source).expect_err("the entry escapes the checkout");
+        assert!(error.to_string().contains("path inside the Git repository"));
+    }
+
+    #[test]
+    fn a_git_dependency_cannot_use_a_runtime_module_name() {
+        let source = r#"{
+            "id": "com.example.shadow",
+            "name": "Shadow",
+            "entry": "main.js",
+            "dependencies": {
+                "gpui": {
+                    "git": "https://github.com/example/not-gpui.git",
+                    "branch": "main"
+                }
+            }
+        }"#;
+
+        let error = PluginManifest::parse(source).expect_err("the dependency is unreachable");
+        assert!(error.to_string().contains("reserved by gpui-shell"));
+    }
+
+    #[test]
+    fn a_git_dependency_rejects_refspec_syntax_in_a_branch() {
+        let source = r#"{
+            "id": "com.example.refspec",
+            "name": "Refspec",
+            "entry": "main.js",
+            "dependencies": {
+                "omarchy-ui": {
+                    "git": "https://github.com/example/omarchy-ui.git",
+                    "branch": "main:refs/heads/injected"
+                }
+            }
+        }"#;
+
+        let error = PluginManifest::parse(source).expect_err("a selector is not a refspec");
+        assert!(error.to_string().contains("valid Git ref name"));
+    }
+
+    #[test]
     fn shell_version_is_declared_in_the_manifest_before_script_runs() {
         let manifest = PluginManifest::parse(VALID)
             .expect("the runtime version belongs in inert manifest metadata");
@@ -2333,6 +2582,7 @@ mod tests {
             parsed.shell_version
         );
         assert_eq!(described.entry, parsed.entry);
+        assert_eq!(described.dependencies, parsed.dependencies);
         assert_eq!(described.capabilities, parsed.capabilities);
     }
 

--- a/crates/shell/src/plugin.rs
+++ b/crates/shell/src/plugin.rs
@@ -89,8 +89,27 @@ pub struct PluginManifest {
 
 /// One JavaScript package fetched from Git before an application starts.
 #[derive(Clone, Debug, PartialEq, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
+#[serde(try_from = "GitDependencyFile")]
+#[schemars(with = "GitDependencyFile")]
 pub struct GitDependency {
+    git: String,
+    branch: Option<String>,
+    tag: Option<String>,
+    entry: String,
+    reference: Option<String>,
+    package_entry: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum GitDependencyFile {
+    Shorthand(String),
+    Object(GitDependencyObject),
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct GitDependencyObject {
     git: String,
     #[serde(default)]
     branch: Option<String>,
@@ -102,6 +121,100 @@ pub struct GitDependency {
 
 fn default_dependency_entry() -> String {
     "index.js".to_owned()
+}
+
+impl TryFrom<GitDependencyFile> for GitDependency {
+    type Error = String;
+
+    fn try_from(value: GitDependencyFile) -> Result<Self, Self::Error> {
+        match value {
+            GitDependencyFile::Object(object) => Ok(Self {
+                git: object.git,
+                branch: object.branch,
+                tag: object.tag,
+                entry: object.entry,
+                reference: None,
+                package_entry: false,
+            }),
+            GitDependencyFile::Shorthand(source) => {
+                let (git, reference) = parse_git_dependency_string(&source)?;
+                Ok(Self {
+                    git,
+                    branch: None,
+                    tag: None,
+                    entry: default_dependency_entry(),
+                    reference,
+                    package_entry: true,
+                })
+            }
+        }
+    }
+}
+
+fn parse_git_dependency_string(source: &str) -> Result<(String, Option<String>), String> {
+    if source.trim() != source || source.is_empty() || source.matches('#').count() > 1 {
+        return Err(
+            "a string dependency must be a Git URL or GitHub owner/repository with one optional #Git ref"
+                .to_owned(),
+        );
+    }
+    let (remote, fragment) = match source.split_once('#') {
+        Some((_remote, "")) => {
+            return Err("a string dependency #Git ref must not be empty".to_owned());
+        }
+        Some((remote, reference)) => (remote, Some(reference)),
+        None => (source, None),
+    };
+    if let Some(reference) = fragment
+        && !valid_git_ref_name(reference)
+    {
+        return Err(format!(
+            "string dependency selector `{reference}` is not a valid Git ref"
+        ));
+    }
+
+    if remote.contains("://") || looks_like_scp_git_url(remote) {
+        if remote.chars().any(char::is_whitespace)
+            || remote.ends_with("://")
+            || remote.starts_with("://")
+        {
+            return Err("a string dependency must contain a valid Git URL".to_owned());
+        }
+        return Ok((remote.to_owned(), fragment.map(str::to_owned)));
+    }
+
+    let mut components = remote.split('/');
+    let owner = components.next().unwrap_or_default();
+    let repository = components.next().unwrap_or_default();
+    if components.next().is_some()
+        || !valid_github_component(owner)
+        || !valid_github_component(repository)
+    {
+        return Err(
+            "GitHub shorthand must contain exactly owner/repository plus an optional #Git ref"
+                .to_owned(),
+        );
+    }
+    Ok((
+        format!("https://github.com/{owner}/{repository}"),
+        Some(fragment.unwrap_or("main").to_owned()),
+    ))
+}
+
+fn looks_like_scp_git_url(remote: &str) -> bool {
+    let Some((authority, path)) = remote.split_once(':') else {
+        return false;
+    };
+    authority.contains('@') && !authority.contains('/') && path.contains('/') && !path.is_empty()
+}
+
+fn valid_github_component(component: &str) -> bool {
+    !component.is_empty()
+        && component != "."
+        && component != ".."
+        && component
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
 }
 
 impl GitDependency {
@@ -119,6 +232,14 @@ impl GitDependency {
 
     pub fn entry(&self) -> &str {
         &self.entry
+    }
+
+    pub(crate) fn reference(&self) -> Option<&str> {
+        self.reference.as_deref()
+    }
+
+    pub(crate) fn uses_package_entry(&self) -> bool {
+        self.package_entry
     }
 }
 
@@ -306,6 +427,16 @@ fn validate_dependencies(
             return Err(ManifestProblem::Dependencies(format!(
                 "`{name}.git` must not be empty"
             )));
+        }
+        if dependency.uses_package_entry() {
+            if let Some(reference) = dependency.reference()
+                && !valid_git_ref_name(reference)
+            {
+                return Err(ManifestProblem::Dependencies(format!(
+                    "`{name}` selector `{reference}` is not a valid Git ref"
+                )));
+            }
+            continue;
         }
         let reference = match (&dependency.branch, &dependency.tag) {
             (Some(branch), None) if !branch.trim().is_empty() => branch,
@@ -992,7 +1123,7 @@ impl std::fmt::Display for ManifestProblem {
             ),
             ManifestProblem::Dependencies(error) => write!(
                 f,
-                "invalid `dependencies`: {error}. Each package needs a Git URL, exactly one non-empty `branch` or `tag`, and an optional repository-relative `entry`"
+                "invalid `dependencies`: {error}. Use a GitHub owner/repository shorthand or full Git URL with an optional #ref, or an object with a Git URL, exactly one non-empty `branch` or `tag`, and an optional repository-relative `entry`"
             ),
         }
     }
@@ -2049,6 +2180,128 @@ mod tests {
         assert_eq!(dependency.branch(), Some("main"));
         assert_eq!(dependency.tag(), None);
         assert_eq!(dependency.entry(), "index.js");
+    }
+
+    #[test]
+    fn a_manifest_accepts_git_dependency_strings() {
+        for (source, expected_git, expected_reference) in [
+            (
+                "https://github.com/huacnlee/omarchy-ui#main",
+                "https://github.com/huacnlee/omarchy-ui",
+                Some("main"),
+            ),
+            (
+                "https://github.com/huacnlee/omarchy-ui#v1.2.0",
+                "https://github.com/huacnlee/omarchy-ui",
+                Some("v1.2.0"),
+            ),
+            (
+                "https://github.com/huacnlee/omarchy-ui#0123456789abcdef0123456789abcdef01234567",
+                "https://github.com/huacnlee/omarchy-ui",
+                Some("0123456789abcdef0123456789abcdef01234567"),
+            ),
+            (
+                "https://github.com/huacnlee/omarchy-ui",
+                "https://github.com/huacnlee/omarchy-ui",
+                None,
+            ),
+        ] {
+            let manifest = PluginManifest::parse(&format!(
+                r#"{{
+                    "id": "com.example.third-party-ui",
+                    "name": "Third-party UI",
+                    "entry": "main.js",
+                    "dependencies": {{ "omarchy-ui": {} }}
+                }}"#,
+                serde_json::to_string(source).expect("dependency as JSON")
+            ))
+            .expect("a Git dependency string should parse");
+            let dependency = &manifest.dependencies()["omarchy-ui"];
+
+            assert_eq!(dependency.git(), expected_git);
+            assert_eq!(dependency.reference(), expected_reference);
+            assert!(dependency.uses_package_entry());
+        }
+    }
+
+    #[test]
+    fn github_shorthand_expands_to_an_https_remote_and_defaults_to_main() {
+        for (source, expected_reference) in [
+            ("huacnlee/omarchy-ui", "main"),
+            ("huacnlee/omarchy-ui#stable", "stable"),
+        ] {
+            let manifest = PluginManifest::parse(&format!(
+                r#"{{
+                    "id": "com.example.third-party-ui",
+                    "name": "Third-party UI",
+                    "entry": "main.js",
+                    "dependencies": {{ "omarchy-ui": {} }}
+                }}"#,
+                serde_json::to_string(source).expect("dependency as JSON")
+            ))
+            .expect("strict GitHub shorthand should parse");
+            let dependency = &manifest.dependencies()["omarchy-ui"];
+
+            assert_eq!(dependency.git(), "https://github.com/huacnlee/omarchy-ui");
+            assert_eq!(dependency.reference(), Some(expected_reference));
+            assert!(dependency.uses_package_entry());
+        }
+    }
+
+    #[test]
+    fn malformed_or_ambiguous_git_dependency_strings_are_rejected() {
+        for source in [
+            "huacnlee",
+            "/omarchy-ui",
+            "huacnlee/",
+            "huacnlee/omarchy-ui/extra",
+            "huacnlee//omarchy-ui",
+            "huacnlee/omarchy-ui#",
+            "https://github.com/huacnlee/omarchy-ui#",
+            "not a git dependency",
+        ] {
+            let error = PluginManifest::parse(&format!(
+                r#"{{
+                    "id": "com.example.third-party-ui",
+                    "name": "Third-party UI",
+                    "entry": "main.js",
+                    "dependencies": {{ "omarchy-ui": {} }}
+                }}"#,
+                serde_json::to_string(source).expect("dependency as JSON")
+            ))
+            .expect_err("malformed string syntax must not select an unintended repository");
+
+            assert!(
+                error.to_string().contains("Git URL")
+                    || error.to_string().contains("owner/repository")
+                    || error.to_string().contains("Git ref"),
+                "`{source}` produced an unclear error: {error:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn object_git_dependencies_keep_their_explicit_selector_and_entry_contract() {
+        let source = r#"{
+            "id": "com.example.third-party-ui",
+            "name": "Third-party UI",
+            "entry": "main.js",
+            "dependencies": {
+                "omarchy-ui": {
+                    "git": "https://github.com/huacnlee/omarchy-ui",
+                    "tag": "v1.2.0",
+                    "entry": "src/public.js"
+                }
+            }
+        }"#;
+
+        let manifest = PluginManifest::parse(source).expect("the legacy object form should parse");
+        let dependency = &manifest.dependencies()["omarchy-ui"];
+
+        assert_eq!(dependency.branch(), None);
+        assert_eq!(dependency.tag(), Some("v1.2.0"));
+        assert_eq!(dependency.entry(), "src/public.js");
+        assert!(!dependency.uses_package_entry());
     }
 
     #[test]

--- a/docs/gpui-shell.md
+++ b/docs/gpui-shell.md
@@ -2766,8 +2766,8 @@ does, because the shape is what the design is about.
 
 ### 18.1 The manifest
 
-Six recognized fields: `id`, `name`, `version`, `shell-version`, `entry`, and
-`capabilities`. Only `id`, `name`, and `entry` are required. An omitted
+Seven recognized fields: `id`, `name`, `version`, `shell-version`, `entry`,
+`dependencies`, and `capabilities`. Only `id`, `name`, and `entry` are required. An omitted
 `version` is reported as `unknown`; an omitted `shell-version` accepts the
 current runtime; omitted `capabilities` grants nothing. The file is
 `gpui-shell.json` — the name makes the owning runtime explicit.
@@ -2779,6 +2779,12 @@ current runtime; omitted `capabilities` grants nothing. The file is
   "version": "1.2.0",
   "shell-version": "0.1.0",
   "entry": "main.js",
+  "dependencies": {
+    "omarchy-ui": {
+      "git": "https://github.com/example/omarchy-ui.git",
+      "tag": "v1.2.0"
+    }
+  },
   "capabilities": {
     "fs": {
       "read": ["${pluginDir}", "${dataDir}"],
@@ -2800,6 +2806,19 @@ current runtime; omitted `capabilities` grants nothing. The file is
   }
 }
 ```
+
+`dependencies` maps a bare JavaScript module name to a Git repository and
+exactly one `branch` or `tag`. The optional repository-relative `entry`
+defaults to `index.js`. Before linking the application module graph, the host
+fetches each repository into `<data home>/gpui-shell/dependencies/git/`. Git is
+non-interactive and each command has a 30-second timeout. A per-remote lock
+serializes mirror updates; the fetched commit is then atomically published as
+an immutable, commit-addressed checkout and registered with the same module
+generation as the application. A branch refreshes on every load; a tag resolves
+to the tagged commit. Relative imports from dependency code remain inside its
+own checkout, and runtime or Standard Runtime module names cannot be shadowed.
+This host-side acquisition step requires `git`; it does not grant the fetched
+script any network capability.
 
 `network.hosts` is the backwards-compatible broad grant: every supported
 network API may reach that host. Use `network.http` when a plugin only needs

--- a/docs/gpui-shell.md
+++ b/docs/gpui-shell.md
@@ -2810,8 +2810,9 @@ current runtime; omitted `capabilities` grants nothing. The file is
 `dependencies` maps a bare JavaScript module name to a Git repository and
 exactly one `branch` or `tag`. The optional repository-relative `entry`
 defaults to `index.js`. Before linking the application module graph, the host
-fetches each repository into `<data home>/gpui-shell/dependencies/git/`. Git is
-non-interactive and each command has a 30-second timeout. A per-remote lock
+fetches each repository into `~/.gpui-shell/cache/dependencies/`. No
+`node_modules` directory participates. Git is non-interactive and each command
+has a 30-second timeout. A per-remote lock
 serializes mirror updates; the fetched commit is then atomically published as
 an immutable, commit-addressed checkout and registered with the same module
 generation as the application. A branch refreshes on every load; a tag resolves

--- a/docs/gpui-shell.md
+++ b/docs/gpui-shell.md
@@ -62,7 +62,7 @@ a scripting language while keeping Rust and the GPU on the render path.
 ### 1.1 Standard Runtime installation and removal
 
 The Standard Runtime is built into `gpui-shell`; a script application does not
-install LLRT, Node.js, npm packages, or a second VM. A Rust host enables it by
+install LLRT, Node.js, external package tooling, or a second VM. A Rust host enables it by
 depending on and initializing GPUI Shell:
 
 ```toml
@@ -91,8 +91,8 @@ import { connect } from "net";
 ```
 
 There are deliberately no `node:` aliases and no claim of Node.js
-compatibility. Unknown bare imports remain errors; npm/package resolution is
-not installed.
+compatibility. Unknown bare imports remain errors; only built-in modules and
+manifest-declared Git dependencies are resolved.
 
 | Surface | Implementation and authority |
 | --- | --- |
@@ -147,7 +147,7 @@ is the best-covered language in public training data, and its type declarations
 (§14.4) are a format both editors and models already read.
 
 The same coverage is also a liability: a model writing for this runtime will
-reach for `document`, full browser `fetch`, `require("fs")`, npm packages, and
+reach for `document`, full browser `fetch`, `require("fs")`, ecosystem packages, and
 `setTimeout`. Only the documented Standard Runtime subset exists. §19.1 answers
 unsupported callable globals with named stubs and rejects unknown modules,
 rather than silently pretending broad compatibility.
@@ -198,7 +198,7 @@ Seven things are deliberately absent, and will stay absent:
    `dlopen`ed native code inside the process defeats the sandbox outright.
 6. **`gpui-base` is not modified.** Everything lives in `crates/shell`.
 7. **There is no Node.js or browser compatibility layer.** There is no DOM,
-   CommonJS `require`, Node module resolution, npm, or `node:` namespace. The
+   CommonJS `require`, general Node module resolution, or `node:` namespace. The
    Standard Runtime deliberately exposes selected bare modules plus a
    WinterCG-style `fetch`; those individual APIs do not imply browser or Node.js
    compatibility. The shell's narrow `window` and `process` globals expose only
@@ -2780,10 +2780,7 @@ current runtime; omitted `capabilities` grants nothing. The file is
   "shell-version": "0.1.0",
   "entry": "main.js",
   "dependencies": {
-    "omarchy-ui": {
-      "git": "https://github.com/example/omarchy-ui.git",
-      "tag": "v1.2.0"
-    }
+    "omarchy-ui": "huacnlee/omarchy-ui#main"
   },
   "capabilities": {
     "fs": {
@@ -2807,17 +2804,34 @@ current runtime; omitted `capabilities` grants nothing. The file is
 }
 ```
 
-`dependencies` maps a bare JavaScript module name to a Git repository and
-exactly one `branch` or `tag`. The optional repository-relative `entry`
-defaults to `index.js`. Before linking the application module graph, the host
-fetches each repository into `~/.gpui-shell/cache/dependencies/`. No
-`node_modules` directory participates. Git is non-interactive and each command
-has a 30-second timeout. A per-remote lock
-serializes mirror updates; the fetched commit is then atomically published as
-an immutable, commit-addressed checkout and registered with the same module
-generation as the application. A branch refreshes on every load; a tag resolves
-to the tagged commit. Relative imports from dependency code remain inside its
-own checkout, and runtime or Standard Runtime module names cannot be shadowed.
+`dependencies` maps a bare JavaScript module name to gpui-shell Git dependency
+syntax. A string may be strict GitHub shorthand (`owner/repository` or
+`owner/repository#ref`) or a full Git URL with optional `#ref`. GitHub shorthand
+without a fragment selects `main`; a full URL without one selects the remote's
+HEAD. A ref may name a branch, tag, or commit-ish such as a commit ID. Branches,
+tags, and remote HEAD are fetched and resolved on each load; a commit ID keeps
+selecting that exact commit.
+
+Once the immutable checkout exists, gpui-shell reads its root `package.json`.
+A string `main` selects the entry; if the file or field is absent, `index.js` is
+used. Invalid JSON, a non-string `main`, or a path that is missing, not a file,
+or outside the checkout fails the load before application code executes.
+
+The original object form remains supported unchanged. It requires exactly one
+explicit `branch` or `tag`, and its optional repository-relative `entry`
+defaults to `index.js`. Existing manifests need no migration. Authors choosing
+the string form publish their entry through `package.json` `main` or root
+`index.js`.
+
+Before linking the application module graph, the host fetches each repository
+into `~/.gpui-shell/cache/dependencies/`. A per-remote lock serializes local
+mirror updates; the fetched commit is atomically published as an immutable,
+commit-addressed checkout and registered with the application's module
+generation. The exact fragment-free URL is the remote and cache identity. The
+raw configured origin is verified, while Git's `url.*.insteadOf` rules may
+still choose the effective fetch URL. Git is non-interactive and each command
+has a 30-second timeout. Relative imports from dependency code remain inside
+its checkout, and runtime or Standard Runtime module names cannot be shadowed.
 This host-side acquisition step requires `git`; it does not grant the fetched
 script any network capability.
 
@@ -4108,7 +4122,7 @@ number must mean the same capabilities and the same behavior under either engine
 No packaging or distribution format exists. The intended one is the simplest
 thing that works — a `.tar.zst` plus an `index.json`, hosted on any static file
 server or git repository, installed by URL with a signature and checksum check,
-carrying pure script source with no build output and no `node_modules`. Building
+carrying pure script source with no generated dependency tree. Building
 a registry service before the plugin count justifies one would be pure
 liability.
 
@@ -4123,7 +4137,7 @@ reopened without new information.
 | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **A second engine (LuaJIT and similar)**               | Removed rather than carried. A fallback nobody exercises rots, and this one had: no `svg`, `Input`, `InputState`, state styles, `accessibility_label`, scheduler, host API, sandbox, or overlays. The seam it justified is kept, because it is what makes the rest of the crate name no VM |
 | **The WASM component model**                           | Every call crosses a serialization boundary, which is the worst possible fit for high-frequency fine-grained UI calls. Heavy toolchain, poor debugging                                                                                                                                     |
-| **Embedding Node.js or Deno**                          | The process model and the size do not match an in-process, main-thread, embedded runtime. Bringing npm in brings native dependencies and a supply chain with it. VS Code's approach requires a separate extension process to work at all                                                   |
+| **Embedding Node.js or Deno**                          | The process model, native dependency surface, and size do not match an in-process, main-thread, embedded runtime. VS Code's approach requires a separate extension process to work at all                                                                                                                       |
 | **A pure-Rust scripting language** (Rhai, Steel, Koto) | Almost no ecosystem, a new language for every author, and a thin corpus — which is disqualifying for generated interfaces                                                                                                                                                                  |
 | **Rust dylib plugins**                                 | No stable ABI, no sandbox, and the compile cost remains, so it solves none of §2.1                                                                                                                                                                                                         |
 | **Rust hot reload**                                    | Solves only the compile time. It does not address plugin distribution or third-party extension, and state preservation is fragile                                                                                                                                                          |

--- a/website/shell/capabilities.md
+++ b/website/shell/capabilities.md
@@ -95,10 +95,11 @@ A directory is recognized by **`gpui-shell.json`**. The manifest is inert data â
 ```
 
 Every Git dependency chooses exactly one non-empty `branch` or `tag`; its
-`entry` defaults to `index.js`. gpui-shell fetches dependencies into its local
-user-data cache before evaluating application code. Branches refresh on every
-load, while tags resolve to their tagged commits. Git runs non-interactively
-with a 30-second command timeout. A locked mirror publishes immutable,
+`entry` defaults to `index.js`. gpui-shell fetches dependencies into
+`~/.gpui-shell/cache/dependencies/` before evaluating application code; no
+`node_modules` directory participates. Branches refresh on every load, while
+tags resolve to their tagged commits. Git runs non-interactively with a
+30-second command timeout. A locked mirror publishes immutable,
 commit-addressed checkouts, preserving concurrent launches and older module
 generations. The dependency map key is the
 bare JavaScript module name, for example

--- a/website/shell/capabilities.md
+++ b/website/shell/capabilities.md
@@ -65,7 +65,7 @@ process.exit() is not granted; set capabilities.process.exit to true in the mani
 
 ## The manifest
 
-A directory is recognized by **`gpui-shell.json`**. The manifest is inert data â€” discovery reads identity, optional version metadata, and requested permissions without executing the entry module. It recognizes `id`, `name`, `version`, `shell-version`, `entry`, and `capabilities`; only `id`, `name`, and `entry` are required:
+A directory is recognized by **`gpui-shell.json`**. The manifest is inert data â€” discovery reads identity, optional version metadata, Git dependencies, and requested permissions without executing the entry module. It recognizes `id`, `name`, `version`, `shell-version`, `entry`, `dependencies`, and `capabilities`; only `id`, `name`, and `entry` are required:
 
 ```json
 {
@@ -74,6 +74,13 @@ A directory is recognized by **`gpui-shell.json`**. The manifest is inert data â
   "version": "1.0.0",
   "shell-version": "0.1.0",
   "entry": "main.js",
+  "dependencies": {
+    "omarchy-ui": {
+      "git": "https://github.com/example/omarchy-ui.git",
+      "branch": "main",
+      "entry": "index.js"
+    }
+  },
   "capabilities": {
     "fs": { "read": ["${pluginDir}"], "write": ["${dataDir}"] },
     "network": {
@@ -86,6 +93,18 @@ A directory is recognized by **`gpui-shell.json`**. The manifest is inert data â
   }
 }
 ```
+
+Every Git dependency chooses exactly one non-empty `branch` or `tag`; its
+`entry` defaults to `index.js`. gpui-shell fetches dependencies into its local
+user-data cache before evaluating application code. Branches refresh on every
+load, while tags resolve to their tagged commits. Git runs non-interactively
+with a 30-second command timeout. A locked mirror publishes immutable,
+commit-addressed checkouts, preserving concurrent launches and older module
+generations. The dependency map key is the
+bare JavaScript module name, for example
+`import { label, style } from "omarchy-ui"`. Package-relative imports and
+package subpath imports stay inside that checkout. Dependency fetching uses the
+host's `git` executable and is separate from script network capabilities.
 
 Every grant in that block defaults to *denied* when omitted, except `storage`, which defaults to granted â€” write `"storage": false` to refuse it.
 

--- a/website/shell/capabilities.md
+++ b/website/shell/capabilities.md
@@ -75,11 +75,7 @@ A directory is recognized by **`gpui-shell.json`**. The manifest is inert data â
   "shell-version": "0.1.0",
   "entry": "main.js",
   "dependencies": {
-    "omarchy-ui": {
-      "git": "https://github.com/example/omarchy-ui.git",
-      "branch": "main",
-      "entry": "index.js"
-    }
+    "omarchy-ui": "huacnlee/omarchy-ui"
   },
   "capabilities": {
     "fs": { "read": ["${pluginDir}"], "write": ["${dataDir}"] },
@@ -94,18 +90,59 @@ A directory is recognized by **`gpui-shell.json`**. The manifest is inert data â
 }
 ```
 
-Every Git dependency chooses exactly one non-empty `branch` or `tag`; its
-`entry` defaults to `index.js`. gpui-shell fetches dependencies into
-`~/.gpui-shell/cache/dependencies/` before evaluating application code; no
-`node_modules` directory participates. Branches refresh on every load, while
-tags resolve to their tagged commits. Git runs non-interactively with a
-30-second command timeout. A locked mirror publishes immutable,
-commit-addressed checkouts, preserving concurrent launches and older module
-generations. The dependency map key is the
-bare JavaScript module name, for example
-`import { label, style } from "omarchy-ui"`. Package-relative imports and
-package subpath imports stay inside that checkout. Dependency fetching uses the
-host's `git` executable and is separate from script network capabilities.
+The string form accepts strict GitHub shorthand or a full Git URL, each with an
+optional `#ref`:
+
+```json
+{
+  "dependencies": {
+    "default-main": "huacnlee/omarchy-ui",
+    "named-ref": "huacnlee/omarchy-ui#v1.2.0",
+    "full-url": "https://github.com/huacnlee/omarchy-ui#0123456789abcdef0123456789abcdef01234567",
+    "remote-head": "https://github.com/huacnlee/omarchy-ui"
+  }
+}
+```
+
+GitHub shorthand without `#ref` selects `main`; a full URL without `#ref`
+selects the remote's HEAD. A ref may name a branch, tag, or commit-ish such as a
+commit ID. A branch, tag, or remote HEAD is fetched and resolved on each
+application load; a commit ID continues to select that exact commit.
+
+After creating the immutable checkout, gpui-shell reads its root
+`package.json`. A string `main` names the package entry. If `package.json` or
+`main` is absent, the entry defaults to `index.js`. Malformed metadata, a
+non-string `main`, and entries that escape the checkout or do not resolve to a
+file are rejected before application JavaScript executes.
+
+The legacy object form remains fully supported. It requires exactly one
+explicit `branch` or `tag`; its optional repository-relative `entry` defaults
+to `index.js`. Existing manifests do not need to migrate. Moving to the string
+form means publishing the entry as `package.json` `main` (or root `index.js`):
+
+```json
+{
+  "dependencies": {
+    "omarchy-ui": {
+      "git": "https://github.com/huacnlee/omarchy-ui",
+      "branch": "main",
+      "entry": "src/public.js"
+    }
+  }
+}
+```
+
+gpui-shell stores dependencies below
+`~/.gpui-shell/cache/dependencies/`. Per-remote locks serialize mirror updates,
+and mirrors publish immutable, commit-addressed checkouts so concurrent loads
+and older module generations cannot rewrite one another. The exact full URL
+without its fragment is both remote and cache identity. gpui-shell verifies the
+raw configured origin while allowing Git's `url.*.insteadOf` rules to choose
+the effective fetch URL. Git runs non-interactively with a 30-second command
+timeout. The dependency map key is the bare JavaScript module name, for example
+`import { label, style } from "omarchy-ui"`; relative and package-subpath
+imports stay confined to that checkout. Fetching uses the host's `git`
+executable and is separate from script network capabilities.
 
 Every grant in that block defaults to *denied* when omitted, except `storage`, which defaults to granted â€” write `"storage": false` to refuse it.
 

--- a/website/zh-CN/shell/capabilities.md
+++ b/website/zh-CN/shell/capabilities.md
@@ -75,10 +75,7 @@ process.exit() is not granted; set capabilities.process.exit to true in the mani
   "shell-version": "0.1.0",
   "entry": "main.js",
   "dependencies": {
-    "omarchy-ui": {
-      "git": "https://github.com/example/omarchy-ui.git",
-      "branch": "main"
-    }
+    "omarchy-ui": "huacnlee/omarchy-ui"
   },
   "capabilities": {
     "fs": { "read": ["${pluginDir}"], "write": ["${dataDir}"] },
@@ -93,15 +90,53 @@ process.exit() is not granted; set capabilities.process.exit to true in the mani
 }
 ```
 
-每个 Git 依赖必须且只能选择一个非空的 `branch` 或 `tag`，`entry` 默认是
-`index.js`。gpui-shell 会在执行应用代码之前，把依赖拉取到
-`~/.gpui-shell/cache/dependencies/`；不使用任何 `node_modules` 目录。branch
-每次加载都会刷新，tag 则解析到对应的标记 commit。Git 以非交互方式运行，每条命令
-限时 30 秒；加锁的本地 mirror 会发布不可变的 commit checkout，避免并发启动或旧
-module generation 被后续刷新改写。JavaScript 以 map key 作为裸模块名导入，例如
-`import { label, style } from "omarchy-ui"`。依赖内部的相对
-import 和包 subpath import 都不能逃出该 checkout。下载使用 Host 上的 `git`，不属于
-脚本的 network capability。
+字符串形式支持严格的 GitHub 简写或完整 Git URL，两者都可以带可选的 `#ref`：
+
+```json
+{
+  "dependencies": {
+    "default-main": "huacnlee/omarchy-ui",
+    "named-ref": "huacnlee/omarchy-ui#v1.2.0",
+    "full-url": "https://github.com/huacnlee/omarchy-ui#0123456789abcdef0123456789abcdef01234567",
+    "remote-head": "https://github.com/huacnlee/omarchy-ui"
+  }
+}
+```
+
+不带 `#ref` 的 GitHub 简写默认选择 `main`；不带 `#ref` 的完整 URL 则选择远端
+HEAD。ref 可以是 branch、tag 或 commit-ish（例如 commit ID）。每次加载应用时都会
+重新 fetch 并解析 branch、tag 或远端 HEAD；commit ID 始终选择同一个 commit。
+
+创建不可变 checkout 后，gpui-shell 会读取根目录的 `package.json`。字符串类型的
+`main` 指定 package entry；没有 `package.json` 或没有 `main` 时默认使用
+`index.js`。格式错误的 metadata、非字符串 `main`、逃出 checkout 的 entry，或未
+解析到文件的 entry，都会在应用 JavaScript 执行前令加载失败。
+
+旧的 object 形式保持完全兼容：它必须显式且只指定一个 `branch` 或 `tag`，可选的
+repository-relative `entry` 仍默认是 `index.js`。现有 manifest 无需迁移；若改为
+字符串形式，则应通过 `package.json` 的 `main`（或根目录 `index.js`）发布 entry：
+
+```json
+{
+  "dependencies": {
+    "omarchy-ui": {
+      "git": "https://github.com/huacnlee/omarchy-ui",
+      "branch": "main",
+      "entry": "src/public.js"
+    }
+  }
+}
+```
+
+gpui-shell 把依赖存储在 `~/.gpui-shell/cache/dependencies/`。每个 remote 的锁会串行化
+mirror 更新；mirror 发布不可变的、按 commit 寻址的 checkout，因此并发加载和旧
+module generation 不会互相改写。去掉 fragment 后的完整 URL 同时是 remote identity
+和 cache identity。gpui-shell 会校验 raw configured origin，同时允许 Git 的
+`url.*.insteadOf` 规则选择实际 fetch URL。Git 以非交互方式运行，每条命令限时 30
+秒。JavaScript 以 map key 作为裸模块名导入，例如
+`import { label, style } from "omarchy-ui"`；依赖内部的相对 import 和 package
+subpath import 都不能逃出该 checkout。下载使用 Host 上的 `git`，不属于脚本的
+network capability。
 
 这个块里的每项授权省略时都默认**拒绝**，只有 `storage` 默认给予——要拒绝它就写 `"storage": false`。
 

--- a/website/zh-CN/shell/capabilities.md
+++ b/website/zh-CN/shell/capabilities.md
@@ -65,7 +65,7 @@ process.exit() is not granted; set capabilities.process.exit to true in the mani
 
 ## Manifest
 
-目录通过 **`gpui-shell.json`** 被识别。Manifest 是惰性数据——发现阶段只读取身份、可选版本元数据与请求的权限，不执行 entry module。它识别 `id`、`name`、`version`、`shell-version`、`entry` 与 `capabilities`；只有 `id`、`name` 和 `entry` 必填：
+目录通过 **`gpui-shell.json`** 被识别。Manifest 是惰性数据——发现阶段只读取身份、可选版本元数据、Git 依赖与请求的权限，不执行 entry module。它识别 `id`、`name`、`version`、`shell-version`、`entry`、`dependencies` 与 `capabilities`；只有 `id`、`name` 和 `entry` 必填：
 
 ```json
 {
@@ -74,6 +74,12 @@ process.exit() is not granted; set capabilities.process.exit to true in the mani
   "version": "1.0.0",
   "shell-version": "0.1.0",
   "entry": "main.js",
+  "dependencies": {
+    "omarchy-ui": {
+      "git": "https://github.com/example/omarchy-ui.git",
+      "branch": "main"
+    }
+  },
   "capabilities": {
     "fs": { "read": ["${pluginDir}"], "write": ["${dataDir}"] },
     "network": {
@@ -86,6 +92,15 @@ process.exit() is not granted; set capabilities.process.exit to true in the mani
   }
 }
 ```
+
+每个 Git 依赖必须且只能选择一个非空的 `branch` 或 `tag`，`entry` 默认是
+`index.js`。gpui-shell 会在执行应用代码之前，把依赖拉取到用户数据目录下的本地缓存；
+branch 每次加载都会刷新，tag 则解析到对应的标记 commit。Git 以非交互方式运行，每条
+命令限时 30 秒；加锁的本地 mirror 会发布不可变的 commit checkout，避免并发启动或旧
+module generation 被后续刷新改写。JavaScript 以 map key 作为裸模块名导入，例如
+`import { label, style } from "omarchy-ui"`。依赖内部的相对
+import 和包 subpath import 都不能逃出该 checkout。下载使用 Host 上的 `git`，不属于
+脚本的 network capability。
 
 这个块里的每项授权省略时都默认**拒绝**，只有 `storage` 默认给予——要拒绝它就写 `"storage": false`。
 

--- a/website/zh-CN/shell/capabilities.md
+++ b/website/zh-CN/shell/capabilities.md
@@ -94,9 +94,10 @@ process.exit() is not granted; set capabilities.process.exit to true in the mani
 ```
 
 每个 Git 依赖必须且只能选择一个非空的 `branch` 或 `tag`，`entry` 默认是
-`index.js`。gpui-shell 会在执行应用代码之前，把依赖拉取到用户数据目录下的本地缓存；
-branch 每次加载都会刷新，tag 则解析到对应的标记 commit。Git 以非交互方式运行，每条
-命令限时 30 秒；加锁的本地 mirror 会发布不可变的 commit checkout，避免并发启动或旧
+`index.js`。gpui-shell 会在执行应用代码之前，把依赖拉取到
+`~/.gpui-shell/cache/dependencies/`；不使用任何 `node_modules` 目录。branch
+每次加载都会刷新，tag 则解析到对应的标记 commit。Git 以非交互方式运行，每条命令
+限时 30 秒；加锁的本地 mirror 会发布不可变的 commit checkout，避免并发启动或旧
 module generation 被后续刷新改写。JavaScript 以 map key 作为裸模块名导入，例如
 `import { label, style } from "omarchy-ui"`。依赖内部的相对
 import 和包 subpath import 都不能逃出该 checkout。下载使用 Host 上的 `git`，不属于


### PR DESCRIPTION
## Description

Add Git-backed dependencies to GPUI Shell manifests. Applications can declare a dependency URL with exactly one `branch` or `tag`, plus an optional JavaScript entry point, and import it through bare package specifiers or package subpaths.

Dependencies are fetched when an application loads and managed in a local cache. The implementation uses verified per-remote mirrors, cross-process locking, immutable commit-addressed checkouts, atomic publication, non-interactive Git commands, and bounded timeouts. Manifest validation and module resolution prevent ambiguous refs, built-in module shadowing, and paths escaping a dependency checkout.

English and Chinese documentation now describe the manifest format and runtime behavior.

## How to Test

- `cargo fmt --all -- --check`
- `cargo clippy -p gpui-shell --all-targets -- -D warnings`
- `cargo test -p gpui-shell --lib --locked`
  - 572 passed, 0 failed, 1 ignored

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (not platform-specific).