### PR TITLE
text_view: Fix prevent TextView markdown render loops performance issue

### DIFF
--- a/crates/base/src/text/markdown_ext.rs
+++ b/crates/base/src/text/markdown_ext.rs
@@ -239,6 +239,21 @@ impl MarkdownExtensions {
         self.revision
     }
 
+    /// Whether replacing these extension handles can change the parsed tree.
+    ///
+    /// Render methods commonly rebuild equivalent plugin closures every frame.
+    /// Their globally unique revisions differ, but the parser shape remains
+    /// stable; render handles may be refreshed without reparsing the document.
+    pub(crate) fn has_same_parser_configuration(&self, other: &Self) -> bool {
+        self.enable_mdx == other.enable_mdx
+            && self.block_parsers.len() == other.block_parsers.len()
+            && self.block_renderers.len() == other.block_renderers.len()
+            && self
+                .block_renderers
+                .keys()
+                .all(|name| other.block_renderers.contains_key(name))
+    }
+
     pub(crate) fn push_block_parser<F>(&mut self, parser: F)
     where
         F: for<'a> Fn(&mdast::Node, &MarkdownParseContext<'a>) -> Option<MarkdownNode>

--- a/crates/base/src/text/state.rs
+++ b/crates/base/src/text/state.rs
@@ -306,8 +306,11 @@ impl TextViewState {
             return;
         }
 
+        let parser_configuration_changed = !self
+            .markdown_extensions
+            .has_same_parser_configuration(&markdown_extensions);
         self.markdown_extensions = markdown_extensions;
