### PR TITLE
story: Fit the chat sections to narrow examples

### DIFF
--- a/crates/story/src/stories/attachment_story.rs
+++ b/crates/story/src/stories/attachment_story.rs
@@ -62,7 +62,7 @@ impl Render for AttachmentStory {
                     .description(
                         "Compose typed metadata and actions, or keep using existing child elements.",
                     )
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -99,7 +99,7 @@ impl Render for AttachmentStory {
                     .description(
                         "The card opens its target while actions stay independently clickable.",
                     )
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -135,7 +135,7 @@ impl Render for AttachmentStory {
                     .description(
                         "Typed titles and descriptions inherit loading and failure states automatically.",
                     )
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -233,7 +233,7 @@ impl Render for AttachmentStory {
             .child(
                 section("Optional slots")
                     .description("Media, metadata, and actions remain independently composable.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -269,7 +269,7 @@ impl Render for AttachmentStory {
                     .description(
                         "Vertical attachments can turn the media slot into a full-width preview.",
                     )
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         Attachment::new()
                             .axis(Axis::Vertical)
@@ -299,7 +299,7 @@ impl Render for AttachmentStory {
                     .description(
                         "Image previews keep their overlays visible while only the image dims during upload.",
                     )
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         Attachment::new()
                             .axis(Axis::Vertical)
@@ -321,7 +321,7 @@ impl Render for AttachmentStory {
             .child(
                 section("Sizes")
                     .description("Semantic sizes keep the media, text, and action density aligned.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -379,7 +379,7 @@ impl Render for AttachmentStory {
             .child(
                 section("Group")
                     .description("Attachment groups arrange multiple files in a scrollable row.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         AttachmentGroup::new("attachment-story-group")
                             .child(
@@ -415,7 +415,7 @@ impl Render for AttachmentStory {
             .child(
                 section("Orientation")
                     .description("The same named slots support horizontal and vertical layouts.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -442,7 +442,7 @@ impl Render for AttachmentStory {
             .child(
                 section("Status inheritance")
                     .description("Typed children inherit lifecycle state unless explicitly overridden.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -472,7 +472,7 @@ impl Render for AttachmentStory {
             .child(
                 section("Long filenames")
                     .description("Long metadata truncates within a constrained, zoom-aware surface.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         Attachment::new()
                             .w_72()
@@ -491,7 +491,7 @@ impl Render for AttachmentStory {
             .child(
                 section("Attachment trigger")
                     .description("Use the existing Button component to add files to a composer.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         Button::new("attachment-add-files")
                             .outline()
@@ -502,7 +502,7 @@ impl Render for AttachmentStory {
             .child(
                 section("Custom style")
                     .description("Every public part accepts caller style refinements.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         Attachment::new()
                             .w_full()

--- a/crates/story/src/stories/bubble_story.rs
+++ b/crates/story/src/stories/bubble_story.rs
@@ -67,7 +67,7 @@ impl Render for BubbleStory {
             .child(
                 section("Variants")
                     .description("Semantic variants match the Base UI bubble treatments.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_4()
                     .child(start_bubble().child("A strong primary bubble."))
@@ -105,7 +105,7 @@ impl Render for BubbleStory {
             .child(
                 section("Alignment")
                     .description("Use the same alignment value as Message.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -122,7 +122,7 @@ impl Render for BubbleStory {
             .child(
                 section("Reactions")
                     .description("Use action for integrated Button controls; child keeps emoji and arbitrary reactions composable.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_8()
                     .py_6()
@@ -155,7 +155,7 @@ impl Render for BubbleStory {
             .child(
                 section("Group")
                     .description("Group consecutive bubbles using the shared spacing scale.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_5()
                     .child(
@@ -190,7 +190,7 @@ impl Render for BubbleStory {
             .child(
                 section("Links and buttons")
                     .description("Compose external links and application actions inside a bubble.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -226,7 +226,8 @@ impl Render for BubbleStory {
             .child(
                 section("Collapsible content")
                     .description("Keep long responses readable with an explicit disclosure action.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
+                    .v_flex()
                     .child(
                         start_bubble().with_variant(BubbleVariant::Muted).content(
                             BubbleContent::new().child(
@@ -260,7 +261,8 @@ impl Render for BubbleStory {
             .child(
                 section("Tooltip")
                     .description("Label icon-only reaction controls with their concrete meaning.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
+                    .v_flex()
                     .py_4()
                     .child(
                         Bubble::new()
@@ -280,7 +282,8 @@ impl Render for BubbleStory {
             .child(
                 section("Popover")
                     .description("Use a semantic popover for contextual failure details.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
+                    .v_flex()
                     .py_4()
                     .child(
                         start_bubble()
@@ -308,7 +311,7 @@ impl Render for BubbleStory {
             .child(
                 section("Rich content")
                     .description("Any GPUI element can be placed directly in the surface.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -339,7 +342,8 @@ impl Render for BubbleStory {
             .child(
                 section("Custom style")
                     .description("Caller refinements override the surface defaults.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
+                    .v_flex()
                     .child(
                         start_bubble().content(
                             BubbleContent::new()

--- a/crates/story/src/stories/marker_story.rs
+++ b/crates/story/src/stories/marker_story.rs
@@ -60,7 +60,7 @@ impl Render for MarkerStory {
                     .description(
                         "Choose a plain row, a centered separator, or a bordered boundary.",
                     )
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_4()
                     .child(Marker::new().content(MarkerContent::new().child("Plain status update")))
@@ -80,7 +80,7 @@ impl Render for MarkerStory {
                     .description(
                         "Compose icons, spinners, and labels without a fixed status model.",
                     )
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -109,7 +109,7 @@ impl Render for MarkerStory {
             .child(
                 section("With icon")
                     .description("Icons can communicate sender activity, notices, and saved items.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -129,7 +129,7 @@ impl Render for MarkerStory {
             .child(
                 section("Loading styles")
                     .description("Choose a spinner or a sweeping, ChatGPT-style text shimmer.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_4()
                     .child(
@@ -176,7 +176,7 @@ impl Render for MarkerStory {
                     .description(
                         "Customize timing, highlight width, direction, and playback independently.",
                     )
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -228,7 +228,7 @@ impl Render for MarkerStory {
             .child(
                 section("Separator")
                     .description("Place a conversation boundary between two semantic lines.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_4()
                     .child(
@@ -249,7 +249,7 @@ impl Render for MarkerStory {
             .child(
                 section("Border")
                     .description("Use a bottom edge for an unread or section boundary.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -272,7 +272,7 @@ impl Render for MarkerStory {
                     .description(
                         "Keep external destinations and in-app commands semantically distinct.",
                     )
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -301,7 +301,7 @@ impl Render for MarkerStory {
             .child(
                 section("Custom style")
                     .description("Caller refinements can replace spacing, color, and surface.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         Marker::new()
                             .px_3()

--- a/crates/story/src/stories/message_scroller_story.rs
+++ b/crates/story/src/stories/message_scroller_story.rs
@@ -447,7 +447,7 @@ impl Render for MessageScrollerStory {
                 .description(
                     "Scroll upward, append a row, jump to unread, or prepend history to exercise each behavior.",
                 )
-                .w(rems(45.))
+                .max_w(rems(45.))
                 .v_flex()
                 .gap_3()
                 .child(
@@ -570,7 +570,7 @@ impl Render for MessageScrollerStory {
                     .description(
                         "Append one assistant response, grow its text progressively, and remeasure only that row.",
                     )
-                    .w(rems(45.))
+                    .max_w(rems(45.))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -636,7 +636,7 @@ impl Render for MessageScrollerStory {
                     .description(
                         "Prepend history without disturbing the currently visible message anchor.",
                     )
-                    .w(rems(45.))
+                    .max_w(rems(45.))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -681,7 +681,7 @@ impl Render for MessageScrollerStory {
                     .description(
                         "Applications resolve stable message IDs to their current row indices.",
                     )
-                    .w(rems(45.))
+                    .max_w(rems(45.))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -736,7 +736,7 @@ impl Render for MessageScrollerStory {
                     .description(
                         "The application owns empty states and switches to a virtual list when data arrives.",
                     )
-                    .w(rems(45.))
+                    .max_w(rems(45.))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -799,7 +799,7 @@ impl Render for MessageScrollerStory {
                     .description(
                         "Change the built-in button, transition, tooltip, list spacing, and row styles.",
                     )
-                    .w(rems(45.))
+                    .max_w(rems(45.))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -852,7 +852,7 @@ impl Render for MessageScrollerStory {
                     .description(
                         "Disable built-in chrome and place the jump action wherever the product needs it.",
                     )
-                    .w(rems(45.))
+                    .max_w(rems(45.))
                     .v_flex()
                     .gap_3()
                     .child(

--- a/crates/story/src/stories/message_story.rs
+++ b/crates/story/src/stories/message_story.rs
@@ -63,7 +63,7 @@ impl Render for MessageStory {
             .child(
                 section("Alignment")
                     .description("The message owns alignment for all of its named slots.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_5()
                     .child(
@@ -97,7 +97,7 @@ impl Render for MessageStory {
             .child(
                 section("Avatar")
                     .description("Use sender avatars, initials, or an empty slot to preserve alignment.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_5()
                     .child(
@@ -144,7 +144,7 @@ impl Render for MessageStory {
             .child(
                 section("Header and footer")
                     .description("Compose sender metadata, timestamps, and delivery status explicitly.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_5()
                     .child(
@@ -184,7 +184,7 @@ impl Render for MessageStory {
             .child(
                 section("Actions")
                     .description("Keep copy, feedback, and retry actions keyboard-accessible.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_5()
                     .child(
@@ -252,7 +252,7 @@ impl Render for MessageStory {
             .child(
                 section("Attachment")
                     .description("Mix image previews, file attachments, and text within one message.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_5()
                     .child(
@@ -308,7 +308,7 @@ impl Render for MessageStory {
             .child(
                 section("Multiple bubbles")
                     .description("A message can hold multiple surfaces, reactions, and long-form text.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         Message::new()
                             .avatar(Avatar::new().name("Assistant").size_8())
@@ -342,9 +342,11 @@ impl Render for MessageStory {
             .child(
                 section("Group")
                     .description("Group consecutive messages while keeping each row composable.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
+                    .v_flex()
                     .child(
                         MessageGroup::new()
+                            .w_full()
                             .child(
                                 Message::new()
                                     .avatar(Avatar::new().name("Alice").size_8())
@@ -373,7 +375,7 @@ impl Render for MessageStory {
             .child(
                 section("Custom style")
                     .description("Every structural part accepts GPUI style refinements.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         Message::new()
                             .p_3()
@@ -389,7 +391,7 @@ impl Render for MessageStory {
             .child(
                 section("Ghost surface")
                     .description("Typed ghost bubbles automatically remove metadata insets.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         Message::new()
                             .with_stack_style(StyleRefinement::default().gap_3())

--- a/crates/story/src/stories/shimmer_story.rs
+++ b/crates/story/src/stories/shimmer_story.rs
@@ -69,7 +69,7 @@ impl Render for ShimmerStory {
             .child(
                 section("Default")
                     .description("A readable, theme-aware highlight crosses the existing text.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_2()
                     .child(ShimmerText::new("Thinking…"))
@@ -81,7 +81,7 @@ impl Render for ShimmerStory {
             .child(
                 section("Color")
                     .description("Highlight colors come from semantic theme roles.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_2()
                     .child(ShimmerText::new("Automatic theme-aware highlight"))
@@ -97,7 +97,7 @@ impl Render for ShimmerStory {
             .child(
                 section("Duration")
                     .description("Each duration controls one complete sweep.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_2()
                     .child(
@@ -116,7 +116,7 @@ impl Render for ShimmerStory {
             .child(
                 section("Spread")
                     .description("Spread is a relative or absolute highlight half-width.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_2()
                     .child(ShimmerText::new("Narrow highlight · 0.12").spread(0.12))
@@ -127,7 +127,7 @@ impl Render for ShimmerStory {
             .child(
                 section("Direction")
                     .description("Reverse changes movement without replacing text or layout.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_2()
                     .child(ShimmerText::new("Forward · left to right"))
@@ -136,7 +136,7 @@ impl Render for ShimmerStory {
             .child(
                 section("Play once")
                     .description("A stable explicit identity controls one-shot playback and replay.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -156,7 +156,7 @@ impl Render for ShimmerStory {
             .child(
                 section("Reusable style")
                     .description("One ShimmerStyle can be shared by independent status labels.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_2()
                     .child(
@@ -171,7 +171,7 @@ impl Render for ShimmerStory {
             .child(
                 section("Typography and wrapping")
                     .description("Text inherits typography, color, and the surrounding layout.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .gap_3()
                     .child(
@@ -187,6 +187,7 @@ impl Render for ShimmerStory {
                     .child(
                         h_flex()
                             .w(rems(24.))
+                            .max_w_full()
                             .min_w_0()
                             .child(ShimmerText::new(
                                 "Long loading messages remain readable as the surrounding region becomes narrower.",
@@ -196,7 +197,7 @@ impl Render for ShimmerStory {
             .child(
                 section("Marker")
                     .description("Marker applies the same reusable style to its text content.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .v_flex()
                     .child(
                         Marker::new()
@@ -209,7 +210,7 @@ impl Render for ShimmerStory {
             .child(
                 section("Attachment")
                     .description("An uploading or processing title can share its loading style.")
-                    .w(rems(42.5))
+                    .max_w(rems(42.5))
                     .child(
                         Attachment::new()
                             .status(AttachmentStatus::Processing)


### PR DESCRIPTION
## Description

The chat components added in #2832 render clipped inside the documentation's
WASM examples: the leading glyph of a start-aligned bubble, the trailing corner
of an end-aligned one, and both avatars of a `Message` row are cut off.

Every section in the six chat stories carries a fixed `w(rems(42.5))` (`rems(45.)`
for `MessageScroller`). A documentation example is about 690px wide, which leaves
the section 624px of content — but width is the cross axis inside `GroupBox`'s
column, so it is never shrunk. The negative free space is then split by the
content box's `items_center`, and `overflow_x_hidden` clips ~25px off *both*
sides. Measured at a 950px window: the section sits at `x=262.5 w=680` while its
content box is `x=288..917`.

The sections now use `max_w(rems(42.5))` and keep the `w_full()` that `section()`
already applies, so they cap at the same width in a wide window and shrink below
it in an example.

## Why four sections also become columns

A responsive width is a percentage, and that exposes a second failure. In the
sections whose base stayed a flex *row* (`section()`'s default), a `Bubble` —
`min_w_0()` plus `max_w(relative(0.8))` — has its width taken as the flex main
size. The first frame is correct; from the second frame on the bubble collapses
to min-content, one word per line, and a single-line section grows from 72.5px to
837.5px before being clipped out of view.

`Bubble` and `Message` are built for a column: their `alignment` is expressed
with `self_start`/`self_end` and auto margins, which a row's `justify_center`
overrides anyway — those four sections were silently centering their bubbles and
ignoring `alignment`. Bubble's `Collapsible content`, `Tooltip`, `Popover` and
`Custom style`, and Message's `Group`, now call `.v_flex()` like their nine
siblings, which both restores alignment and keeps the bubble's width on the cross
axis, where it is measured against a definite container width.

`crates/ui` is unchanged. The collapse is triggered by any `min_w_0` in the
chain, and the components carry several deliberately — they are what lets long
content wrap inside a bounded column.

## How to Test

Sizes were verified by measurement rather than by eye, since the first frame of a
collapsed section looks correct. A temporary `gpui::canvas` probe in
`StorySection::render` logged each section's `x/w/h` every frame, and the story
binary was pointed at `Gallery::embedded_view` + `StoryRoot::embedded` at 690px
to match the documentation iframe. Across all six stories:

- every section reports `x=33 w=624` — inside the content box, nothing clipped
- every section reports a single height, so no section collapses after the first
  frame, and each matches its 1600px-window baseline
- `cargo run -- Bubble`, `Message`, `Attachment`, `Marker`, `Shimmer`,
  `MessageScroller`
- `cargo clippy -p gpui-component-story`, `cargo fmt --check`

## Checklist

- [x] Reviewed the changes in this PR and confirmed AI generated code is accurate.
- [x] Passed `cargo run` for the story tests related to the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)