### PR TITLE
notification: stop ticking the toast clock while nothing is mounted

### DIFF
--- a/crates/ui/src/notification.rs
+++ b/crates/ui/src/notification.rs
@@ -24,6 +24,7 @@ const NOTIFICATION_TRANSITION_DURATION: Duration = Duration::from_millis(400);
 const NOTIFICATION_EXIT_DURATION: Duration = Duration::from_millis(200);
 const NOTIFICATION_TRANSITION_OFFSET: Pixels = px(96.);
 const DEFAULT_NOTIFICATION_WIDTH: Pixels = px(382.);
+const NOTIFICATION_ADVANCE_INTERVAL: Duration = Duration::from_millis(50);
 struct DismissRequest;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -694,32 +695,51 @@ pub struct NotificationList {
     pub(crate) notifications: ToastManager<NotificationId, Entity<Notification>>,
     stacks: Vec<(Anchor, AnchorStack)>,
     focus_handle: FocusHandle,
+    /// Whether the lifecycle clock is running. The loop clears it as it exits.
+    is_advancing: bool,
     _subscriptions: HashMap<NotificationId, Subscription>,
 }
 
 impl NotificationList {
-    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let view = cx.entity().downgrade();
-        cx.spawn_in(window, async move |_, cx| {
+    pub fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
+        Self {
+            notifications: ToastManager::new(ToastMotion::sonner()),
+            stacks: Vec::new(),
+            focus_handle: cx.focus_handle().tab_stop(true),
+            is_advancing: false,
+            _subscriptions: HashMap::new(),
+        }
+    }
+
+    /// Tick the toast lifecycle until the last notification is unmounted.
+    ///
+    /// It advances the transition phases and samples the pause inputs (stack
+    /// expansion, window activation) that reach the list through no event.
+    /// With nothing mounted there is nothing to do, so an idle window arms no
+    /// timer.
+    fn start_advancing(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_advancing {
+            return;
+        }
+        self.is_advancing = true;
+        // Detached rather than kept as a `Task`: the loop ends itself, and a
+        // handle on the list would have to be dropped from inside its own future.
+        cx.spawn_in(window, async move |view, cx| {
             loop {
                 cx.background_executor()
-                    .timer(Duration::from_millis(50))
+                    .timer(NOTIFICATION_ADVANCE_INTERVAL)
                     .await;
-                if view
-                    .update_in(cx, |view, window, cx| view.advance(window, cx))
-                    .is_err()
-                {
+                let running = view.update_in(cx, |view, window, cx| {
+                    view.advance(window, cx);
+                    view.is_advancing = !view.notifications.is_empty();
+                    view.is_advancing
+                });
+                if !matches!(running, Ok(true)) {
                     break;
                 }
             }
         })
         .detach();
-        Self {
-            notifications: ToastManager::new(ToastMotion::sonner()),
-            stacks: Vec::new(),
-            focus_handle: cx.focus_handle().tab_stop(true),
-            _subscriptions: HashMap::new(),
-        }
     }
 
     fn is_expanded(&self) -> bool {
@@ -822,6 +842,7 @@ impl NotificationList {
             },
             cx.background_executor().now(),
         );
+        self.start_advancing(window, cx);
         cx.notify();
     }
 
@@ -1238,6 +1259,47 @@ mod tests {
             .advance_clock(Duration::from_millis(1));
         cx.run_until_parked();
         assert!(ids(&list, cx).is_empty());
+    }
+
+    #[gpui::test]
+    fn lifecycle_clock_runs_only_while_a_notification_is_mounted(cx: &mut TestAppContext) {
+        cx.update(|cx| cx.set_global(Theme::default()));
+        let (root, cx) = cx.add_window_view(|window, cx| TestRoot {
+            list: cx.new(|cx| NotificationList::new(window, cx)),
+            other_focus: cx.focus_handle(),
+        });
+        cx.update(|window, _| window.activate_window());
+        let list = root.read_with(cx, |root, _| root.list.clone());
+
+        // A list that has never shown anything arms no timer.
+        cx.background_executor.advance_clock(Duration::from_secs(1));
+        cx.run_until_parked();
+        assert!(!list.read_with(cx, |list, _| list.is_advancing));
+
+        list.update_in(cx, |list, window, cx| {
+            list.push(Notification::info("tick").id::<FooKind>(), window, cx);
+        });
+        assert!(list.read_with(cx, |list, _| list.is_advancing));
+
+        // Autohide expiry plus the exit transition stops the clock with it.
+        cx.background_executor
+            .advance_clock(NOTIFICATION_TRANSITION_DURATION + Duration::from_secs(5));
+        cx.run_until_parked();
+        flush_dismiss(cx);
+        assert!(ids(&list, cx).is_empty());
+        assert!(!list.read_with(cx, |list, _| list.is_advancing));
+
+        // A later notification restarts it.
+        list.update_in(cx, |list, window, cx| {
+            list.push(Notification::info("again").id::<BarKind>(), window, cx);
+        });
+        assert!(list.read_with(cx, |list, _| list.is_advancing));
+        cx.background_executor
+            .advance_clock(NOTIFICATION_TRANSITION_DURATION + Duration::from_secs(5));
+        cx.run_until_parked();
+        flush_dismiss(cx);
+        assert!(ids(&list, cx).is_empty());
+        assert!(!list.read_with(cx, |list, _| list.is_advancing));
     }
 
     #[gpui::test]


### PR DESCRIPTION
`NotificationList::new` armed a 50ms repeating timer that lived as long as the `Root` owning it, so every app paid ~20 wakeups per second for the whole process lifetime, even if a notification was never shown. `ToastManager::advance` has nothing to do in that state: it iterates an empty deque, reports no change and never notifies.

Measured with `examples/hello_world`, window open and idle for 20s: 394 main thread voluntary wakeups and 190ms of CPU, which is the 50ms tick. A downstream app profiled in Chrome DevTools showed the same shape on wasm: 44 `TimerFire` and 39 `TimerInstall` with `timeout: 50` over a 2s idle slice, with zero animation frames.

## What the clock is for

It advances mounted toasts between phases (enter completion at 400ms, autohide at 5s, unmount after the 200ms exit) and samples the two pause inputs that reach the list through no event: stack expansion (hover/focus) and window activation.

## What changed

The loop now starts from `push` and ends itself once the manager is empty. `push` is the only insertion point, and the loop only exits at an instant when nothing is mounted, so a mounted toast always has a running clock. Timing, interval and ordering are untouched, so animation and expiry behave exactly as before. No API change.

Alternatives rejected: waking on the next deadline breaks pausing, since `advance` only consumes the timeout when not paused and a single long wake would swallow a hover that started midway; driving from the render pass does not work either, because a `Present` toast waiting out its 5s produces no frames.

Trade-off: while a toast is mounted the tick stays at a fixed 50ms, precisely because hover and window activation are polled rather than evented. Turning those into events first would be a prerequisite for deadline based waking.

## Other loops

Checked every `timer(...).await` in the workspace. None of the others outlive what they animate: `auto_scroll` breaks when the delta clears, `blink_cursor` reschedules per epoch, `scrollbar`, `sidebar`, `clipboard`, `list` and the LSP paths are one shot or debounce.

## Verification

- `cargo test -p gpui-component -p gpui-base`: all green. The 15 existing notification tests pass unchanged, including bursts, manual dismiss mid animation, and pause on focus or inactive window.
- New test `lifecycle_clock_runs_only_while_a_notification_is_mounted`: a fresh list arms no timer across 1s of clock, `push` starts it, expiry stops it, a later `push` restarts it.
- `cargo clippy --workspace --all-targets` and `cargo fmt --check` clean.
- Idle `examples/hello_world` over 20s: 394 wakeups and 19 CPU ticks before, 0 and 0 after.

AI generated with Claude Code, reviewed by me.