### PR TITLE
dialog: Restore the overlay behind an open dialog

### DIFF
--- a/crates/base/src/dialog.rs
+++ b/crates/base/src/dialog.rs
@@ -544,6 +544,10 @@ impl RenderOnce for Dialog {
                         let request_close = request_close.clone();
                         this.child(
                             div()
+                                // The backdrop covers the host, so a caller's
+                                // `absolute()` surface has a box to fill.
+                                .absolute()
+                                .inset_0()
                                 .on_any_mouse_down(move |event, window, cx| {
                                     if event.position.y < dismiss_below_y {
                                         return;
@@ -614,6 +618,58 @@ mod tests {
         assert_eq!(
             &*changes.borrow(),
             &[(true, DialogChangeReason::TriggerPress)]
+        );
+    }
+
+    /// The backdrop is the dimming surface every caller hands over as an
+    /// `absolute()` element, so it has to have the host's box to resolve
+    /// against — a collapsed wrapper leaves it zero-sized and invisible.
+    #[gpui::test]
+    fn the_backdrop_fills_the_host(cx: &mut gpui::TestAppContext) {
+        use gpui::{Bounds, canvas};
+        use std::cell::Cell;
+
+        struct Harness {
+            focus: FocusHandle,
+            bounds: Rc<Cell<Bounds<Pixels>>>,
+        }
+        impl Render for Harness {
+            fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+                let bounds = self.bounds.clone();
+                Dialog::new(cx)
+                    .open(true)
+                    .focus_handle(self.focus.clone())
+                    .backdrop(
+                        canvas(
+                            move |bounds_of_backdrop, _, _| bounds.set(bounds_of_backdrop),
+                            |_, _, _, _| {},
+                        )
+                        .absolute()
+                        .size_full(),
+                    )
+                    .popup(div().size(px(100.)))
+            }
+        }
+
+        cx.update(crate::init);
+        let bounds = Rc::new(Cell::new(Bounds::default()));
+        let (_, cx) = cx.add_window_view({
+            let bounds = bounds.clone();
+            move |_, cx| Harness {
+                focus: cx.focus_handle(),
+                bounds,
+            }
+        });
+        let viewport = cx.update(|window, cx| {
+            let viewport = window.viewport_size();
+            window.draw(cx).clear(cx);
+            viewport
+        });
+
+        assert_eq!(
+            bounds.get().size,
+            viewport,
+            "a zero-sized backdrop paints no overlay behind the dialog"
         );
     }
 }


### PR DESCRIPTION
## Description

Every `Dialog` and `AlertDialog` opened without a dimmed overlay, and clicking
outside one did not close it.

`Dialog` hands its `backdrop` to a wrapper `div()` that exists only to carry
`on_any_mouse_down`. `div()` is a flex column and the backdrop is `absolute()`,
so the backdrop contributes nothing to the wrapper's content size: the wrapper
collapsed to `1920px × 0px`, and the backdrop's own `size_full()` — a percentage
of that box — collapsed with it. The surface painted nothing and its hitbox was
empty, which is why backdrop dismissal went with it.

The wrapper now covers the host with `absolute().inset_0()`, so any caller's
`absolute()` backdrop has a box to fill. `Sheet` was never affected: it hangs
the overlay directly off the host and keeps the dismissal layer as a sibling.

#2677 introduced this when it split the modal into Base. Before that split the
overlay color sat on the full-size dialog container directly, with no wrapper in
between.

`gpui-component`'s public API is unchanged. `gpui-shell`'s dialog backdrop
(`crates/shell/src/root.rs`) is fixed by the same change.

## Test plan

- `cargo test -p gpui-base --lib dialog::` — `the_backdrop_fills_the_host`
  measures the backdrop's painted bounds through a `canvas` probe and compares
  them to the viewport; it reports `1920px × 0px` without the fix
- `alert_dialog::tests::backdrop_is_not_closable_by_default` was passing on an
  empty hitbox and only now exercises `overlay_closable`
- `cargo test --workspace --exclude gpui-shell`
- `cargo test -p gpui-component --doc`
- `cargo check -p gpui-component --no-default-features`
- `cargo clippy --workspace --exclude gpui-shell --all-targets -- --deny warnings`
- `cargo fmt --check`

Verify by hand with `cargo run --example dialog_overlay`: the overlay is back,
and clicking outside the dialog closes it. In the light palette the dim is
`overlay: #0000000d` (5% black), so it is deliberately subtle.

---

Parts of this PR were written with Claude Code.
