### PR TITLE
docs: Add gpui-shell dependencies on their own page

### DIFF
--- a/website/shell/api.md
+++ b/website/shell/api.md
@@ -1,14 +1,14 @@
 ---
 title: API Reference
 description: Every name a script can import or reach — the four built-in modules, the cx and window globals, and the element methods that are not styles.
-order: 9
+order: 10
 ---
 
 # API Reference
 
 An inventory of the script surface: what exists, and which module it comes from. The other pages explain why each thing works the way it does — this one is for looking a name up.
 
-The authority is not this page. The runtime generates `gpui.d.ts` for its own version and refreshes it beside your source when the application loads. That refresh is best-effort; `gpui-shell types <directory>` performs the same write and reports a failure. The generated header names the `gpui-shell` version and includes that application's HostModule registrations. Keep the file ignored, and put `// @ts-check` at the top of a script to have an editor check against it. The manifest's Git dependencies are not listed here either: they are linked into `node_modules` by the same refresh, and their names, signatures and documentation come from the packages themselves.
+The authority is not this page. The runtime generates `gpui.d.ts` for its own version and refreshes it beside your source when the application loads. That refresh is best-effort; `gpui-shell types <directory>` performs the same write and reports a failure. The generated header names the `gpui-shell` version and includes that application's HostModule registrations. Keep the file ignored, and put `// @ts-check` at the top of a script to have an editor check against it. The manifest's Git dependencies are not listed here either: they are linked into `node_modules` by the same refresh, and their names, signatures and documentation come from the packages themselves. See [Dependencies](./dependencies.md).
 
 ## The modules
 

--- a/website/shell/capabilities.md
+++ b/website/shell/capabilities.md
@@ -90,85 +90,14 @@ A directory is recognized by **`gpui-shell.json`**. The manifest is inert data �
 }
 ```
 
-The string form accepts strict GitHub shorthand or a full Git URL, each with an
-optional `#ref`:
-
-```json
-{
-  "dependencies": {
-    "default-main": "huacnlee/omarchy-ui",
-    "named-ref": "huacnlee/omarchy-ui#v1.2.0",
-    "full-url": "https://github.com/huacnlee/omarchy-ui#0123456789abcdef0123456789abcdef01234567",
-    "remote-head": "https://github.com/huacnlee/omarchy-ui"
-  }
-}
-```
-
-GitHub shorthand without `#ref` selects `main`; a full URL without `#ref`
-selects the remote's HEAD. A ref may name a branch, tag, or commit-ish such as a
-commit ID. A branch, tag, or remote HEAD is fetched and resolved on each
-application load; a commit ID continues to select that exact commit.
-
-After creating the immutable checkout, gpui-shell reads its root
-`package.json`. A string `main` names the package entry. If `package.json` or
-`main` is absent, the entry defaults to `index.js`. Malformed metadata, a
-non-string `main`, and entries that escape the checkout or do not resolve to a
-file are rejected before application JavaScript executes.
-
-The legacy object form remains fully supported. It requires exactly one
-explicit `branch` or `tag`; its optional repository-relative `entry` defaults
-to `index.js`. Existing manifests do not need to migrate. Moving to the string
-form means publishing the entry as `package.json` `main` (or root `index.js`):
-
-```json
-{
-  "dependencies": {
-    "omarchy-ui": {
-      "git": "https://github.com/huacnlee/omarchy-ui",
-      "branch": "main",
-      "entry": "src/public.js"
-    }
-  }
-}
-```
-
-gpui-shell stores dependencies below
-`~/.gpui-shell/cache/dependencies/`. Per-remote locks serialize mirror updates,
-and mirrors publish immutable, commit-addressed checkouts so concurrent loads
-and older module generations cannot rewrite one another. The exact full URL
-without its fragment is both remote and cache identity. gpui-shell verifies the
-raw configured origin while allowing Git's `url.*.insteadOf` rules to choose
-the effective fetch URL. Git runs non-interactively with a 30-second command
-timeout. The dependency map key is the bare JavaScript module name, for example
-`import { label, style } from "omarchy-ui"`; relative and package-subpath
-imports stay confined to that checkout. Fetching uses the host's `git`
-executable and is separate from script network capabilities.
-
-An editor answers that import a different way: it walks `node_modules` up from
-the importing file and knows nothing about the manifest, so a correct import is
-underlined as a module it cannot find, and every name behind it loses its type,
-its parameter hints and its documentation. Every load — and `gpui-shell
-types` — therefore links each materialized checkout into
-`<application>/node_modules` under the name the manifest gave it, and scaffolds
-a `jsconfig.json` when the directory has neither that nor a `tsconfig.json`.
-The editor then reads the same files the runtime is about to execute, so the
-signatures and JSDoc it shows cannot drift from what runs.
-
-Only entries gpui-shell owns are ever replaced or removed — a symlink into the
-dependency cache, or a directory carrying its marker file — so an installed
-package of the same name is left alone, and a link whose dependency the
-manifest no longer declares goes away. Where the platform refuses a symlink,
-such as an unprivileged Windows process, gpui-shell writes a small package that
-re-exports the checkout instead: a bare import types the same way, and a
-package-subpath import stays unresolved.
-
-The directory is called `node_modules` because that is the one place every
-editor looks; no package manager is involved, nothing is downloaded from a
-registry, and each entry is a link into the Git checkout gpui-shell already
-made. It also buys quiet: TypeScript treats what it resolves there as an
-external library and stops reporting a dependency's own implicit-`any`
-diagnostics as if they were yours. `node_modules` is generated, like
-`gpui.d.ts`. Ignore both.
+`dependencies` maps a bare module name to a JavaScript package fetched from
+Git before the entry module runs — `import { Title } from "omarchy-ui"`. The
+string form takes strict GitHub shorthand or a full Git URL with an optional
+`#ref`; the object form with an explicit `branch` or `tag` remains supported.
+Every load also links the package where an editor finds it, so the import
+carries the package's own types and documentation. See
+[Dependencies](./dependencies.md) for version selection, the package entry,
+the cache, and what an editor sees.
 
 Every grant in that block defaults to *denied* when omitted, except `storage`, which defaults to granted — write `"storage": false` to refuse it.
 