-        if self.format == TextViewFormat::Markdown {
+        if parser_configuration_changed && self.format == TextViewFormat::Markdown {
             let text = self.text.clone();
             self.increment_update(&text, false, cx);
         }

--- a/crates/base/src/text/text_view.rs
+++ b/crates/base/src/text/text_view.rs
@@ -733,6 +733,11 @@ impl Element for TextView {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
     use super::{TextView, TextViewPlugin};
     use crate::text::{TableData, TextViewState, TextViewStyle};
     use gpui::{
@@ -744,6 +749,20 @@ mod tests {
 
     struct TextViewTestRoot {
         text_view: Entity<TextViewState>,
+    }
+
+    struct StatelessMarkdownRoot {
+        renders: Arc<AtomicUsize>,
+    }
+
+    impl Render for StatelessMarkdownRoot {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            self.renders.fetch_add(1, Ordering::Relaxed);
+            div().child(
+                TextView::markdown("stateless-markdown", include_str!("../../../../README.md"))
+                    .markdown_block_parser(|_, _| None),
+            )
+        }
     }
 
     struct DummyTextViewPlugin;
@@ -763,6 +782,24 @@ mod tests {
         assert!(TextView::new(&state).selectable);
         assert!(TextView::markdown("markdown", "text").selectable);
         assert!(TextView::html("html", "<p>text</p>").selectable);
+    }
+
+    #[gpui::test]
+    fn stateless_markdown_with_rebuilt_parser_settles(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let renders = Arc::new(AtomicUsize::new(0));
+        let (_, cx) = cx.add_window_view({
+            let renders = renders.clone();
+            move |_, _| StatelessMarkdownRoot { renders }
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        cx.run_until_parked();
+        assert!(
+            renders.load(Ordering::Relaxed) <= 2,
+            "an unchanged TextView must settle after its parse, but rendered {} times",
+            renders.load(Ordering::Relaxed),
+        );
     }
 
     #[gpui::test]

--- a/crates/story/examples/html.rs
+++ b/crates/story/examples/html.rs
@@ -74,7 +74,7 @@ impl Render for Example {
                         )
                         .child(
                             html(self.input_state.read(cx).value())
-                                .p_5()
+                                .px_5()
                                 .scrollable(true)
                                 .selectable(true)
                                 .selection_format(self.selection_format)

--- a/crates/story/examples/markdown.rs
+++ b/crates/story/examples/markdown.rs
@@ -1411,7 +1411,7 @@ impl Render for Example {
                                             // status bar toggle switches to wrapping.
                                             .style(self.text_view_style())
                                             .flex_none()
-                                            .p_5()
+                                            .px_5()
                                             .scrollable(true)
                                             .selectable(true)
                                             .selection_format(self.selection_format),

--- a/crates/ui/src/text/compat.rs
+++ b/crates/ui/src/text/compat.rs
@@ -386,3 +386,47 @@ pub fn html(source: impl Into<SharedString>) -> TextView {
         source,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use gpui::{
+        Context, IntoElement, ParentElement as _, Render, TestAppContext, VisualTestContext, div,
+    };
+
+    struct StatelessMarkdown {
+        renders: Arc<AtomicUsize>,
+    }
+
+    impl Render for StatelessMarkdown {
+        fn render(&mut self, _: &mut gpui::Window, _: &mut Context<Self>) -> impl IntoElement {
+            self.renders.fetch_add(1, Ordering::Relaxed);
+            div().child(
+                super::markdown(include_str!("../../../story/examples/fixtures/test.md"))
+                    .markdown_block_parser(|_, _| None),
+            )
+        }
+    }
+
+    #[gpui::test]
+    fn stateless_markdown_facade_settles_after_parsing(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let renders = Arc::new(AtomicUsize::new(0));
+        let (_, cx) = cx.add_window_view({
+            let renders = renders.clone();
+            move |_, _| StatelessMarkdown { renders }
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        cx.run_until_parked();
+        assert!(
+            renders.load(Ordering::Relaxed) <= 2,
+            "an unchanged compatibility TextView must settle after its parse, but rendered {} times",
+            renders.load(Ordering::Relaxed),
+        );
+    }
+}

--- a/crates/ui/src/text/window_selection.rs
+++ b/crates/ui/src/text/window_selection.rs
@@ -700,6 +700,10 @@ mod tests {
         text_view: Entity<TextViewState>,
     }
 
+    struct AutoScrollTextViewTest {
+        text_view: Entity<TextViewState>,
+    }
+
     struct PaddedScrollableTextViewTest {
         text_view: Entity<TextViewState>,
     }
@@ -732,6 +736,108 @@ mod tests {
                 ),
             )
         }
+    }
+
+    impl Render for AutoScrollTextViewTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().child(
+                div()
+                    .debug_selector(|| "scrollable-text-view".into())
+                    .h(px(300.))
+                    .overflow_hidden()
+                    .child(
+                        TextView::new(&self.text_view)
+                            .flex_none()
+                            .px_5()
+                            .selectable(true)
+                            .scrollable(true),
+                    ),
+            )
+        }
+    }
+
+    #[gpui::test]
+    fn compatibility_text_view_drag_selection_auto_scrolls_both_directions(
+        cx: &mut TestAppContext,
+    ) {
+        use gpui::ListOffset;
+
+        let source = (0..100)
+            .map(|ix| format!("Paragraph {ix} with enough text to select"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        cx.update(crate::init);
+        let (root, cx) = cx.add_window_view(|window, cx| {
+            let view = cx.new(|cx| AutoScrollTextViewTest {
+                text_view: cx.new(|cx| TextViewState::markdown(&source, cx)),
+            });
+            Root::new(view, window, cx)
+        });
+        let view = root.read_with(cx, |root, _| {
+            root.view()
+                .clone()
+                .downcast::<AutoScrollTextViewTest>()
+                .unwrap()
+        });
+        let cx: &mut VisualTestContext = cx;
+        cx.run_until_parked();
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+
+        let bounds = cx
+            .debug_bounds("scrollable-text-view")
+            .expect("scrollable TextView bounds");
+        let before = view.read_with(cx, |view, cx| {
+            let state = view.text_view.read(cx);
+            let offset = state.list_state().logical_scroll_top();
+            (offset.item_ix, offset.offset_in_item)
+        });
+        let start = point(bounds.left() + px(30.), bounds.top() + px(30.));
+        let edge = point(bounds.left() + px(60.), bounds.bottom() - px(2.));
+        cx.simulate_mouse_down(start, MouseButton::Left, Modifiers::default());
+        cx.simulate_mouse_move(edge, Some(MouseButton::Left), Modifiers::default());
+        cx.executor().advance_clock(Duration::from_millis(64));
+        cx.run_until_parked();
+
+        let after = view.read_with(cx, |view, cx| {
+            let offset = view.text_view.read(cx).list_state().logical_scroll_top();
+            (offset.item_ix, offset.offset_in_item)
+        });
+        cx.simulate_mouse_up(edge, MouseButton::Left, Modifiers::default());
+        assert_ne!(
+            before, after,
+            "dragging at the viewport edge must auto-scroll"
+        );
+
+        let list_state =
+            view.read_with(cx, |view, cx| view.text_view.read(cx).list_state().clone());
+        list_state.scroll_to(ListOffset {
+            item_ix: 99,
+            offset_in_item: px(0.),
+        });
+        cx.update(|window, cx| {
+            let _ = window.draw(cx);
+        });
+        let before_up = view.read_with(cx, |view, cx| {
+            let offset = view.text_view.read(cx).list_state().logical_scroll_top();
+            (offset.item_ix, offset.offset_in_item)
+        });
+        let start = point(bounds.left() + px(30.), bounds.bottom() - px(30.));
+        let edge = point(bounds.left() + px(60.), bounds.top() + px(2.));
+        cx.simulate_mouse_down(start, MouseButton::Left, Modifiers::default());
+        cx.simulate_mouse_move(edge, Some(MouseButton::Left), Modifiers::default());
+        cx.executor().advance_clock(Duration::from_millis(64));
+        cx.run_until_parked();
+        let after_up = view.read_with(cx, |view, cx| {
+            let offset = view.text_view.read(cx).list_state().logical_scroll_top();
+            (offset.item_ix, offset.offset_in_item)
+        });
+        cx.simulate_mouse_up(edge, MouseButton::Left, Modifiers::default());
+        assert_ne!(
+            before_up, after_up,
+            "dragging at the top viewport edge must auto-scroll upward"
+        );
     }
 
     impl Render for PaddedScrollableTextViewTest {


### PR DESCRIPTION
## Summary

This is fix for #2881 included issue.

- avoid reparsing unchanged markdown when stateless TextView plugin closures are rebuilt during render
- keep parser and renderer handles refreshed without triggering a render loop
- restore upward and downward drag-selection auto-scroll in the Markdown and HTML examples by keeping vertical viewport edges interactive
- add regressions for stateless markdown settling and bidirectional selection auto-scroll

## Test Plan

- `cargo fmt --all -- --check`
- `cargo check --example markdown --example html`
- `cargo test -p gpui-base -p gpui-component`