### PR TITLE
shell: Give Git dependencies types in an editor

### DIFF
--- a/crates/shell/README.md
+++ b/crates/shell/README.md
@@ -473,6 +473,35 @@ so an import says which layer a script depends on.
 
 Add `gpui.d.ts` to `.gitignore`; the file's own first line says so.
 
+### Dependencies an editor can see
+
+The declarations describe the runtime. A Git dependency the manifest declares is
+the rest of what a script imports, and an editor answers `import { style } from
+"omarchy-ui"` by walking `node_modules` up from the importing file — it knows
+nothing about `gpui-shell.json`. Left alone, a correct import is underlined as a
+module it cannot find, and every name behind it has no type, no parameter hints
+and no documentation.
+
+So the same invocations link each materialized checkout into the application's
+`node_modules` under the name the manifest gave it, and scaffold a
+`jsconfig.json` when the directory has neither that nor a `tsconfig.json`. The
+editor reads the same files the runtime is about to execute, so a package's own
+JSDoc is what it shows and cannot drift from what runs.
+
+Only entries gpui-shell wrote are ever replaced or removed — a symlink into its
+dependency cache, or a directory carrying its marker file — so an installed
+package of the same name is left alone, and a link whose dependency the manifest
+no longer declares goes away. Where the platform refuses a symlink, such as an
+unprivileged Windows process, a small package that re-exports the checkout is
+written instead: a bare import types the same way, and a package-subpath import
+stays unresolved.
+
+The directory is called `node_modules` because that is the one place every
+editor looks — no package manager is involved and nothing comes from a
+registry. It also buys quiet: TypeScript treats what it resolves there as an
+external library, so a dependency's own implicit-`any` diagnostics stay out of
+your build. Ignore it, the way `gpui.d.ts` is ignored.
+
 The style methods, their argument types and the colour-token union are generated
 from the tables the runtime dispatches through, so a name that type-checks is a
 name the dispatcher accepts.
@@ -517,8 +546,10 @@ A directory that refuses the write is logged, never fatal.
 
 Do not commit it. This repository ignores `gpui.d.ts` everywhere, including
 beside its own example and story scripts — a committed copy could only ever be
-the stale one. What *is* committed is the hand-written part: a `jsconfig.json`
-that turns checking on.
+the stale one. What *is* committed is the part that has no machine in it: a
+`jsconfig.json` that turns checking on. An application that has none is given
+one on its first launch, in the shape `examples/js_todolist/jsconfig.json`
+uses; from then on it belongs to whoever edits it and is never rewritten.
 
 The header names the gpui-shell version that generated it. Application/runtime
 compatibility is declared separately by `shell-version` in `gpui-shell.json`

--- a/crates/shell/src/bin/gpui-shell.rs
+++ b/crates/shell/src/bin/gpui-shell.rs
@@ -53,6 +53,17 @@ fn main() {
                     std::process::exit(1);
                 }
             }