--- a/website/shell/dependencies.md
+++ b/website/shell/dependencies.md
@@ -1,0 +1,248 @@
+---
+title: Dependencies
+description: Shell packages — what makes a Git repository one, and how a manifest names, selects, fetches and imports it, down to what an editor sees.
+order: 9
+---
+
+# Dependencies
+
+An application imports its own files by relative path. Every other import it writes comes from one of two places: a **built-in module** the runtime provides — `gpui`, `gpui-base`, `gpui-shell`, `gpui-fps`, and the standard runtime's `fs/promises`, `path`, `crypto`, `net`, `websocket` — or a **dependency**, a JavaScript package the manifest declares and gpui-shell fetches from Git before the entry module is evaluated.
+
+There is no registry, no package manager and no install step. A dependency is a Git remote, a ref, and the name a script imports it by.
+
+## Shell package
+
+A dependency is any Git repository the manifest points at. `omarchy-ui` is a particular kind of one, and that kind has a name: **a shell package** — a JavaScript package written for gpui-shell rather than for Node or a browser, the way a crate is written for Cargo. Five things make a repository one:
+
+| A shell package                                                  | Because                                                                              |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Ships ES modules, and needs no build step                          | The runtime evaluates the checkout's files as they are, and `require` does not exist   |
+| Has a root `package.json` with `"type": "module"` and a `main`     | It makes the declaration one line, and names the entry for the runtime and the editor  |
+| Imports only the built-in modules and its own files                | Nothing else resolves — it cannot reach the application that imported it               |
+| Treats `gpui` and `gpui-base` as provided, never as dependencies   | They come from the runtime that loaded it, at the version the host chose               |
+| Declares no capabilities of its own                                | Its `fs` and `fetch` calls run under the consuming application's grants                |
+
+Nothing reads the name: a dependency is recognized by being declared, not by being labelled. It is what one author writes so another can find the package, and `gpui-shell` is the repository topic that spells it for a search engine.
+
+[`omarchy-ui`](https://github.com/huacnlee/omarchy-ui) is one, and it is the example on the rest of this page.
+
+## Declaring a dependency
+
+`omarchy-ui` is a package of presentation components and theme utilities. One line in `gpui-shell.json` adds it:
+
+```json
+{
+  "id": "com.example.projects",
+  "name": "Projects",
+  "entry": "main.js",
+  "dependencies": {
+    "omarchy-ui": "huacnlee/omarchy-ui"
+  }
+}
+```
+
+The map key is the bare module name — nothing inside the package chooses it. The manifest names the package the way an `as` clause names an import, so two applications may reach the same remote under different names, and renaming a repository does not rename the import:
+
+```js
+import {
+  AppShell,
+  Button,
+  CenteredWorkspace,
+  MutedText,
+  PageColumn,
+  Surface,
+  Title,
+} from "omarchy-ui";
+
+export function render(cx) {
+  const card = new Surface()
+    .children([
+      new Title("Projects").build(cx),
+      new MutedText("Choose a project to continue").build(cx),
+      new Button("project-create")
+        .label("Create project…")
+        .onClick((_event, context) => context.notify())
+        .build(cx),
+    ])
+    .build(cx);
+
+  const page = new PageColumn("projects-page").child(card).build(cx);
+  return new AppShell()
+    .content(new CenteredWorkspace("projects-workspace").content(page).build(cx))
+    .build(cx);
+}
+```
+
+Nothing else changes. The script is still the script from [Getting Started](./getting-started.md); the dependency only widens what it may import.
+
+## What resolves, and to what
+
+| Written                          | Resolves to                                                       |
+| -------------------------------- | ----------------------------------------------------------------- |
+| `"omarchy-ui"`                   | The package entry — see [Package entry](#package-entry)    |
+| `"omarchy-ui/src/style"`         | That file inside the checkout; the `.js` extension is optional     |
+| `"./theme.js"` inside a package  | A file inside that package's own checkout                          |
+| `"gpui"` inside a package        | The built-in module, exactly as in application code                |
+| Another declared dependency name | The other package's entry — declared packages can see one another  |
+| An application file, by bare name, from inside a package | Refused: a package cannot reach back into the application that imported it |
+
+A specifier that resolves outside the checkout it started in is refused before the module is loaded, so `../` cannot walk out of a package and into the cache beside it. Inside the application directory the same boundary is the application root, which is the rule [the sandbox](./capabilities.md#the-sandbox) already applies to relative imports.
+
+**A dependency is not a second sandbox.** It is evaluated in the application's own context and holds exactly the grants the manifest holds: a package that reads a file is reading it under your `fs.read` scope. Declaring a dependency is trusting its code the way importing a Rust crate is, and the ref you pin is what decides which code that is.
+
+## Selecting a version
+
+The string form is a strict GitHub shorthand or a full Git URL, each with an optional `#ref`:
+
+```json
+{
+  "dependencies": {
+    "default-main": "huacnlee/omarchy-ui",
+    "named-ref": "huacnlee/omarchy-ui#v1.2.0",
+    "commit": "https://github.com/huacnlee/omarchy-ui#0123456789abcdef0123456789abcdef01234567",
+    "remote-head": "https://github.com/huacnlee/omarchy-ui"
+  }
+}
+```
+
+| Form                                     | Selects                       |
+| ---------------------------------------- | ----------------------------- |
+| `owner/repository`                       | `main`                        |
+| `owner/repository#ref`                   | That branch, tag or commit-ish |
+| `https://…/repository`                   | The remote's `HEAD`           |
+| `https://…/repository#ref`               | That branch, tag or commit-ish |
+
+Shorthand is deliberately strict: exactly one `owner/repository` pair of alphanumerics, `.`, `-` and `_`, at most one `#`, no surrounding whitespace, and a fragment that is a valid Git ref name. Anything else is a manifest error rather than a URL guessed from a typo. A full URL may be any Git transport, `ssh://` and `git@host:owner/repo` included.
+
+**A branch, a tag or a remote `HEAD` is re-fetched and re-resolved on every application load; a commit ID always selects that commit.** Depending on a branch means the code changes under you the next time the window opens, which is convenient while you develop a package and a supply-chain decision once you ship one. Pin a tag or a commit for anything you do not control.
+
+Fetching needs `git` on the host's `PATH`, and it happens before script capabilities exist — it is gpui-shell running Git on the application's behalf, not the script reaching the network, so it is not covered by `capabilities.network` and does not need `fs.execute`. With nothing to fetch (the cache already holds the commit) a load performs no network access at all; with a moving ref and no network, the fetch fails and the application does not load.
+
+## Package entry
+
+After the checkout exists, gpui-shell reads the package's root `package.json` and takes a string `main` as the entry. `omarchy-ui` publishes:
+
+```json
+{
+  "type": "module",
+  "main": "src/index.js",
+  "types": "src/index.d.ts"
+}
+```
+
+So `import { Title } from "omarchy-ui"` evaluates `src/index.js`. When `package.json` is missing, or has no `main`, the entry is the root `index.js`.
+
+The runtime reads `main`; an editor reads `types`. Both come out of the same file, which is why a package that ships `.d.ts` files needs nothing from the application to be fully typed at the call site.
+
+Malformed JSON, a non-string `main`, and an entry that is absent, not a file, or escapes the checkout all fail the load before any application JavaScript runs.
+
+## The object form
+
+The original object form remains supported unchanged. It requires exactly one explicit `branch` or `tag`, and its repository-relative `entry` defaults to `index.js`:
+
+```json
+{
+  "dependencies": {
+    "omarchy-ui": {
+      "git": "https://github.com/huacnlee/omarchy-ui",
+      "tag": "v1.2.0",
+      "entry": "src/index.js"
+    }
+  }
+}
+```
+
+Existing manifests do not need to migrate. Moving to the string form means the package publishes its entry itself, through `package.json` `main` or a root `index.js`, instead of every consumer repeating it.
+
+## The cache
+
+```text
+~/.gpui-shell/cache/dependencies/
+├── locks/<remote>.lock
+├── mirrors/<remote>.git
+└── checkouts/<remote>/<commit>/
+```
+
+`<remote>` is a SHA-256 of the exact fragment-free URL, which is both the remote's identity and its cache identity. A per-remote lock serializes mirror updates. Checkouts are commit-addressed and never rewritten, so concurrent launches and an older hot-reload generation each keep reading the tree they started with.
+
+The mirror's configured origin is verified against the manifest on every use, and it is the raw configured value that is compared — Git's `url.*.insteadOf` may still choose a different effective fetch URL, which is how a mirror or an internal host substitution keeps working. Git runs non-interactively, with credential prompts disabled and a 30-second limit per command, so a repository that wants a password fails with a message instead of hanging a window that is waiting to open.
+
+Nothing prunes this cache automatically. It is content-addressed, so deleting it is safe: the next load re-fetches what it needs.
+
+## What an editor sees
+
+The runtime answers `import { Title } from "omarchy-ui"` from the manifest. An editor answers it by walking `node_modules` up from the importing file, and it has never heard of `gpui-shell.json`. Left alone, a correct import is underlined as a module that cannot be found, and every name behind it loses its type, its parameter hints and its documentation.
+
+So every load — and `gpui-shell types` — links each materialized checkout into the application's `node_modules` under the name the manifest gave it:
+
+```text
+projects/
+├── gpui-shell.json
+├── main.js
+├── gpui.d.ts          generated by the runtime — ignore it
+├── jsconfig.json      scaffolded once, then yours
+└── node_modules/
+    └── omarchy-ui  →  ~/.gpui-shell/cache/dependencies/checkouts/<remote>/<commit>
+```
+
+The editor then reads the same files the runtime is about to execute, so the signatures and JSDoc it shows are the package's own and cannot drift from what runs.
+
+Only entries gpui-shell wrote are ever replaced or removed — a symlink into its own dependency cache, or a directory carrying its marker file. An installed package of the same name is left alone, and the link of a dependency the manifest no longer declares goes away. Where the platform refuses a symlink, such as an unprivileged Windows process without developer mode, gpui-shell writes a small package that re-exports the checkout instead: a bare import types the same way, and only a package-subpath import is left unresolved.
+
+A `jsconfig.json` is scaffolded when the directory has neither that nor a `tsconfig.json`, and it is written once — an existing configuration is never replaced. It is not decoration. An inferred `moduleResolution` can land on the one that never looks in `node_modules`, which underlines a dependency the runtime resolves fine; and the default `lib` hands a script the browser's globals, whose declarations collide with the ones `gpui.d.ts` makes, so the file describing the API is itself reported as the error.
+
+`node_modules` is generated, like `gpui.d.ts`. Ignore both:
+
+```text
+gpui.d.ts
+node_modules/
+```
+
+The directory is called `node_modules` because that is the one place every editor looks; no package manager is involved and nothing comes from a registry. It also buys quiet: TypeScript treats what it resolves there as an external library, so a dependency's own implicit-`any` diagnostics stay out of your own.
+
+## When fetching and linking happen
+
+| Invocation                                   | Fetches and links | On failure                              |
+| -------------------------------------------- | ----------------- | --------------------------------------- |
+| `gpui-shell <directory>`                      | Yes               | Load fails; linking alone is best-effort |
+| `gpui-shell check <directory>`                | Yes               | Reported as a check failure              |
+| `gpui-shell types <directory>`                | Yes               | Reported, with an exit status            |
+| An embedded host's `ShellRuntime::load`       | Yes               | Load fails; linking alone is best-effort |
+| `gpui_shell::write_dependency_links(root)`    | Yes               | Returned as an error to the caller       |
+
+Fetching is what a load depends on, so a dependency that cannot be materialized fails the load. Writing the editor links is not: a read-only application directory is a reason to lose editor types, not a reason to refuse to run. `gpui-shell types` exists for exactly the case where that difference matters — it does the same work and reports what it could not do.
+
+Hot-reload picks up a package the same way it picks up an application file: each load is a new module generation, so restarting the application is enough to move a branch dependency forward.
+
+## What can fail
+
+Every one of these is reported before the application's JavaScript is evaluated:
+
+| Message                                                       | Cause                                                          |
+| ------------------------------------------------------------- | -------------------------------------------------------------- |
+| `GitHub shorthand must contain exactly owner/repository …`     | A shorthand with a path, a scheme, or an invalid character      |
+| `a string dependency #Git ref must not be empty`               | A trailing `#`                                                  |
+| `could not clone Git dependency …`                             | Git failed: no such remote, no credentials, no network          |
+| `git timed out after 30 seconds …`                             | A hung fetch, usually an interactive credential prompt          |
+| `Git dependency … cache origin is …, expected …`               | Two manifests disagree about one cache entry; remove it and retry |
+| `Git dependency … package.json main must be a string`          | A `main` that is an object, or a path escaping the checkout     |
+| `Git dependency … has no entry …`                              | `main`, or an object form's `entry`, names nothing              |
+| `cannot resolve module … from …`                               | A subpath import with no such file, or one leaving the checkout |
+
+## Publishing a shell package
+
+A shell package is a plain Git repository; `omarchy-ui` has no build output, no lockfile and no publish step. Beyond the five things that make it one, what makes it comfortable to depend on:
+
+- **A root `package.json` with `main`**, so consumers write one line and no `entry`. `"type": "module"` alongside it keeps the editor and the runtime agreeing that the source is ES modules.
+- **A single entry that re-exports the public surface.** `src/index.js` decides what a consumer can name; anything else in the checkout stays reachable by subpath, which is a useful escape hatch and a poor public API.
+- **Types beside the source**, through `types` in `package.json`. Generated `.d.ts` files or JSDoc both work, and both arrive at the call site through the link — a consumer's `jsconfig.json` needs no `paths` entry.
+- **Tags for releases**, so consumers can pin `#v1.2.0` instead of tracking `main`.
+- **A `gpui-shell` topic on the repository**, so someone looking for a shell package can find it.
+
+## Read next
+
+| Page                                              | What it covers                                                          |
+| ------------------------------------------------- | ----------------------------------------------------------------------- |
+| [Capabilities](./capabilities.md)                 | The rest of the manifest: identity, versions, and what a script may reach |
+| [Getting Started](./getting-started.md)           | `gpui-shell types`, `check`, and the declarations a dependency joins      |
+| [API Reference](./api.md)                         | The built-in modules a package imports alongside yours                    |

--- a/website/shell/dock.md
+++ b/website/shell/dock.md
@@ -1,7 +1,7 @@
 ---
 title: Dock and Panels
 description: A dockable layout drawn entirely by script — panels that survive a restart, chrome you draw yourself, and commands instead of callbacks.
-order: 12
+order: 13
 ---
 
 # Dock and Panels

--- a/website/shell/engine.md
+++ b/website/shell/engine.md
@@ -1,7 +1,7 @@
 ---
 title: The Engine Seam
 description: QuickJS behind one internal interface, why the seam exists, and the three measurements that tell script cost apart from frame cost.
-order: 14
+order: 15
 ---
 
 # The Engine Seam

--- a/website/shell/getting-started.md
+++ b/website/shell/getting-started.md
@@ -151,7 +151,7 @@ cargo run -p gpui-shell -- types hello
 
 This writes `gpui.d.ts` next to the application. Put `// @ts-check` at the top of a script and an editor will complete the whole API and reject a mistyped style method, a colour token that does not exist, or `.p("auto")` — at the call site, before it runs.
 
-It also sets up everything else the editor needs: each Git dependency the manifest declares is fetched and linked into `node_modules` under its declared name, so `import { style } from "omarchy-ui"` resolves to the same files the runtime will execute and carries the package's own types, parameters and JSDoc; and a `jsconfig.json` is scaffolded when the directory has neither that nor a `tsconfig.json`. See [Capabilities](./capabilities.md#the-manifest).
+It also sets up everything else the editor needs: each Git dependency the manifest declares is fetched and linked into `node_modules` under its declared name, so `import { style } from "omarchy-ui"` resolves to the same files the runtime will execute and carries the package's own types, parameters and JSDoc; and a `jsconfig.json` is scaffolded when the directory has neither that nor a `tsconfig.json`. See [Dependencies](./dependencies.md).
 
 The declarations can be trusted because they are **generated from the tables the runtime dispatches through**, not transcribed from this documentation:
 

--- a/website/shell/host-module.md
+++ b/website/shell/host-module.md
@@ -1,7 +1,7 @@
 ---
 title: HostModule
 description: How a host lends its own Rust to a script — registration, the import that reaches it, the plain-data boundary, and the rules a Host function runs under.
-order: 11
+order: 12
 ---
 
 # HostModule

--- a/website/shell/hosting.md
+++ b/website/shell/hosting.md
@@ -1,7 +1,7 @@
 ---
 title: Hosting
 description: The Rust side in full — runtime lifetime, mounting script Views, refreshing them from host state, metrics, exit requests and hot-reload.
-order: 10
+order: 11
 ---
 
 # Hosting

--- a/website/shell/index.md
+++ b/website/shell/index.md
@@ -198,6 +198,7 @@ What the script gains in exchange for the extra typing is the whole application 
 | [State and Views](./state.md) | `init` / `render`, `cx.notify()`, retained state, async |
 | [Overlays](./overlays.md) | Dialogs, the sheet, toasts, and the phase rule |
 | [Capabilities](./capabilities.md) | `gpui-shell.json`, default deny, filesystem, storage, process and network APIs |
+| [Dependencies](./dependencies.md) | Shell packages: what makes one, how a manifest names and pins it, and the types an editor gets |
 | [Hosting](./hosting.md) | The Rust side in full: mounting, refreshing, metrics, exit, hot-reload |
 | [HostModule](./host-module.md) | Lending the host's own Rust to a script, and the plain-data boundary |
 | [Dock and Panels](./dock.md) | A script View as a dockable panel, the chrome you draw for it, and what survives a restart |

--- a/website/shell/performance.md
+++ b/website/shell/performance.md
@@ -1,7 +1,7 @@
 ---
 title: Performance
 description: What a script costs once frame rate stops being the variable — invalidation against description size, the View as the boundary that bounds both, and the two failures FPS cannot tell apart.
-order: 13
+order: 14
 ---
 
 # Performance

--- a/website/zh-CN/shell/api.md
+++ b/website/zh-CN/shell/api.md
@@ -1,14 +1,14 @@
 ---
 title: API 参考
 description: 脚本能 import 或触及的每个名字——四个内置模块、cx 与 window 全局对象，以及那些不是样式的元素方法。
-order: 9
+order: 10
 ---
 
 # API Reference
 
 脚本接口的一份清单：有什么，以及它来自哪个模块。其余页面解释每样东西为什么是这个样子——这一页是用来查名字的。
 
-权威不在这一页。runtime 会为自己的版本生成 `gpui.d.ts`，并在应用加载时尽力刷新到源码旁；`gpui-shell types <directory>` 执行同一次写入，并会明确报告失败。生成文件的头部带有 `gpui-shell` 版本，也包含该应用注册的 HostModule 。请忽略这个文件而不要提交，并在脚本顶部写上 `// @ts-check` 让编辑器照着它检查。manifest 声明的 Git 依赖同样不在这一页：它们由同一次刷新链接进 `node_modules`，名字、签名与文档都来自 package 自身。
+权威不在这一页。runtime 会为自己的版本生成 `gpui.d.ts`，并在应用加载时尽力刷新到源码旁；`gpui-shell types <directory>` 执行同一次写入，并会明确报告失败。生成文件的头部带有 `gpui-shell` 版本，也包含该应用注册的 HostModule 。请忽略这个文件而不要提交，并在脚本顶部写上 `// @ts-check` 让编辑器照着它检查。manifest 声明的 Git 依赖同样不在这一页：它们由同一次刷新链接进 `node_modules`，名字、签名与文档都来自 package 自身。见[依赖](./dependencies.md)。
 
 ## 模块
 

--- a/website/zh-CN/shell/capabilities.md
+++ b/website/zh-CN/shell/capabilities.md
@@ -90,73 +90,12 @@ process.exit() is not granted; set capabilities.process.exit to true in the mani
 }
 ```
 
-字符串形式支持严格的 GitHub 简写或完整 Git URL，两者都可以带可选的 `#ref`：
-
-```json
-{
-  "dependencies": {
-    "default-main": "huacnlee/omarchy-ui",
-    "named-ref": "huacnlee/omarchy-ui#v1.2.0",
-    "full-url": "https://github.com/huacnlee/omarchy-ui#0123456789abcdef0123456789abcdef01234567",
-    "remote-head": "https://github.com/huacnlee/omarchy-ui"
-  }
-}
-```
-
-不带 `#ref` 的 GitHub 简写默认选择 `main`；不带 `#ref` 的完整 URL 则选择远端
-HEAD。ref 可以是 branch、tag 或 commit-ish（例如 commit ID）。每次加载应用时都会
-重新 fetch 并解析 branch、tag 或远端 HEAD；commit ID 始终选择同一个 commit。
-
-创建不可变 checkout 后，gpui-shell 会读取根目录的 `package.json`。字符串类型的
-`main` 指定 package entry；没有 `package.json` 或没有 `main` 时默认使用
-`index.js`。格式错误的 metadata、非字符串 `main`、逃出 checkout 的 entry，或未
-解析到文件的 entry，都会在应用 JavaScript 执行前令加载失败。
-
-旧的 object 形式保持完全兼容：它必须显式且只指定一个 `branch` 或 `tag`，可选的
-repository-relative `entry` 仍默认是 `index.js`。现有 manifest 无需迁移；若改为
-字符串形式，则应通过 `package.json` 的 `main`（或根目录 `index.js`）发布 entry：
-
-```json
-{
-  "dependencies": {
-    "omarchy-ui": {
-      "git": "https://github.com/huacnlee/omarchy-ui",
-      "branch": "main",
-      "entry": "src/public.js"
-    }
-  }
-}
-```
-
-gpui-shell 把依赖存储在 `~/.gpui-shell/cache/dependencies/`。每个 remote 的锁会串行化
-mirror 更新；mirror 发布不可变的、按 commit 寻址的 checkout，因此并发加载和旧
-module generation 不会互相改写。去掉 fragment 后的完整 URL 同时是 remote identity
-和 cache identity。gpui-shell 会校验 raw configured origin，同时允许 Git 的
-`url.*.insteadOf` 规则选择实际 fetch URL。Git 以非交互方式运行，每条命令限时 30
-秒。JavaScript 以 map key 作为裸模块名导入，例如
-`import { label, style } from "omarchy-ui"`；依赖内部的相对 import 和 package
-subpath import 都不能逃出该 checkout。下载使用 Host 上的 `git`，不属于脚本的
-network capability。
-
-编辑器解析同一条 import 的方式完全不同：它从导入文件向上查找 `node_modules`，对
-manifest 一无所知。于是一条正确的 import 会被标红成找不到的模块，它背后的每个名字
-也随之失去类型、参数提示和文档。因此每次加载——以及 `gpui-shell types`——都会把
-materialize 出来的 checkout 按 manifest 给的名字链接到
-`<application>/node_modules`；若目录里既没有 `jsconfig.json` 也没有
-`tsconfig.json`，还会生成一份 `jsconfig.json`。这样编辑器读到的就是运行时即将执行
-的同一批文件，它显示的签名和 JSDoc 不会和实际运行的代码脱节。
-
-只有 gpui-shell 自己写下的条目会被替换或删除——指向依赖缓存的 symlink，或带有它
-标记文件的目录——因此同名的已安装 package 不会被动到；manifest 中已移除的依赖，其
-链接也会一并清除。若平台拒绝创建 symlink（例如权限不足的 Windows 进程），
-gpui-shell 改为写入一个转发该 checkout 的小 package：裸 import 的类型效果相同，
-package subpath import 则无法解析。
-
-目录之所以叫 `node_modules`，是因为所有编辑器只认这一个位置；这里没有包管理器
-参与，不会从 registry 下载任何东西，每一项都只是指向 gpui-shell 已经拉好的 Git
-checkout 的链接。这个名字还换来了安静：TypeScript 会把从这里解析到的内容视为
-external library，不再把依赖自身的 implicit-`any` 之类诊断当成你的代码来报。
-`node_modules` 和 `gpui.d.ts` 一样属于生成物，两者都应加入忽略列表。
+`dependencies` 把裸模块名映射到一个 JavaScript package，gpui-shell 会在 entry
+module 运行之前从 Git 抓取它——`import { Title } from "omarchy-ui"`。字符串形式
+接受严格的 GitHub 简写或完整 Git URL，可带可选的 `#ref`；显式指定 `branch` 或
+`tag` 的 object 形式同样保持支持。每次加载还会把 package 链接到编辑器能找到的
+位置，于是这条 import 会带上 package 自己的类型与文档。版本选择、package entry、
+缓存，以及编辑器看见的东西，详见[依赖](./dependencies.md)。
 
 这个块里的每项授权省略时都默认**拒绝**，只有 `storage` 默认给予——要拒绝它就写 `"storage": false`。
 

--- a/website/zh-CN/shell/dependencies.md
+++ b/website/zh-CN/shell/dependencies.md
@@ -1,0 +1,248 @@
+---
+title: 依赖
+description: shell package——什么样的 Git 仓库算一个，以及 manifest 如何命名、选择版本、抓取与导入它，直到编辑器看见它。
+order: 9
+---
+
+# 依赖
+
+应用用相对路径 import 自己的文件。除此之外，它写下的每一条 import 只有两个来源：运行时提供的**内建模块**——`gpui`、`gpui-base`、`gpui-shell`、`gpui-fps`，以及标准运行时的 `fs/promises`、`path`、`crypto`、`net`、`websocket`——或者一个**依赖**：manifest 声明、gpui-shell 在 entry module 求值之前从 Git 抓取的 JavaScript package。
+
+这里没有 registry，没有包管理器，也没有安装步骤。一个依赖就是一个 Git remote、一个 ref，加上脚本 import 它时用的名字。
+
+## Shell package
+
+依赖可以是 manifest 指向的任何一个 Git 仓库。`omarchy-ui` 属于其中一类，而这一类有自己的名字：**shell package**——为 gpui-shell 而写、而不是为 Node 或浏览器而写的 JavaScript package，就像 crate 是为 Cargo 而写的一样。五件事决定一个仓库是不是 shell package：
+
+| shell package                                          | 原因                                                       |
+| ------------------------------------------------------ | ---------------------------------------------------------- |
+| 发布 ES module，且不需要构建步骤                       | 运行时直接求值 checkout 里的文件，而且 `require` 不存在     |
+| 根目录 `package.json` 带 `"type": "module"` 与 `main`   | 它让声明只需一行，并同时向运行时和编辑器指明 entry          |
+| 只 import 内建模块与自己的文件                          | 其余的都解析不了——它无法反向伸回 import 它的应用            |
+| 把 `gpui` 与 `gpui-base` 当作由环境提供，而非自己的依赖 | 它们来自加载它的运行时，版本由 Host 决定                    |
+| 不声明任何属于自己的 capability                         | 它的 `fs` 与 `fetch` 调用都跑在使用方应用的授权之下         |
+
+这个名字不会被任何代码读取：依赖是靠被声明来识别的，不是靠被贴标签。它的作用是让一个作者写下、另一个作者找到；写给搜索引擎的那一份，是仓库上的 `gpui-shell` topic。
+
+[`omarchy-ui`](https://github.com/huacnlee/omarchy-ui) 就是一个 shell package，本页余下部分都以它为例。
+
+## 声明一个依赖
+
+`omarchy-ui` 是一个提供展示组件与主题工具的 shell package。在 `gpui-shell.json` 里加一行就够了：
+
+```json
+{
+  "id": "com.example.projects",
+  "name": "Projects",
+  "entry": "main.js",
+  "dependencies": {
+    "omarchy-ui": "huacnlee/omarchy-ui"
+  }
+}
+```
+
+map key 就是脚本使用的裸模块名——package 内部并不参与决定它。是 manifest 给 package 起名，就像 import 的 `as` 子句那样：两个应用可以用不同名字引用同一个 remote，而仓库改名也不会改变 import：
+
+```js
+import {
+  AppShell,
+  Button,
+  CenteredWorkspace,
+  MutedText,
+  PageColumn,
+  Surface,
+  Title,
+} from "omarchy-ui";
+
+export function render(cx) {
+  const card = new Surface()
+    .children([
+      new Title("Projects").build(cx),
+      new MutedText("Choose a project to continue").build(cx),
+      new Button("project-create")
+        .label("Create project…")
+        .onClick((_event, context) => context.notify())
+        .build(cx),
+    ])
+    .build(cx);
+
+  const page = new PageColumn("projects-page").child(card).build(cx);
+  return new AppShell()
+    .content(new CenteredWorkspace("projects-workspace").content(page).build(cx))
+    .build(cx);
+}
+```
+
+其他什么都不用改。脚本还是[快速开始](./getting-started.md)里的那个脚本，依赖只是拓宽了它能 import 的范围。
+
+## 什么能解析，解析到哪里
+
+| 写法                             | 解析结果                                                     |
+| -------------------------------- | ------------------------------------------------------------ |
+| `"omarchy-ui"`                   | package entry——见 [package entry](#package-entry)            |
+| `"omarchy-ui/src/style"`         | checkout 内的该文件，`.js` 后缀可省略                        |
+| package 内部的 `"./theme.js"`    | 该 package 自己 checkout 内的文件                            |
+| package 内部的 `"gpui"`          | 内建模块，与应用代码中完全一致                               |
+| 另一个已声明的依赖名             | 那个 package 的 entry——已声明的 package 之间互相可见         |
+| 从 package 内部用裸名 import 应用文件 | 拒绝：package 不能反向伸回 import 它的应用                |
+
+解析结果一旦离开起点所在的 checkout，就会在模块加载前被拒绝，因此 `../` 无法走出一个 package、进入旁边的缓存。在应用目录内，同一条边界就是应用根目录，也正是[沙箱](./capabilities.md#沙箱)对相对 import 已有的规则。
+
+**依赖不是第二层沙箱。** 它在应用自己的上下文里求值，持有的授权与 manifest 完全相同：package 读文件，用的就是你的 `fs.read` 范围。声明一个依赖，等于像引入一个 Rust crate 那样信任它的代码，而你钉住的 ref 决定了那究竟是哪一份代码。
+
+## 选择版本
+
+字符串形式是严格的 GitHub 简写或完整 Git URL，两者都可带可选的 `#ref`：
+
+```json
+{
+  "dependencies": {
+    "default-main": "huacnlee/omarchy-ui",
+    "named-ref": "huacnlee/omarchy-ui#v1.2.0",
+    "commit": "https://github.com/huacnlee/omarchy-ui#0123456789abcdef0123456789abcdef01234567",
+    "remote-head": "https://github.com/huacnlee/omarchy-ui"
+  }
+}
+```
+
+| 形式                       | 选中                        |
+| -------------------------- | --------------------------- |
+| `owner/repository`         | `main`                      |
+| `owner/repository#ref`     | 该 branch、tag 或 commit-ish |
+| `https://…/repository`     | remote 的 `HEAD`            |
+| `https://…/repository#ref` | 该 branch、tag 或 commit-ish |
+
+简写形式故意收得很紧：恰好一组 `owner/repository`，字符限于字母数字与 `.`、`-`、`_`，最多一个 `#`，前后不能有空白，fragment 必须是合法的 Git ref 名。其余一律作为 manifest 错误，而不是从一个笔误里猜出 URL。完整 URL 可以是任意 Git 传输方式，包括 `ssh://` 与 `git@host:owner/repo`。
+
+**branch、tag 或 remote `HEAD` 在每次加载应用时都会重新 fetch 并解析；commit ID 永远选中同一个 commit。** 依赖一个 branch，意味着下次开窗时代码会在你脚下变化——这在你自己开发 package 时很方便，而在你发布之后就是一个供应链决定。凡是不由你掌控的东西，请钉住 tag 或 commit。
+
+抓取需要 Host 的 `PATH` 上有 `git`，并且发生在脚本 capability 存在之前——这是 gpui-shell 代表应用运行 Git，不是脚本在访问网络，因此它不受 `capabilities.network` 管辖，也不需要 `fs.execute`。当没有东西要抓（缓存里已有该 commit）时，这次加载完全不产生网络访问；而当依赖是移动 ref 且当前没有网络时，fetch 失败，应用不会加载。
+
+## Package entry
+
+checkout 就绪后，gpui-shell 读取 package 根目录的 `package.json`，把字符串类型的 `main` 作为 entry。`omarchy-ui` 发布的是：
+
+```json
+{
+  "type": "module",
+  "main": "src/index.js",
+  "types": "src/index.d.ts"
+}
+```
+
+于是 `import { Title } from "omarchy-ui"` 求值的是 `src/index.js`。没有 `package.json`，或者其中没有 `main` 时，entry 是根目录的 `index.js`。
+
+运行时读 `main`，编辑器读 `types`。两者出自同一个文件——这正是为什么一个附带 `.d.ts` 的 package 不需要应用做任何事，就能在调用处拥有完整类型。
+
+JSON 格式错误、非字符串 `main`，以及缺失、不是文件或逃出 checkout 的 entry，都会在应用 JavaScript 执行前令加载失败。
+
+## Object 形式
+
+最初的 object 形式保持完全兼容。它必须显式且只指定一个 `branch` 或 `tag`，其 repository 相对的 `entry` 默认是 `index.js`：
+
+```json
+{
+  "dependencies": {
+    "omarchy-ui": {
+      "git": "https://github.com/huacnlee/omarchy-ui",
+      "tag": "v1.2.0",
+      "entry": "src/index.js"
+    }
+  }
+}
+```
+
+现有 manifest 无需迁移。改用字符串形式，意味着由 package 通过 `package.json` 的 `main`（或根目录 `index.js`）自己发布 entry，而不是让每个使用方各写一遍。
+
+## 缓存
+
+```text
+~/.gpui-shell/cache/dependencies/
+├── locks/<remote>.lock
+├── mirrors/<remote>.git
+└── checkouts/<remote>/<commit>/
+```
+
+`<remote>` 是去掉 fragment 后完整 URL 的 SHA-256，它既是 remote 的身份，也是缓存的身份。每个 remote 一把锁，串行化 mirror 更新。checkout 按 commit 寻址且从不改写，因此并发启动与旧的 hot-reload generation 各自读到自己开始时的那棵树。
+
+每次使用都会拿 mirror 的 configured origin 与 manifest 校验，且比较的是原始配置值——Git 的 `url.*.insteadOf` 仍可以选择另一个实际 fetch URL，镜像站或企业内网替换因此照常可用。Git 以非交互方式运行，禁用凭据提示，每条命令限时 30 秒，于是一个要求输入密码的仓库会给出错误信息，而不是把一个正等着打开的窗口挂在那里。
+
+这份缓存不会被自动清理。它是内容寻址的，所以直接删掉是安全的：下次加载会重新抓取需要的部分。
+
+## 编辑器看见的东西
+
+运行时靠 manifest 回答 `import { Title } from "omarchy-ui"`。编辑器则是从 import 所在文件向上查找 `node_modules`，它从来没听说过 `gpui-shell.json`。放着不管，一条正确的 import 会被标红成找不到的模块，它背后的每个名字也随之失去类型、参数提示和文档。
+
+因此每次加载——以及 `gpui-shell types`——都会把 materialize 出来的 checkout 按 manifest 给的名字链接进应用的 `node_modules`：
+
+```text
+projects/
+├── gpui-shell.json
+├── main.js
+├── gpui.d.ts          运行时生成——请忽略
+├── jsconfig.json      只生成一次，之后归你
+└── node_modules/
+    └── omarchy-ui  →  ~/.gpui-shell/cache/dependencies/checkouts/<remote>/<commit>
+```
+
+这样编辑器读到的，就是运行时即将执行的同一批文件，它显示的签名与 JSDoc 都来自 package 自身，不会与实际运行的代码脱节。
+
+只有 gpui-shell 自己写下的条目会被替换或删除——指向自身依赖缓存的 symlink，或带有它标记文件的目录。同名的已安装 package 不会被动到；manifest 中已移除的依赖，其链接也会一并清除。若平台拒绝创建 symlink（例如未开启开发者模式、权限不足的 Windows 进程），gpui-shell 改为写入一个转发该 checkout 的小 package：裸 import 的类型效果相同，只有 package subpath import 无法解析。
+
+当目录里既没有 `jsconfig.json` 也没有 `tsconfig.json` 时会生成一份 `jsconfig.json`，且只生成一次——已有的配置永远不会被替换。它不是装饰：靠推断得到的 `moduleResolution` 可能落到那种从不查看 `node_modules` 的解析方式，把运行时明明能解析的依赖标红；而默认的 `lib` 会把浏览器的全局对象塞给脚本，它们的声明与 `gpui.d.ts` 产生冲突，于是描述 API 的那个文件本身反倒被报成错误。
+
+`node_modules` 和 `gpui.d.ts` 一样属于生成物，两者都应加入忽略列表：
+
+```text
+gpui.d.ts
+node_modules/
+```
+
+这个目录之所以叫 `node_modules`，是因为所有编辑器只认这一个位置；这里没有包管理器参与，也没有任何东西来自 registry。这个名字还换来了安静：TypeScript 会把从这里解析到的内容视为 external library，于是依赖自身的 implicit-`any` 之类诊断不会混进你自己的诊断里。
+
+## 抓取与链接何时发生
+
+| 调用                                          | 抓取并链接 | 失败时                                  |
+| --------------------------------------------- | ---------- | --------------------------------------- |
+| `gpui-shell <directory>`                       | 是         | 加载失败；仅链接这一步是 best-effort    |
+| `gpui-shell check <directory>`                 | 是         | 作为 check 失败报告                     |
+| `gpui-shell types <directory>`                 | 是         | 报告错误，并带非零退出码                |
+| 嵌入式 Host 的 `ShellRuntime::load`            | 是         | 加载失败；仅链接这一步是 best-effort    |
+| `gpui_shell::write_dependency_links(root)`     | 是         | 以 error 返回给调用方                   |
+
+加载依赖抓取，所以无法 materialize 的依赖会让加载失败。写编辑器链接则不然：只读的应用目录是失去编辑器类型的理由，不是拒绝运行的理由。`gpui-shell types` 存在的意义正是这个差别——它做同样的事，并把没能完成的部分报出来。
+
+hot-reload 对待 package 的方式与对待应用文件一致：每次加载都是一个新的 module generation，所以重启应用就足以让一个 branch 依赖前进到新的 commit。
+
+## 可能的失败
+
+以下每一种都在应用 JavaScript 求值之前报告：
+
+| 信息                                                       | 原因                                                    |
+| ---------------------------------------------------------- | ------------------------------------------------------- |
+| `GitHub shorthand must contain exactly owner/repository …`  | 简写里带了路径、scheme 或非法字符                       |
+| `a string dependency #Git ref must not be empty`            | 末尾多了一个 `#`                                        |
+| `could not clone Git dependency …`                          | Git 失败：remote 不存在、没有凭据、没有网络             |
+| `git timed out after 30 seconds …`                          | fetch 卡住，通常是弹出了交互式凭据提示                  |
+| `Git dependency … cache origin is …, expected …`            | 两个 manifest 对同一条缓存记录不一致；删掉它再试        |
+| `Git dependency … package.json main must be a string`       | `main` 是对象，或是逃出 checkout 的路径                 |
+| `Git dependency … has no entry …`                           | `main` 或 object 形式的 `entry` 指向不存在的东西        |
+| `cannot resolve module … from …`                            | subpath import 指向不存在的文件，或离开了 checkout      |
+
+## 发布一个 shell package
+
+shell package 就是一个普通的 Git 仓库：`omarchy-ui` 没有构建产物、没有 lockfile，也没有发布步骤。在决定它是不是 shell package 的那五件事之外，让它用起来舒服的是这些：
+
+- **根目录 `package.json` 里的 `main`**，使用方只写一行、不用写 `entry`。旁边的 `"type": "module"` 让编辑器和运行时对「源码是 ES module」保持一致。
+- **一个统一 re-export 公开面的 entry。** 由 `src/index.js` 决定使用方能叫出哪些名字；checkout 里的其余文件仍可通过 subpath 触达——那是有用的应急出口，却是糟糕的公开 API。
+- **类型放在源码旁边**，通过 `package.json` 的 `types` 指出。生成的 `.d.ts` 与 JSDoc 都可以，两者都会顺着链接抵达调用处——使用方的 `jsconfig.json` 不需要任何 `paths` 配置。
+- **为发布打 tag**，让使用方可以钉住 `#v1.2.0`，而不是跟着 `main` 走。
+- **在仓库上加 `gpui-shell` topic**，让想找 shell package 的人能找到它。
+
+## 继续阅读
+
+| 页面                                    | 内容                                               |
+| --------------------------------------- | -------------------------------------------------- |
+| [能力](./capabilities.md)               | manifest 的其余部分：身份、版本，以及脚本能触达什么 |
+| [快速开始](./getting-started.md)        | `gpui-shell types`、`check`，以及依赖加入的那份声明 |
+| [API 参考](./api.md)                    | package 与你的代码一同 import 的内建模块            |

--- a/website/zh-CN/shell/dock.md
+++ b/website/zh-CN/shell/dock.md
@@ -1,7 +1,7 @@
 ---
 title: Dock 与面板
 description: 完全由脚本绘制的可停靠布局——重启后仍在原处的面板、自己画的 chrome，以及用命令代替回调。
-order: 12
+order: 13
 ---
 
 # Dock 与面板

--- a/website/zh-CN/shell/engine.md
+++ b/website/zh-CN/shell/engine.md
@@ -1,7 +1,7 @@
 ---
 title: 引擎接缝
 description: QuickJS 位于一条内部接口之后、这条分界线存在的理由，以及把脚本成本与帧成本分开的三项实测。
-order: 14
+order: 15
 ---
 
 # The Engine Seam

--- a/website/zh-CN/shell/getting-started.md
+++ b/website/zh-CN/shell/getting-started.md
@@ -150,7 +150,7 @@ cargo run -p gpui-shell -- types hello
 
 它会在应用旁边写出 `gpui.d.ts`。在脚本顶部加上 `// @ts-check`，编辑器就会补全整套 API，并在运行之前、在调用点上直接拒绝拼错的样式方法、不存在的颜色 token，或者 `.p("auto")`。
 
-它同时会把编辑器需要的其余部分一并配好：manifest 声明的每个 Git 依赖都会被抓取并按声明的名字链接进 `node_modules`，于是 `import { style } from "omarchy-ui"` 解析到的正是运行时将要执行的那批文件，连同该 package 自己的类型、参数与 JSDoc；若目录里既没有 `jsconfig.json` 也没有 `tsconfig.json`，还会生成一份 `jsconfig.json`。详见[能力](./capabilities.md#the-manifest)。
+它同时会把编辑器需要的其余部分一并配好：manifest 声明的每个 Git 依赖都会被抓取并按声明的名字链接进 `node_modules`，于是 `import { style } from "omarchy-ui"` 解析到的正是运行时将要执行的那批文件，连同该 package 自己的类型、参数与 JSDoc；若目录里既没有 `jsconfig.json` 也没有 `tsconfig.json`，还会生成一份 `jsconfig.json`。详见[依赖](./dependencies.md)。
 
 这份声明可信，是因为它**从运行时实际派发所依据的那几张表生成**，而不是照着文档抄的：
 

--- a/website/zh-CN/shell/host-module.md
+++ b/website/zh-CN/shell/host-module.md
@@ -1,7 +1,7 @@
 ---
 title: HostModule
 description: Host 如何把自己的 Rust 借给脚本——注册、脚本侧的 import、纯数据边界，以及 Host function 运行时受到的约束。
-order: 11
+order: 12
 ---
 
 # HostModule

--- a/website/zh-CN/shell/hosting.md
+++ b/website/zh-CN/shell/hosting.md
@@ -1,7 +1,7 @@
 ---
 title: Hosting
 description: Rust 这一侧的全貌——运行时的生命周期、挂载脚本 View、从 Host 状态刷新它、指标、退出请求与 hot-reload。
-order: 10
+order: 11
 ---
 
 # Hosting

--- a/website/zh-CN/shell/index.md
+++ b/website/zh-CN/shell/index.md
@@ -198,6 +198,7 @@ GPUI 的元素是**被消费**的值：`RenderOnce::render` 按值取走 `self`�
 | [State and Views](./state.md) | `init` / `render`、`cx.notify()`、留存状态、异步 |
 | [Overlays](./overlays.md) | dialog、sheet、toast，以及 phase 规则 |
 | [Capabilities](./capabilities.md) | `gpui-shell.json`、默认拒绝、文件、存储、进程与网络 API |
+| [依赖](./dependencies.md) | shell package：什么样的仓库算一个，manifest 如何命名与钉住它，以及编辑器拿到的类型 |
 | [Hosting](./hosting.md) | Rust 这一侧的全貌：挂载、刷新、指标、退出、hot-reload |
 | [HostModule](./host-module.md) | 把 Host 自己的 Rust 借给脚本，以及那条纯数据边界 |
 | [Dock 与面板](./dock.md) | 把脚本 View 变成可停靠面板、为它绘制 chrome，以及重启后什么会留下 |

--- a/website/zh-CN/shell/performance.md
+++ b/website/zh-CN/shell/performance.md
@@ -1,7 +1,7 @@
 ---
 title: 性能
 description: 当帧率不再是变量之后，JavaScript 真正的开销——失效频率乘以描述规模、每个 View 各自的 Snapshot，以及 FPS 分辨不出来的那两类问题。
-order: 13
+order: 14
 ---
 
 # Performance


### PR DESCRIPTION
A manifest's Git dependencies were documented as eight paragraphs inside [Capabilities](https://gpui-component.dev/shell/capabilities), a page about what a script may *not* reach. Someone adding a package to an application had no reason to look there, and what they found once they did stopped short of what they needed: no worked example, no account of what a bare import actually resolves to, nothing on what fails and when.

They now have a page. It follows one real package, [`huacnlee/omarchy-ui`](https://github.com/huacnlee/omarchy-ui), end to end — the manifest line that declares it, the import it answers, the ref that pins it, the `package.json` `main` that names its entry, the cache it lands in, the `node_modules` link that gives an editor its types, and the eight failures that are reported before any application JavaScript runs.

It also names the thing. **A shell package** is a JavaScript package written for gpui-shell rather than for Node or a browser, and five requirements make a repository one — ES modules and no build step, a root `package.json` with `"type": "module"` and `main`, imports confined to the built-ins and its own files, `gpui` and `gpui-base` treated as provided, and no capabilities of its own. The term was missing, so every sentence about one had to describe it again from scratch.

Nothing in the runtime changed; this is the documentation for #2879 and #2888.

## What moved

`capabilities.md` keeps the `dependencies` field in its manifest example plus a five-line summary, and points at the new page. `index.md`, `getting-started.md` and `api.md` link to it, and the six pages after it shift `order` by one. Both locales, as always.

## Verified

`typos` and `vitepress build` — the latter includes VitePress's dead-link check. Every claim on the page was read out of `crates/shell/src/dependencies.rs`, `plugin.rs`, `typings.rs` and the module resolver rather than restated from the previous prose; the `omarchy-ui` example is its real `package.json` and its real README usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3vsniPbu2S8bQRZEqSA5u