### PR TITLE
base: Block the mouse behind an anchored popup

### DIFF
--- a/crates/base/src/popup.rs
+++ b/crates/base/src/popup.rs
@@ -136,6 +136,9 @@ impl RenderOnce for Popup {
             deferred(
                 Positioner::corner(anchor, position.get())
                     .margin(WINDOW_MARGIN)
+                    // The host blocks the mouse, so no caller has to remember:
+                    // what a popup covers belongs to the popup.
+                    .occlude()
                     .child(content),
             )
             .with_priority(POPUP_PRIORITY),
@@ -180,6 +183,74 @@ mod tests {
                     .size(px(20.)),
             )
         }
+    }
+
+    /// A caller that styles its own surface — a hover card, a dropdown — does
+    /// not have to remember to block the mouse. The host does it, so the panel
+    /// a popup covers stops reacting to a pointer that is over the popup.
+    struct OcclusionHarness {
+        background_hovered: Rc<Cell<bool>>,
+        content_hovered: Rc<Cell<bool>>,
+    }
+
+    impl Render for OcclusionHarness {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            let background = self.background_hovered.clone();
+            let content = self.content_hovered.clone();
+            div()
+                .relative()
+                .size(px(200.))
+                .child(
+                    div()
+                        .id("background")
+                        .absolute()
+                        .size_full()
+                        .on_mouse_move(move |_, _, _| background.set(true)),
+                )
+                .child(
+                    Popup::new("popup", div().size(px(100.))).content(
+                        div()
+                            .id("content")
+                            .size(px(40.))
+                            .on_mouse_move(move |_, _, _| content.set(true)),
+                    ),
+                )
+        }
+    }
+
+    #[gpui::test]
+    fn the_popup_surface_blocks_the_panel_it_covers(cx: &mut gpui::TestAppContext) {
+        let background_hovered = Rc::new(Cell::new(false));
+        let content_hovered = Rc::new(Cell::new(false));
+        let (_, window) = cx.add_window_view({
+            let background_hovered = background_hovered.clone();
+            let content_hovered = content_hovered.clone();
+            move |_, _| OcclusionHarness {
+                background_hovered,
+                content_hovered,
+            }
+        });
+        window.update(|window, cx| window.draw(cx).clear(cx));
+        window.update(|window, cx| window.draw(cx).clear(cx));
+
+        window.simulate_mouse_move(
+            gpui::point(px(20.), px(110.)),
+            None,
+            gpui::Modifiers::default(),
+        );
+        assert!(!background_hovered.get());
+        // The surface blocks what is behind it, not its own content: the
+        // hitbox goes in ahead of the children, never over them.
+        assert!(content_hovered.get());
+
+        // The same pointer outside the surface still reaches the panel, so the
+        // assertion above is about occlusion and not a dead listener.
+        window.simulate_mouse_move(
+            gpui::point(px(150.), px(180.)),
+            None,
+            gpui::Modifiers::default(),
+        );
+        assert!(background_hovered.get());
     }
 
     #[gpui::test]

--- a/crates/base/src/positioner.rs
+++ b/crates/base/src/positioner.rs
@@ -5,7 +5,7 @@
 //! tooltips, and menus.
 
 use gpui::{
-    Anchor, AnyElement, App, Bounds, Display, Element, GlobalElementId, Half as _,
+    Anchor, AnyElement, App, Bounds, Display, Element, GlobalElementId, Half as _, HitboxBehavior,
     InspectorElementId, IntoElement, LayoutId, ParentElement, Pixels, Point, Position, Size, Style,
     Window, point, px,
 };
@@ -62,6 +62,7 @@ pub struct ResolvedPosition {
 pub struct Positioner {
     strategy: Strategy,
     margin: Pixels,
+    occlude: bool,
     children: Vec<AnyElement>,
 }
 
@@ -81,6 +82,7 @@ impl Positioner {
                 offset: px(0.),
             },
             margin: px(4.),
+            occlude: false,
             children: Vec::new(),
         }
     }
@@ -94,6 +96,7 @@ impl Positioner {
         Self {
             strategy: Strategy::Corner { anchor, position },
             margin: px(4.),
+            occlude: false,
             children: Vec::new(),
         }
     }
@@ -124,6 +127,17 @@ impl Positioner {
         if let Strategy::Side { offset: slot, .. } = &mut self.strategy {
             *slot = offset;
         }
+        self
+    }
+
+    /// Blocks the mouse over the positioned popup.
+    ///
+    /// Off by default, because a tooltip that swallowed the pointer would
+    /// un-hover the very trigger keeping it open. An interactive surface — a
+    /// popover, a menu, a dropdown — wants it on: what the surface covers is
+    /// the surface's, not the panel underneath.
+    pub fn occlude(mut self) -> Self {
+        self.occlude = true;
         self
     }
 
@@ -327,6 +341,12 @@ impl Element for Positioner {
             window.viewport_size(),
             self.margin + client_inset,
         );
+        // Ahead of the children so it blocks what is behind the popup without
+        // blocking the popup's own content.
+        if self.occlude {
+            window.insert_hitbox(position.bounds, HitboxBehavior::BlockMouse);
+        }
+
         let offset = position.bounds.origin - bounds.origin;
         let offset = point(offset.x.round(), offset.y.round());
 


### PR DESCRIPTION
## Description

Hovering an open popover or menu still reached the panel underneath it. `Popup`
left occlusion to each caller, and `HoverCard` never opted in, so its surface
did not block the mouse at all.

`Positioner` already resolves the popup's final bounds during prepaint, so it
now takes an opt-in `occlude()` that inserts a `BlockMouse` hitbox there. The
hitbox goes in ahead of the children, so the surface blocks what is behind it
without blocking its own content — a wrapper element would have added a layout
node, which `Positioner` deliberately avoids.

`Popup` turns it on. That covers `Popover`, `DropdownMenu` (a `Popover`
underneath) and `HoverCard` in one place, instead of asking every caller to
remember. `PopupMenu`, `Select`, `Combobox` and `DatePicker` do not route
through `Popup` and already occlude themselves.

It stays off by default because `TooltipPositioner` shares `Positioner`: a
tooltip that swallowed the pointer would un-hover the very trigger keeping it
open.

### Test

`the_popup_surface_blocks_the_panel_it_covers` moves the pointer onto a popup
surface laid over a panel and asserts, in the same event, that the panel does
not react and the popup's own content still does. A second move outside the
surface asserts the panel is still live, so the first assertion is about
occlusion and not a dead listener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsvAy7WNeqDJh3g84QBeGC