+            // The declarations describe the runtime; the manifest's Git
+            // dependencies are the rest of what the editor has to resolve, and
+            // a command that wrote half of it and said nothing would leave the
+            // import underlined with no explanation.
+            match gpui_shell::write_dependency_links(&directory) {
+                Ok(_) => {}
+                Err(error) => {
+                    eprintln!("gpui-shell: {error:#}");
+                    std::process::exit(1);
+                }
+            }
             return;
         }
         Ok(Invocation::Check(arguments)) => {
@@ -221,9 +232,10 @@ Arguments:
   <directory>  The application root, or the {ENTRY} inside it.
 
 Commands:
-  types        Write gpui.d.ts next to the application, so an editor — or a
-               model writing the code — sees the whole API and catches a
-               mistyped style method before it runs.
+  types        Write gpui.d.ts next to the application and link the manifest's
+               Git dependencies into node_modules, so an editor — or a model
+               writing the code — sees the whole API, the packages it imports,
+               and catches a mistyped style method before it runs.
   check        Load and render the application once without showing a window,
                then exit 0 if it worked and 1 if it did not. JavaScript has no
                compiler, so this is what takes its place: it reports syntax

--- a/crates/shell/src/dependencies.rs
+++ b/crates/shell/src/dependencies.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     fs::File,
     path::{Path, PathBuf},
     process::{Command, Output, Stdio},
@@ -11,7 +12,7 @@ use fs2::FileExt as _;
 use sha2::{Digest as _, Sha256};
 use wait_timeout::ChildExt as _;
 
-use crate::plugin::GitDependency;
+use crate::plugin::{GitDependency, PluginManifest};
 
 /// Materializes Git-backed JavaScript packages in gpui-shell's user cache.
 pub(crate) struct GitDependencyStore {
@@ -177,6 +178,232 @@ impl GitDependencyStore {
 
         Ok(MaterializedDependency { root, entry })
     }
+
+    /// Materializes every dependency a manifest declares, in manifest order.
+    pub(crate) fn materialize_all(
+        &self,
+        manifest: &PluginManifest,
+    ) -> Result<BTreeMap<String, MaterializedDependency>> {
+        manifest
+            .dependencies()
+            .iter()
+            .map(|(name, dependency)| {
+                self.materialize(name, dependency)
+                    .map(|materialized| (name.clone(), materialized))
+            })
+            .collect()
+    }
+
+    /// Points an editor at the packages this application will import.
+    ///
+    /// The runtime answers `import { style } from "omarchy-ui"` from the
+    /// manifest. An editor answers it by walking `node_modules` up from the
+    /// importing file, so nothing in the application directory tells it where
+    /// the package is: a correct import is underlined as a missing module, and
+    /// every name behind it loses its type, its parameters and its
+    /// documentation.
+    ///
+    /// Linking the checkout under the name the manifest gave it closes that gap
+    /// without writing a second description of the package. The editor reads
+    /// the same files the runtime is about to execute, so the signatures and
+    /// JSDoc it shows are the package's own and cannot drift from what runs.
+    ///
+    /// The links live in `node_modules` — already ignored by every JavaScript
+    /// project — rather than in `gpui.d.ts` or a `tsconfig.json`, because they
+    /// name a machine-specific cache path and both of those files are committed.
+    ///
+    /// Only entries this store owns are ever replaced or removed: a symlink
+    /// into its own cache, or a directory carrying the marker file it writes.
+    /// Anything else in `node_modules` belongs to whoever installed it.
+    /// Returns the links that were created or repointed.
+    pub(crate) fn link_for_editor(
+        &self,
+        app_root: &Path,
+        dependencies: &BTreeMap<String, MaterializedDependency>,
+    ) -> Result<Vec<PathBuf>> {
+        let modules = app_root.join(EDITOR_MODULE_DIRECTORY);
+        if dependencies.is_empty() && !modules.is_dir() {
+            return Ok(Vec::new());
+        }
+        std::fs::create_dir_all(&modules)
+            .with_context(|| format!("creating {}", modules.display()))?;
+
+        let mut linked = Vec::new();
+        let mut declared = Vec::new();
+        for (name, dependency) in dependencies {
+            let link = modules.join(name);
+            declared.push(link.clone());
+            if let Some(parent) = link.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating {}", parent.display()))?;
+            }
+            if self.relink(&link, name, dependency)? {
+                linked.push(link);
+            }
+        }
+        self.prune(&modules, &declared);
+        Ok(linked)
+    }
+
+    /// Makes `link` point at `dependency`, and reports whether it had to.
+    fn relink(&self, link: &Path, name: &str, dependency: &MaterializedDependency) -> Result<bool> {
+        match std::fs::symlink_metadata(link) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                let current = std::fs::read_link(link)
+                    .with_context(|| format!("reading {}", link.display()))?;
+                if current == dependency.root {
+                    return Ok(false);
+                }
+                if !current.starts_with(&self.root) {
+                    tracing::debug!(
+                        "leaving {} alone: it already points outside the dependency cache",
+                        link.display()
+                    );
+                    return Ok(false);
+                }
+                remove_directory_link(link)
+                    .with_context(|| format!("replacing {}", link.display()))?;
+            }
+            Ok(_) if is_editor_link_stub(link) => {
+                std::fs::remove_dir_all(link)
+                    .with_context(|| format!("replacing {}", link.display()))?;
+            }
+            Ok(_) => {
+                tracing::debug!(
+                    "leaving {} alone: an installed package already claims that name",
+                    link.display()
+                );
+                return Ok(false);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| format!("inspecting {}", link.display()));
+            }
+        }
+
+        match symlink_directory(&dependency.root, link) {
+            Ok(()) => Ok(true),
+            // Windows refuses a symlink to an unprivileged process unless
+            // developer mode is on. A package that re-exports the checkout by
+            // absolute path types the same way for a bare import; only a
+            // package-subpath import is left unresolved.
+            Err(error) => {
+                tracing::debug!(
+                    "linking dependency `{name}` failed ({error}); writing a re-export instead"
+                );
+                write_editor_link_stub(link, name, dependency)?;
+                Ok(true)
+            }
+        }
+    }
+
+    /// Removes the links of dependencies the manifest no longer declares.
+    ///
+    /// Bounded at the depth a scoped name needs, and confined to entries this
+    /// store wrote, so a stale link cannot outlive its manifest entry and an
+    /// installed package cannot be mistaken for one.
+    fn prune(&self, modules: &Path, declared: &[PathBuf]) {
+        let mut pending = vec![(modules.to_path_buf(), 0usize)];
+        while let Some((directory, depth)) = pending.pop() {
+            for entry in std::fs::read_dir(&directory)
+                .into_iter()
+                .flatten()
+                .flatten()
+            {
+                let path = entry.path();
+                if declared.contains(&path) {
+                    continue;
+                }
+                let Ok(file_type) = entry.file_type() else {
+                    continue;
+                };
+                if file_type.is_symlink() {
+                    if std::fs::read_link(&path).is_ok_and(|target| target.starts_with(&self.root))
+                    {
+                        let _ = remove_directory_link(&path);
+                    }
+                } else if file_type.is_dir() {
+                    if is_editor_link_stub(&path) {
+                        let _ = std::fs::remove_dir_all(&path);
+                    } else if depth < 1 {
+                        pending.push((path, depth + 1));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Where an editor looks for a bare module specifier.
+const EDITOR_MODULE_DIRECTORY: &str = "node_modules";
+
+/// Names the file that marks a directory as one [`GitDependencyStore`] wrote.
+///
+/// A marker rather than a naming convention: it is what lets pruning tell its
+/// own re-export package from an installed one that happens to sit under the
+/// same name.
+const EDITOR_LINK_MARKER: &str = ".gpui-shell-link";
+
+fn is_editor_link_stub(link: &Path) -> bool {
+    link.join(EDITOR_LINK_MARKER).is_file()
+}
+
+/// Writes the package that stands in for a symlink the platform refused.
+fn write_editor_link_stub(
+    link: &Path,
+    name: &str,
+    dependency: &MaterializedDependency,
+) -> Result<()> {
+    std::fs::create_dir_all(link).with_context(|| format!("creating {}", link.display()))?;
+    let manifest = serde_json::json!({
+        "name": name,
+        "private": true,
+        "type": "module",
+        "main": "index.js",
+    });
+    let entry = module_specifier(&dependency.entry);
+    std::fs::write(
+        link.join(EDITOR_LINK_MARKER),
+        format!("{}\n", dependency.root.display()),
+    )?;
+    std::fs::write(
+        link.join("package.json"),
+        format!("{}\n", serde_json::to_string_pretty(&manifest)?),
+    )?;
+    std::fs::write(
+        link.join("index.js"),
+        format!(
+            "// Written by gpui-shell so an editor can resolve `{name}`.\n             // The runtime resolves the manifest entry directly and never reads this file.\n             export * from {};\n",
+            serde_json::to_string(&entry)?
+        ),
+    )?;
+    Ok(())
+}
+
+/// A path as TypeScript wants to read it: rooted, with forward slashes.
+fn module_specifier(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(unix)]
+fn symlink_directory(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn symlink_directory(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(target, link)
+}
+
+/// Removes a symlink to a directory, which the two platforms spell differently.
+#[cfg(unix)]
+fn remove_directory_link(link: &Path) -> std::io::Result<()> {
+    std::fs::remove_file(link)
+}
+
+#[cfg(windows)]
+fn remove_directory_link(link: &Path) -> std::io::Result<()> {
+    std::fs::remove_dir(link)
 }
 
 fn dependency_entry_name(name: &str, dependency: &GitDependency, root: &Path) -> Result<String> {
@@ -369,7 +596,10 @@ impl Drop for CacheLock {
 
 #[cfg(test)]
 mod tests {
-    use super::{GitDependencyStore, dependency_cache_root, digest};
+    use super::{
+        EDITOR_LINK_MARKER, EDITOR_MODULE_DIRECTORY, GitDependencyStore, MaterializedDependency,
+        dependency_cache_root, digest,
+    };
     use crate::plugin::PluginManifest;
     use std::{
         ffi::OsString,
@@ -829,6 +1059,147 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(package.entry).unwrap(),
             "export const version = 1;"
+        );
+    }
+
+    /// A store, an application, and checkouts under the store's own cache —
+    /// everything linking needs, and nothing Git does.
+    struct LinkFixture {
+        root: PathBuf,
+        store: GitDependencyStore,
+        app: PathBuf,
+        cache: PathBuf,
+    }
+
+    impl LinkFixture {
+        fn new() -> Self {
+            let unique = NEXT.fetch_add(1, Ordering::Relaxed);
+            let root = std::env::temp_dir().join(format!(
+                "gpui-shell-dependency-link-{}-{unique}",
+                std::process::id()
+            ));
+            let cache = root.join("cache");
+            let app = root.join("app");
+            std::fs::create_dir_all(&app).expect("application directory");
+            std::fs::create_dir_all(&cache).expect("cache directory");
+            Self {
+                store: GitDependencyStore::new(cache.clone()),
+                root,
+                app,
+                cache,
+            }
+        }
+
+        /// A checkout of `name` at `commit`, holding one entry file.
+        fn checkout(&self, name: &str, commit: &str) -> MaterializedDependency {
+            let root = self.cache.join("checkouts").join(name).join(commit);
+            std::fs::create_dir_all(&root).expect("checkout directory");
+            let entry = root.join("index.js");
+            std::fs::write(&entry, "export const marker = 1;\n").expect("checkout entry");
+            MaterializedDependency { root, entry }
+        }
+
+        fn link(&self, name: &str) -> PathBuf {
+            self.app.join(EDITOR_MODULE_DIRECTORY).join(name)
+        }
+
+        fn link_all(&self, dependencies: &[(&str, &MaterializedDependency)]) -> Vec<PathBuf> {
+            let map = dependencies
+                .iter()
+                .map(|(name, dependency)| ((*name).to_owned(), (*dependency).clone()))
+                .collect();
+            self.store
+                .link_for_editor(&self.app, &map)
+                .expect("linking is writable")
+        }
+    }
+
+    impl Drop for LinkFixture {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn linking_points_an_editor_at_the_checkout_the_runtime_will_load() {
+        let fixture = LinkFixture::new();
+        let dependency = fixture.checkout("omarchy-ui", "aaaa");
+
+        let written = fixture.link_all(&[("omarchy-ui", &dependency)]);
+
+        let link = fixture.link("omarchy-ui");
+        assert_eq!(written, vec![link.clone()]);
+        assert_eq!(
+            std::fs::canonicalize(link.join("index.js")).expect("the link resolves"),
+            std::fs::canonicalize(&dependency.entry).expect("the entry exists")
+        );
+    }
+
+    #[test]
+    fn linking_rewrites_nothing_when_the_checkout_has_not_moved() {
+        let fixture = LinkFixture::new();
+        let dependency = fixture.checkout("omarchy-ui", "aaaa");
+
+        assert_eq!(fixture.link_all(&[("omarchy-ui", &dependency)]).len(), 1);
+        assert!(fixture.link_all(&[("omarchy-ui", &dependency)]).is_empty());
+    }
+
+    #[test]
+    fn linking_repoints_when_the_selector_resolves_to_a_new_commit() {
+        let fixture = LinkFixture::new();
+        let before = fixture.checkout("omarchy-ui", "aaaa");
+        let after = fixture.checkout("omarchy-ui", "bbbb");
+
+        fixture.link_all(&[("omarchy-ui", &before)]);
+        assert_eq!(fixture.link_all(&[("omarchy-ui", &after)]).len(), 1);
+
+        assert_eq!(
+            std::fs::read_link(fixture.link("omarchy-ui")).expect("a link"),
+            after.root
+        );
+    }
+
+    #[test]
+    fn linking_removes_a_dependency_the_manifest_no_longer_declares() {
+        let fixture = LinkFixture::new();
+        let kept = fixture.checkout("omarchy-ui", "aaaa");
+        let dropped = fixture.checkout("charts", "bbbb");
+
+        fixture.link_all(&[("omarchy-ui", &kept), ("charts", &dropped)]);
+        fixture.link_all(&[("omarchy-ui", &kept)]);
+
+        assert!(std::fs::symlink_metadata(fixture.link("omarchy-ui")).is_ok());
+        assert!(std::fs::symlink_metadata(fixture.link("charts")).is_err());
+    }
+
+    #[test]
+    fn linking_leaves_an_installed_package_of_the_same_name_alone() {
+        let fixture = LinkFixture::new();
+        let dependency = fixture.checkout("omarchy-ui", "aaaa");
+        let installed = fixture.link("omarchy-ui");
+        std::fs::create_dir_all(&installed).expect("an installed package");
+        std::fs::write(installed.join("package.json"), "{}").expect("its manifest");
+
+        assert!(fixture.link_all(&[("omarchy-ui", &dependency)]).is_empty());
+
+        assert!(
+            std::fs::symlink_metadata(&installed)
+                .expect("the installed package survives")
+                .is_dir()
+        );
+        assert!(!installed.join(EDITOR_LINK_MARKER).exists());
+    }
+
+    #[test]
+    fn a_scoped_dependency_name_becomes_a_nested_link() {
+        let fixture = LinkFixture::new();
+        let dependency = fixture.checkout("ui", "aaaa");
+
+        fixture.link_all(&[("@omarchy/ui", &dependency)]);
+
+        assert_eq!(
+            std::fs::read_link(fixture.link("@omarchy/ui")).expect("a nested link"),
+            dependency.root
         );
     }
 }

--- a/crates/shell/src/engine/quickjs/mod.rs
+++ b/crates/shell/src/engine/quickjs/mod.rs
@@ -817,15 +817,20 @@ impl ShellRuntime {
 
         let dependencies = if root.join(crate::plugin::MANIFEST_FILE).is_file() {
             let manifest = crate::plugin::PluginManifest::read(&root)?;
-            manifest
-                .dependencies()
-                .iter()
-                .map(|(name, dependency)| {
-                    self.dependency_store
-                        .materialize(name, dependency)
-                        .map(|materialized| (name.clone(), materialized))
-                })
-                .collect::<Result<BTreeMap<_, _>>>()?
+            let dependencies = self.dependency_store.materialize_all(&manifest)?;
+            // Beside the declarations, and for the same reason: the process
+            // that will resolve these imports is the one that tells an editor
+            // where they are, so a package cannot be typed against a checkout
+            // this load is not going to use. Best-effort, like the
+            // declarations — a read-only directory is not a reason to refuse to
+            // run.
+            if let Err(error) = self.dependency_store.link_for_editor(&root, &dependencies) {
+                tracing::debug!(
+                    "could not link dependencies for an editor in {}: {error:#}",
+                    root.display()
+                );
+            }
+            dependencies
         } else {
             BTreeMap::new()
         };

--- a/crates/shell/src/lib.rs
+++ b/crates/shell/src/lib.rs
@@ -115,6 +115,34 @@ pub fn write_type_declarations(root: &std::path::Path) -> std::io::Result<Vec<Pa
     typings::write_application(root)
 }
 
+/// Links an application's declared Git dependencies where an editor finds them.
+///
+/// `gpui.d.ts` describes the runtime; this describes the packages the manifest
+/// adds to it. Without it `import { style } from "omarchy-ui"` is a module an
+/// editor cannot resolve, so the names behind it have no types, no parameter
+/// hints and no documentation even though the runtime resolves them fine.
+///
+/// The dependencies are fetched if the cache does not already hold them, which
+/// is why this is separate from [`write_type_declarations`]: one writes a file,
+/// the other may reach the network. [`ShellRuntime::load`] does both, so an
+/// ordinary host needs neither. This explicit operation exists for tooling such
+/// as `gpui-shell types` that must report a failure to its caller.
+///
+/// An application without a manifest, or one that declares no dependencies, has
+/// nothing to link and is not an error. Returns the links that were written.
+pub fn write_dependency_links(root: &std::path::Path) -> anyhow::Result<Vec<PathBuf>> {
+    if !root.join(plugin::MANIFEST_FILE).is_file() {
+        return Ok(Vec::new());
+    }
+    let manifest = plugin::PluginManifest::read(root)?;
+    if manifest.dependencies().is_empty() {
+        return Ok(Vec::new());
+    }
+    let store = dependencies::GitDependencyStore::for_user()?;
+    let dependencies = store.materialize_all(&manifest)?;
+    store.link_for_editor(root, &dependencies)
+}
+
 /// Grants an application its capabilities.
 ///
 /// Nothing is permitted until this is called: a script gets no file, storage,

--- a/crates/shell/src/typings.rs
+++ b/crates/shell/src/typings.rs
@@ -98,6 +98,74 @@ use crate::value::Bridged;
 /// having them in the project, not by being told where.
 pub const FILE_NAME: &str = "gpui.d.ts";
 
+/// The editor configuration filename, in the spelling a JavaScript project uses.
+pub const CONFIG_FILE_NAME: &str = "jsconfig.json";
+
+/// The configuration this one is written beside, and defers to.
+const TYPESCRIPT_CONFIG_FILE_NAME: &str = "tsconfig.json";
+
+/// What an editor has to be told before `gpui.d.ts` and the linked packages
+/// mean anything.
+///
+/// The settings match the ones the applications in this repository were
+/// written against — `examples/js_todolist/jsconfig.json` and its siblings —
+/// so a generated project and a hand-written one are checked the same way.
+/// The file explains each of them to whoever opens it, which is why it carries
+/// its own `"// why"`.
+///
+/// It is only ever written into a directory that has no configuration at all,
+/// so `checkJs` turns checking on for an application that had none rather than
+/// changing the terms under an application that already chose.
+const EDITOR_CONFIG: &str = r#"{
+  "// why": [
+    "Written once by gpui-shell, then yours: an existing jsconfig.json or",
+    "tsconfig.json is never replaced, and this file is not rewritten.",
+    "",
+    "`moduleResolution` is how a bare specifier is answered. Left to be",
+    "inferred it can still land on the resolution that never looks in",
+    "node_modules, and a Git dependency the runtime resolves fine is",
+    "underlined as a module the editor cannot find.",
+    "",
+    "`lib` decides which globals exist. The default hands a script the",
+    "browser's — a `console`, a `localStorage`, a `Window` this runtime does",
+    "not have — and their declarations collide with the ones gpui.d.ts makes,",
+    "so the file describing the API is itself reported as the error.",
+    "",
+    "`strictNullChecks` is off, and this one is the runtime's shape rather than",
+    "a preference. A view assigns its state in `init`, which TypeScript cannot",
+    "see as definite assignment the way it sees a constructor, so every field",
+    "would read as possibly-undefined and every use would want a `?.` that",
+    "means nothing at run time. Turning it on would buy noise, not safety."
+  ],
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "checkJs": true,
+    "strict": true,
+    "strictNullChecks": false,
+    "noEmit": true
+  }
+}
+"#;
+
+/// Writes the editor configuration beside an application, once.
+///
+/// Only when the directory has neither configuration file: the first launch
+/// scaffolds one, and everything after that leaves the author's own settings
+/// alone. Returns the path only when it actually wrote.
+fn write_editor_config(directory: &Path) -> std::io::Result<Option<PathBuf>> {
+    let path = directory.join(CONFIG_FILE_NAME);
+    if std::fs::symlink_metadata(&path).is_ok()
+        || std::fs::symlink_metadata(directory.join(TYPESCRIPT_CONFIG_FILE_NAME)).is_ok()
+    {
+        return Ok(None);
+    }
+    std::fs::write(&path, EDITOR_CONFIG)?;
+    Ok(Some(path))
+}
+
 /// Emits the TypeScript declarations for the script API.
 ///
 /// The output is deterministic — no timestamps, no reflection order — so
@@ -246,6 +314,16 @@ pub(crate) fn write_application(root: &Path) -> std::io::Result<Vec<PathBuf>> {
 
     let mut written = Vec::new();
     let mut first_error = None;
+    // The application root only: one project, one configuration, and a nested
+    // directory that happens to import `gpui` is part of it rather than a
+    // second project.
+    match write_editor_config(root) {
+        Ok(Some(path)) => written.push(path),
+        Ok(None) => {}
+        Err(error) => {
+            first_error.get_or_insert(error);
+        }
+    }
     for directory in directories {
         match refresh(&directory) {
             Ok(Some(path)) => written.push(path),
@@ -3142,7 +3220,6 @@ const BASE_IMPORTS: &str = r#"  import {
     Context,
     Element,
     FocusHandle,
-    Placement,
   } from "gpui";
 
 "#;
@@ -4283,9 +4360,34 @@ mod tests {
         let written = write_application(&directory).expect("declarations are writable");
         let path = directory.join(FILE_NAME);
 
-        assert_eq!(written, vec![path.clone()]);
+        assert_eq!(
+            written,
+            vec![directory.join(CONFIG_FILE_NAME), path.clone()]
+        );
         assert_eq!(path.file_name().unwrap(), FILE_NAME);
         assert_eq!(std::fs::read_to_string(&path).unwrap(), declarations());
+
+        let _ = std::fs::remove_dir_all(&directory);
+    }
+
+    #[test]
+    fn an_existing_editor_configuration_is_never_replaced() {
+        let directory = std::env::temp_dir().join(format!(
+            "gpui-shell-typings-config-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&directory);
+        std::fs::create_dir_all(&directory).expect("application root");
+        std::fs::write(directory.join(TYPESCRIPT_CONFIG_FILE_NAME), "{}").expect("a tsconfig");
+
+        write_application(&directory).expect("declarations are writable");
+
+        assert!(!directory.join(CONFIG_FILE_NAME).exists());
+        assert_eq!(
+            std::fs::read_to_string(directory.join(TYPESCRIPT_CONFIG_FILE_NAME)).unwrap(),
+            "{}"
+        );
 
         let _ = std::fs::remove_dir_all(&directory);
     }

--- a/crates/story/js/motion/jsconfig.json
+++ b/crates/story/js/motion/jsconfig.json
@@ -1,0 +1,31 @@
+{
+  "// why": [
+    "This file exists so an editor resolves `from \"gpui\"` and `from",
+    "\"gpui-base\"` and knows what each module holds. Without it the imports",
+    "are opaque and the 700-odd style methods are invisible.",
+    "",
+    "`noImplicitAny` is on: every parameter and every piece of state carries a",
+    "type, written as JSDoc rather than TypeScript. That gives the compiler the",
+    "same information without a build step — editing a file still changes the",
+    "window with no compile in between, which is the whole argument for a",
+    "script layer. `types.d.ts` holds the shapes, so the annotations at the",
+    "call sites are one word each.",
+    "",
+    "`strictNullChecks` is off, and this one is the runtime's shape rather than",
+    "a preference. A view assigns its state in `init`, which TypeScript cannot",
+    "see as definite assignment the way it sees a constructor, so every field",
+    "would read as possibly-undefined and every use would want a `?.` that",
+    "means nothing at run time. Turning it on would buy noise, not safety."
+  ],
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "checkJs": true,
+    "strict": true,
+    "strictNullChecks": false,
+    "noEmit": true
+  },
+  "include": ["*.js", "*.d.ts"]
+}

--- a/website/shell/api.md
+++ b/website/shell/api.md
@@ -8,7 +8,7 @@ order: 9
 
 An inventory of the script surface: what exists, and which module it comes from. The other pages explain why each thing works the way it does — this one is for looking a name up.
 
-The authority is not this page. The runtime generates `gpui.d.ts` for its own version and refreshes it beside your source when the application loads. That refresh is best-effort; `gpui-shell types <directory>` performs the same write and reports a failure. The generated header names the `gpui-shell` version and includes that application's HostModule registrations. Keep the file ignored, and put `// @ts-check` at the top of a script to have an editor check against it.
+The authority is not this page. The runtime generates `gpui.d.ts` for its own version and refreshes it beside your source when the application loads. That refresh is best-effort; `gpui-shell types <directory>` performs the same write and reports a failure. The generated header names the `gpui-shell` version and includes that application's HostModule registrations. Keep the file ignored, and put `// @ts-check` at the top of a script to have an editor check against it. The manifest's Git dependencies are not listed here either: they are linked into `node_modules` by the same refresh, and their names, signatures and documentation come from the packages themselves.
 
 ## The modules
 

--- a/website/shell/capabilities.md
+++ b/website/shell/capabilities.md
@@ -144,6 +144,32 @@ timeout. The dependency map key is the bare JavaScript module name, for example
 imports stay confined to that checkout. Fetching uses the host's `git`
 executable and is separate from script network capabilities.
 
+An editor answers that import a different way: it walks `node_modules` up from
+the importing file and knows nothing about the manifest, so a correct import is
+underlined as a module it cannot find, and every name behind it loses its type,
+its parameter hints and its documentation. Every load — and `gpui-shell
+types` — therefore links each materialized checkout into
+`<application>/node_modules` under the name the manifest gave it, and scaffolds
+a `jsconfig.json` when the directory has neither that nor a `tsconfig.json`.
+The editor then reads the same files the runtime is about to execute, so the
+signatures and JSDoc it shows cannot drift from what runs.
+
+Only entries gpui-shell owns are ever replaced or removed — a symlink into the
+dependency cache, or a directory carrying its marker file — so an installed
+package of the same name is left alone, and a link whose dependency the
+manifest no longer declares goes away. Where the platform refuses a symlink,
+such as an unprivileged Windows process, gpui-shell writes a small package that
+re-exports the checkout instead: a bare import types the same way, and a
+package-subpath import stays unresolved.
+
+The directory is called `node_modules` because that is the one place every
+editor looks; no package manager is involved, nothing is downloaded from a
+registry, and each entry is a link into the Git checkout gpui-shell already
+made. It also buys quiet: TypeScript treats what it resolves there as an
+external library and stops reporting a dependency's own implicit-`any`
+diagnostics as if they were yours. `node_modules` is generated, like
+`gpui.d.ts`. Ignore both.
+
 Every grant in that block defaults to *denied* when omitted, except `storage`, which defaults to granted — write `"storage": false` to refuse it.
 
 Unknown fields, invalid reverse-DNS ids, invalid explicitly declared SemVer values, incompatible `shell-version` values, escaping entries, and unknown `${...}` placeholders invalidate the manifest before code runs. Omitted `version` is reported as `unknown`. Omitted `shell-version` accepts the current runtime; when present, it names the oldest compatible gpui-shell release the application requires. Compatibility follows SemVer: `0.x` applications stay on the same minor line; stable releases stay on the same major line. The standalone CLI refuses an invalid manifest instead of executing its entry with silently different assumptions.

--- a/website/shell/getting-started.md
+++ b/website/shell/getting-started.md
@@ -151,6 +151,8 @@ cargo run -p gpui-shell -- types hello
 
 This writes `gpui.d.ts` next to the application. Put `// @ts-check` at the top of a script and an editor will complete the whole API and reject a mistyped style method, a colour token that does not exist, or `.p("auto")` — at the call site, before it runs.
 
+It also sets up everything else the editor needs: each Git dependency the manifest declares is fetched and linked into `node_modules` under its declared name, so `import { style } from "omarchy-ui"` resolves to the same files the runtime will execute and carries the package's own types, parameters and JSDoc; and a `jsconfig.json` is scaffolded when the directory has neither that nor a `tsconfig.json`. See [Capabilities](./capabilities.md#the-manifest).
+
 The declarations can be trusted because they are **generated from the tables the runtime dispatches through**, not transcribed from this documentation:
 
 - style method names come from the same list the JavaScript prelude loops over to build the element prototype;
@@ -187,7 +189,7 @@ gpui-shell --help | --version
 | -------------- | --------------------------------------------------------------- |
 | `<directory>`  | The application root, or the `main.js` inside it                |
 | `check`        | Load and render once without a window; exit `0` or `1`          |
-| `types`        | Write `gpui.d.ts` next to the application                       |
+| `types`        | Write `gpui.d.ts`, link the manifest's dependencies, scaffold config |
 | `--watch`      | Reload when the sources change                                  |
 | `--dev`        | Development mode; implies `--watch`                             |
 | `--print-spec` | With `check`, also print the element description that was built |

--- a/website/zh-CN/shell/api.md
+++ b/website/zh-CN/shell/api.md
@@ -8,7 +8,7 @@ order: 9
 
 脚本接口的一份清单：有什么，以及它来自哪个模块。其余页面解释每样东西为什么是这个样子——这一页是用来查名字的。
 
-权威不在这一页。runtime 会为自己的版本生成 `gpui.d.ts`，并在应用加载时尽力刷新到源码旁；`gpui-shell types <directory>` 执行同一次写入，并会明确报告失败。生成文件的头部带有 `gpui-shell` 版本，也包含该应用注册的 HostModule 。请忽略这个文件而不要提交，并在脚本顶部写上 `// @ts-check` 让编辑器照着它检查。
+权威不在这一页。runtime 会为自己的版本生成 `gpui.d.ts`，并在应用加载时尽力刷新到源码旁；`gpui-shell types <directory>` 执行同一次写入，并会明确报告失败。生成文件的头部带有 `gpui-shell` 版本，也包含该应用注册的 HostModule 。请忽略这个文件而不要提交，并在脚本顶部写上 `// @ts-check` 让编辑器照着它检查。manifest 声明的 Git 依赖同样不在这一页：它们由同一次刷新链接进 `node_modules`，名字、签名与文档都来自 package 自身。
 
 ## 模块
 

--- a/website/zh-CN/shell/capabilities.md
+++ b/website/zh-CN/shell/capabilities.md
@@ -138,6 +138,26 @@ module generation 不会互相改写。去掉 fragment 后的完整 URL 同时�
 subpath import 都不能逃出该 checkout。下载使用 Host 上的 `git`，不属于脚本的
 network capability。
 
+编辑器解析同一条 import 的方式完全不同：它从导入文件向上查找 `node_modules`，对
+manifest 一无所知。于是一条正确的 import 会被标红成找不到的模块，它背后的每个名字
+也随之失去类型、参数提示和文档。因此每次加载——以及 `gpui-shell types`——都会把
+materialize 出来的 checkout 按 manifest 给的名字链接到
+`<application>/node_modules`；若目录里既没有 `jsconfig.json` 也没有
+`tsconfig.json`，还会生成一份 `jsconfig.json`。这样编辑器读到的就是运行时即将执行
+的同一批文件，它显示的签名和 JSDoc 不会和实际运行的代码脱节。
+
+只有 gpui-shell 自己写下的条目会被替换或删除——指向依赖缓存的 symlink，或带有它
+标记文件的目录——因此同名的已安装 package 不会被动到；manifest 中已移除的依赖，其
+链接也会一并清除。若平台拒绝创建 symlink（例如权限不足的 Windows 进程），
+gpui-shell 改为写入一个转发该 checkout 的小 package：裸 import 的类型效果相同，
+package subpath import 则无法解析。
+
+目录之所以叫 `node_modules`，是因为所有编辑器只认这一个位置；这里没有包管理器
+参与，不会从 registry 下载任何东西，每一项都只是指向 gpui-shell 已经拉好的 Git
+checkout 的链接。这个名字还换来了安静：TypeScript 会把从这里解析到的内容视为
+external library，不再把依赖自身的 implicit-`any` 之类诊断当成你的代码来报。
+`node_modules` 和 `gpui.d.ts` 一样属于生成物，两者都应加入忽略列表。
+
 这个块里的每项授权省略时都默认**拒绝**，只有 `storage` 默认给予——要拒绝它就写 `"storage": false`。
 
 未知字段、非法 reverse-DNS id、显式填写但不合法的 SemVer、不兼容的 `shell-version`、逃出目录的 entry，以及未知 `${...}` placeholder 都会在代码执行前令 manifest 失效。省略 `version` 时显示为 `unknown`。省略 `shell-version` 时接受当前 runtime；显式填写时，它表示应用所需的最早兼容 gpui-shell 版本。兼容规则遵循 SemVer：`0.x` 应用保持相同 minor，稳定版本保持相同 major。独立 CLI 会拒绝非法 manifest，不会在假设已经不一致时继续执行 entry。

--- a/website/zh-CN/shell/getting-started.md
+++ b/website/zh-CN/shell/getting-started.md
@@ -150,6 +150,8 @@ cargo run -p gpui-shell -- types hello
 
 它会在应用旁边写出 `gpui.d.ts`。在脚本顶部加上 `// @ts-check`，编辑器就会补全整套 API，并在运行之前、在调用点上直接拒绝拼错的样式方法、不存在的颜色 token，或者 `.p("auto")`。
 
+它同时会把编辑器需要的其余部分一并配好：manifest 声明的每个 Git 依赖都会被抓取并按声明的名字链接进 `node_modules`，于是 `import { style } from "omarchy-ui"` 解析到的正是运行时将要执行的那批文件，连同该 package 自己的类型、参数与 JSDoc；若目录里既没有 `jsconfig.json` 也没有 `tsconfig.json`，还会生成一份 `jsconfig.json`。详见[能力](./capabilities.md#the-manifest)。
+
 这份声明可信，是因为它**从运行时实际派发所依据的那几张表生成**，而不是照着文档抄的：
 
 - 样式方法名来自 JavaScript prelude 构建元素原型时遍历的同一份列表；
@@ -186,7 +188,7 @@ gpui-shell --help | --version
 | -------------- | ------------------------------------------- |
 | `<directory>`  | 应用根目录，或其中的 `main.js`              |
 | `check`        | 不开窗口地加载并渲染一次，退出码 `0` 或 `1` |
-| `types`        | 在应用旁边写出 `gpui.d.ts`                  |
+| `types`        | 写出 `gpui.d.ts`、链接 manifest 依赖、生成配置 |
 | `--watch`      | 源码变化时重载                              |
 | `--dev`        | 开发模式，隐含 `--watch`                    |
 | `--print-spec` | 配合 `check`，额外打印构建出的元素描述      |


### PR DESCRIPTION
A manifest dependency resolves at run time and nowhere else. An editor answers `import { style } from "omarchy-ui"` by walking `node_modules` up from the importing file and knows nothing about `gpui-shell.json`, so a correct import is underlined as a module it cannot find and every name behind it loses its type, its parameters and its documentation.

Every load — and `gpui-shell types` — now links each materialized checkout into the application's `node_modules` under its declared name. The editor reads the same files the runtime is about to execute, so a package's own JSDoc is what it shows and cannot drift. Only entries gpui-shell wrote are replaced or removed, so an installed package of the same name is left alone; where a platform refuses a symlink, a small re-export package is written instead.

A `jsconfig.json` is scaffolded when the directory has neither that nor a `tsconfig.json`. It is not decoration: an inferred `moduleResolution` can land on the one that never looks in `node_modules`, and the default `lib` hands a script the browser's globals, whose declarations collide with the ones `gpui.d.ts` makes.

Also stops `declare module "gpui-base"` importing `Placement` from `"gpui"`, which declares no such name — every application was reading one `TS2305` in its own declarations.

Verified end to end against `huacnlee/omarchy-ui`: hover, signature help and JSDoc all arrive, and a wrong argument is rejected across the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFkoCeExzzWVctmzd5z6T