### PR TITLE
scroll: Restore the Markdown table's wheel axis lock

### DIFF
--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -47,6 +47,7 @@ mod progress;
 mod radio;
 mod radio_group;
 mod resizable;
+mod scrollable_mask;
 mod scrollbar;
 mod select;
 mod selectable_text;
@@ -138,6 +139,7 @@ pub use resizable::{
     ResizablePanel, ResizablePanelEvent, ResizablePanelGroup, ResizableState, ResizeHandleContext,
     ResizeHandleRenderer, h_resizable, resizable_panel, v_resizable,
 };
+pub use scrollable_mask::ScrollableMask;
 pub use scrollbar::{
     Scrollbar, ScrollbarAxis, ScrollbarEntrance, ScrollbarHandle, ScrollbarMode, ScrollbarMotion,
     ScrollbarStyles, ScrollbarThumbStyle, ScrollbarTrackStyle,

--- a/crates/base/src/scrollable_mask.rs
+++ b/crates/base/src/scrollable_mask.rs
@@ -10,9 +10,15 @@ use gpui::{
 };
 use gpui::{Corners, Pixels};
 
-use super::ScrollbarHandle;
-use super::scrollable::caller_id;
-use crate::{AxisExt, OngoingScrollExt as _, StyledExt as _};
+use crate::{AxisExt, OngoingScrollExt as _, ScrollbarHandle, StyledExt as _};
+
+/// Default element id for a mask: the call site, so two masks built in
+/// different places never share their per-gesture axis lock.
+#[inline]
+#[track_caller]
+fn caller_id() -> ElementId {
+    ElementId::CodeLocation(*std::panic::Location::caller())
+}
 
 /// A horizontal scroll viewport that only consumes horizontal wheel deltas.
 ///
@@ -20,7 +26,6 @@ use crate::{AxisExt, OngoingScrollExt as _, StyledExt as _};
 /// scrolling when there is no vertical overflow. This wrapper keeps the visual
 /// clipping and scroll offset, while delegating wheel input to [`ScrollableMask`]
 /// so vertical wheel events can continue bubbling to the parent scroller.
-#[allow(dead_code)]
 pub(crate) fn horizontal_scroll_area(
     id: impl Into<ElementId>,
     scroll_handle: &ScrollHandle,

--- a/crates/base/src/text/node.rs
+++ b/crates/base/src/text/node.rs
@@ -8,13 +8,14 @@ use gpui::{
     AnyElement, App, DefiniteLength, Div, ElementId, FontStyle, FontWeight, HighlightStyle, Hsla,
     Image, ImageFormat, InteractiveElement as _, IntoElement, Length, ObjectFit, Overflow,
     ParentElement, Pixels, ScrollHandle, SharedString, SharedUri, StatefulInteractiveElement,
-    Styled, StyledImage as _, WhiteSpace, Window, div, img, prelude::FluentBuilder as _, px,
-    relative, rems,
+    StyleRefinement, Styled, StyledImage as _, WhiteSpace, Window, div, img,
+    prelude::FluentBuilder as _, px, relative, rems,
 };
 use markdown::mdast;
 
 use crate::{
     StyledExt, h_flex,
+    scrollable_mask::horizontal_scroll_area,
     text::{
         CodeBlockActionsFn, CodeBlockHighlighterFn, LinkClickHandlerFn, MarkdownExtensions,
         MarkdownNode, TableActionsFn,
@@ -2178,22 +2179,27 @@ impl BlockNode {
                 // Scroll viewport owns the visible frame, including any
                 // caller-provided radius. Keeping the border here makes the
                 // rounded frame stable while the wider row track moves below it.
-                div()
-                    .id(("table", options.ix))
-                    .bg(cx.theme().tokens.colors.surface)
-                    .border_1()
-                    .border_color(style.border())
-                    .overflow_x_scroll()
-                    .track_scroll(&scroll_handle)
-                    .refine_style(&style.table())
-                    .child(
-                        // Row track sized to `max(viewport, column floors)`:
-                        // `min_w_full` fills the frame while the columns can still
-                        // shrink-to-fit (their text wrapping), the definite
-                        // `w(min_total_w)` keeps the floors once they are reached,
-                        // letting the track exceed the viewport and scroll.
-                        div().min_w_full().w(px(min_total_w)).children(rows),
-                    ),
+                //
+                // `horizontal_scroll_area` clips with `overflow_hidden` and
+                // delegates the wheel to a sibling `ScrollableMask`, so the
+                // gesture is locked to its starting axis and a horizontal swipe
+                // is consumed before an ancestor scroller (`gpui::list` under
+                // `TextView::scrollable`) can take its vertical component.
+                horizontal_scroll_area(
+                    ("table", options.ix),
+                    &scroll_handle,
+                    &StyleRefinement::default()
+                        .bg(cx.theme().tokens.colors.surface)
+                        .border_1()
+                        .border_color(style.border())
+                        .refine_style(style.table()),
+                    // Row track sized to `max(viewport, column floors)`:
+                    // `min_w_full` fills the frame while the columns can still
+                    // shrink-to-fit (their text wrapping), the definite
+                    // `w(min_total_w)` keeps the floors once they are reached,
+                    // letting the track exceed the viewport and scroll.
+                    div().min_w_full().w(px(min_total_w)).children(rows),
+                ),
             )
             // Custom actions row (e.g. copy / download) rendered below the
             // table. The hook's element spans full width; alignment is up to

--- a/crates/ui/src/scroll/mod.rs
+++ b/crates/ui/src/scroll/mod.rs
@@ -1,13 +1,12 @@
 mod scrollable;
-mod scrollable_mask;
 
 pub use gpui_base::AutoScroll;
+pub use gpui_base::ScrollableMask;
 pub use gpui_base::{
     Scrollbar, ScrollbarAxis, ScrollbarEntrance, ScrollbarHandle, ScrollbarMode, ScrollbarMotion,
     ScrollbarStyles, ScrollbarThumbStyle, ScrollbarTrackStyle,
 };
 pub use scrollable::*;
-pub use scrollable_mask::*;
 
 #[cfg(test)]
 mod tests {

--- a/crates/ui/src/scroll/scrollable.rs
+++ b/crates/ui/src/scroll/scrollable.rs
@@ -207,7 +207,7 @@ where
 
 #[inline]
 #[track_caller]
-pub(super) fn caller_id() -> ElementId {
+fn caller_id() -> ElementId {
     ElementId::CodeLocation(*Location::caller())
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -398,6 +398,17 @@ masking, deferred scroll-to-item requests, and clamped offsets. The caller owns
 item sizes and renders only the requested range. Tree builds on GPUI's uniform
 list because its visible entries share a row height.
 
+`ScrollableMask` owns wheel dispatch, not scrolling. GPUI's own overflow
+listener runs in the bubble phase and never stops propagation, so a scroll area
+nested inside another one cannot win: `gpui::list` registers its listener after
+its items paint, and bubble runs in reverse registration order. The mask is a
+sibling of the scrolled element that consumes axis-dominant wheel events in the
+capture phase, locks each gesture to the axis it started on, and stays inert
+while occluded. Edge semantics differ per axis, matching platform scrollers: a
+vertical mask chains to the ancestor at the edge, a horizontal one keeps
+consuming. `horizontal_scroll_area` is the paired viewport and mask, used by the
+Markdown scrolling table.
+
 One handle represents one logical viewport. Sharing a handle between nested or
 unrelated scroll areas causes offsets, hitboxes, and scrollbar geometry to
 interfere.


### PR DESCRIPTION
## Description

A trackpad swipe over a horizontally scrollable Markdown table scrolled the
document instead, and scrolling the document slid the table sideways.

#2881 moved the table renderer into `gpui-base` and replaced
`horizontal_scroll_area()` — an `overflow_hidden` viewport plus a sibling
`ScrollableMask` — with a plain `div().overflow_x_scroll()`, dropping #2468,
#2608 and #2648 in one step. The only trace was an `#[allow(dead_code)]` added
to the now-unreachable helper, so CI stayed green: the mask's tests cover the
mask, not whether the table uses it.

`ScrollableMask` moves to `gpui-base` with its 16 tests (its dependencies —
`ScrollbarHandle`, `AxisExt`, `StyledExt`, `OngoingScrollExt` — already lived
there), and the table calls `horizontal_scroll_area` again. The viewport keeps
the border and background #2881 put on it, folded into the refinement.

`gpui-component`'s public API is unchanged: `gpui_component::scroll::ScrollableMask`
still resolves, now re-exported from Base.

## Why the mask, and not `restrict_scroll_to_axis`

`.lock_scroll_axis()` alone fixes only half of it. GPUI's overflow listener runs
in the bubble phase and never stops propagation, and `gpui::list` — the body
under `TextView::scrollable(true)` — registers its listener after its items
paint, so bubble's reverse order runs the list first. A diagonal swipe therefore
loses its vertical component to the document no matter what the table does.
Winning requires consuming the event in the capture phase, which is what the
mask is for.

## Test plan

- `cargo test -p gpui-base --lib scrollable_mask` — 16 tests, including
  `horizontal_scroll_area_in_list_keeps_horizontal_dominant_wheel`, which is the
  regression this PR fixes
- `cargo test --workspace --exclude gpui-shell`
- `cargo test -p gpui-component --doc`
- `cargo check -p gpui-component --no-default-features`
- `cargo clippy --workspace --exclude gpui-shell --all-targets -- --deny warnings`
- `cargo fmt --check`
- By hand with a trackpad: `cargo run -p markdown_table`, and at several frame
  widths via `WIN_W=<px>`

---

Parts of this PR were written with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
