### PR TITLE
shell: Let a script state its type scale

### DIFF
--- a/crates/shell/src/engine/quickjs/theme_api.rs
+++ b/crates/shell/src/engine/quickjs/theme_api.rs
@@ -15,6 +15,50 @@ struct ScriptTokens {
     colors: HashMap<String, String>,
     spacing: HashMap<String, f32>,
     radius: HashMap<String, f32>,
+    /// The type scale, and the only block a theme may leave out.
+    ///
+    /// Colours, spacing and radius are required because a script that names
+    /// them names all of them: a palette with half its roles missing is a
+    /// window drawn in two themes. Typography is different -- it arrived after
+    /// themes were already being written, and a theme that says nothing about
+    /// type is not incomplete, it is one that accepts the scale it was given.
+    #[serde(default)]
+    typography: TypographyOverride,
+}
+
+/// What a script changes about the type scale, rather than what the scale is.
+///
+/// `ScriptTheme` and `ScriptTokens` above are whole shapes: a script sends all
+/// of one. This is the other kind, and is named for it -- every field is
+/// optional, and every one left out keeps the token it would have replaced.
+/// That is what lets an application state the one size it has an opinion about
+/// -- usually `md`, the window's base text size -- without restating a line
+/// height, a weight, and two font families it does not.
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct TypographyOverride {
+    /// The face the scale below is set in, and the scale itself.
+    sans: Option<String>,
+    xs: TextStyleOverride,
+    sm: TextStyleOverride,
+    md: TextStyleOverride,
+    lg: TextStyleOverride,
+    xl: TextStyleOverride,
+    /// Code, which is a face and one size rather than a scale. `mono_md` is
+    /// not a sixth step of the one above -- it is the size `mono` is set at,
+    /// and the two are read together. They default apart for that reason:
+    /// 13px against the scale's 16px.
+    mono: Option<String>,
+    mono_md: TextStyleOverride,
+}
+
+/// One entry of a [`TypographyOverride`], on the same terms.
+#[derive(Default, Deserialize)]
+#[serde(default)]
+struct TextStyleOverride {
+    size: Option<f32>,
+    line_height: Option<f32>,
+    weight: Option<f32>,
 }
 
 pub fn install(ctx: &Ctx<'_>, module: &Object<'_>) -> JsResult<()> {
@@ -59,6 +103,8 @@ fn set_theme<'js>(ctx: Ctx<'js>, value: Value<'js>) -> JsResult<()> {
             |name, value| set_radius(&mut tokens.radius, name, value),
         )
         .map_err(|e| Exception::throw_type(&ctx, &e))?;
+        apply_typography(&mut tokens.typography, &supplied.tokens.typography)
+            .map_err(|e| Exception::throw_type(&ctx, &e))?;
         let base = Theme::global_mut(cx);
         base.appearance = supplied.appearance;
         base.tokens = tokens;
@@ -128,6 +174,68 @@ fn apply_scale(
     }
     Ok(())
 }
+/// Applies whatever a script stated about type, and leaves the rest.
+///
+/// Font families are taken as written -- a family name this platform does not
+/// have falls back the way every other missing family does, and refusing one
+/// here would mean this module deciding which fonts exist.
+fn apply_typography(
+    typography: &mut gpui_base::TypographyTokens,
+    supplied: &TypographyOverride,
+) -> Result<(), String> {
+    if let Some(sans) = &supplied.sans {
+        typography.sans = sans.clone().into();
+    }
+    if let Some(mono) = &supplied.mono {
+        typography.mono = mono.clone().into();
+    }
+    for (name, style, token) in [
+        ("xs", &supplied.xs, &mut typography.xs),
+        ("sm", &supplied.sm, &mut typography.sm),
+        ("md", &supplied.md, &mut typography.md),
+        ("lg", &supplied.lg, &mut typography.lg),
+        ("xl", &supplied.xl, &mut typography.xl),
+        ("mono_md", &supplied.mono_md, &mut typography.mono_md),
+    ] {
+        apply_text_style(name, style, token)?;
+    }
+    Ok(())
+}
+
+fn apply_text_style(
+    name: &str,
+    supplied: &TextStyleOverride,
+    token: &mut gpui_base::TextStyleToken,
+) -> Result<(), String> {
+    // Above zero, not merely non-negative: a size or a line height of zero is
+    // text that cannot be read, and it would be applied silently. The scales
+    // above allow zero because a gap of zero is a real answer.
+    if let Some(size) = supplied.size {
+        if !size.is_finite() || size <= 0. {
+            return Err(format!("theme typography `{name}.size` must be above zero"));
+        }
+        token.size = gpui::px(size);
+    }
+    if let Some(line_height) = supplied.line_height {
+        if !line_height.is_finite() || line_height <= 0. {
+            return Err(format!(
+                "theme typography `{name}.line_height` must be above zero"
+            ));
+        }
+        token.line_height = gpui::px(line_height);
+    }
+    if let Some(weight) = supplied.weight {
+        // The CSS range, which is what `FontWeight`'s own constants span.
+        if !weight.is_finite() || !(1. ..=1000.).contains(&weight) {
+            return Err(format!(
+                "theme typography `{name}.weight` must be between 1 and 1000"
+            ));
+        }
+        token.weight = gpui::FontWeight(weight);
+    }
+    Ok(())
+}
+
 fn set_spacing(t: &mut gpui_base::SpacingTokens, n: &str, v: f32) {
     let v = gpui::px(v);
     match n {
@@ -178,6 +286,31 @@ fn snapshot_json() -> String {
             })
             .collect(),
     );
+    let typography = theme_tokens::typography_tokens()
+        .map(|t| {
+            let style = |name: &str, s: &gpui_base::TextStyleToken| {
+                format!(
+                    "\"{name}\":{{\"size\":{},\"line_height\":{},\"weight\":{}}}",
+                    f32::from(s.size),
+                    f32::from(s.line_height),
+                    s.weight.0
+                )
+            };
+            let mut parts = vec![
+                format!("\"sans\":{}", json_string(&t.sans)),
+                format!("\"mono\":{}", json_string(&t.mono)),
+            ];
+            parts.extend([
+                style("xs", &t.xs),
+                style("sm", &t.sm),
+                style("md", &t.md),
+                style("lg", &t.lg),
+                style("xl", &t.xl),
+                style("mono_md", &t.mono_md),
+            ]);
+            join(parts)
+        })
+        .unwrap_or_default();
     let appearance =
         crate::scope::with_current_app(|cx| Theme::global(cx).appearance).unwrap_or_default();
     let name = match appearance {
@@ -185,10 +318,16 @@ fn snapshot_json() -> String {
         ThemeAppearance::Dark => "dark",
     };
     format!(
-        "{{{direct},\"colors\":{{{colors}}},\"spacing\":{{{spacing}}},\"radius\":{{{radius}}},\"appearance\":\"{name}\",\"is_dark\":{}}}",
+        "{{{direct},\"colors\":{{{colors}}},\"spacing\":{{{spacing}}},\"radius\":{{{radius}}},\"typography\":{{{typography}}},\"appearance\":\"{name}\",\"is_dark\":{}}}",
         appearance == ThemeAppearance::Dark
     )
 }
+/// A font family name as a JSON string. Families are author-supplied, so the
+/// two characters JSON cannot carry raw are escaped rather than assumed absent.
+fn json_string(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
 fn hex(color: gpui::Hsla) -> String {
     let c = gpui::Rgba::from(color);
     let b = |v: f32| (v.clamp(0., 1.) * 255.).round() as u8;

--- a/crates/shell/src/root.rs
+++ b/crates/shell/src/root.rs
@@ -736,6 +736,20 @@ impl Render for ShellRoot {
 
         div()
             .id("shell-root")
+            // The window's base text size, from the theme rather than from
+            // GPUI's default rem.
+            //
+            // Everything this root draws itself -- toasts, the sheet, the
+            // dialog scrim's chrome -- states no size of its own and inherits
+            // this one. Without it that chrome sat at GPUI's 16px default
+            // while the components an application builds set their own sizes,
+            // so a dense application drawn at 12px got 16px notifications over
+            // it. `md` is the base by the library's own convention: it is what
+            // `gpui_component::Theme` already takes its `font_size` from.
+            //
+            // The default `md` is that same 16px, so a theme that says nothing
+            // about type is drawn exactly as it was before this existed.
+            .text_size(tokens.typography.md.size)
             .key_context(CONTEXT)
             .on_action(cx.listener(Self::on_action_tab))
             .on_action(cx.listener(Self::on_action_tab_prev))

--- a/crates/shell/src/tests/render.rs
+++ b/crates/shell/src/tests/render.rs
@@ -3541,6 +3541,128 @@ export default class ThemeSwitch extends View {
     });
 }
 
+/// A script states its type scale, and the chrome the shell draws follows it.
+///
+/// The regression this guards is a dense application with oversized
+/// notifications: everything `ShellRoot` draws for itself states no text size
+/// and inherited GPUI's 16px default, while the components an application
+/// builds set their own — so a window drawn at 12px got 16px toasts over it.
+/// `md` is the base, and it is an override: a theme that says nothing about
+/// type keeps the scale it was given.
+#[gpui::test]
+fn javascript_can_state_the_type_scale(cx: &mut TestAppContext) {
+    cx.update(|cx| crate::init(cx));
+    let runtime = ShellRuntime::new_isolated().expect("runtime");
+    cx.update(|cx| runtime.set_global(cx));
+    let source = r##"
+import { View, div } from "gpui";
+import { set_theme } from "gpui-base";
+const color = "#111111";
+const base = {
+  colors: {
+    background: color, foreground: color, surface: color, surface_foreground: color,
+    primary: color, primary_foreground: color, secondary: color, secondary_foreground: color,
+    muted: color, muted_foreground: color, accent: color, accent_foreground: color,
+    destructive: color, destructive_foreground: color, border: color, input: color, ring: color,
+    selection: color,
+  },
+  spacing: { xxs: 2, xs: 4, sm: 8, md: 12, lg: 16, xl: 24, xxl: 32 },
+  radius: { none: 0, sm: 3, md: 6, lg: 8, xl: 12, full: 9999 },
+};
+export default class TypeScale extends View {
+  init() {
+    // Only what this application has an opinion about. The line height, the
+    // weight and both font families are left as they are.
+    set_theme({ appearance: "light", tokens: { ...base, typography: { md: { size: 12 } } } });
+  }
+  render(cx) { return div(); }
+}
+"##;
+    let view_type = runtime.load_source("type-scale", source).expect("load");
+    let loaded = runtime.clone();
+    let window = cx.add_window(move |window, cx| {
+        let object = loaded.instantiate(&view_type, window, cx).unwrap();
+        ScriptView::new(loaded, object)
+    });
+    let mut context = VisualTestContext::from_window(*window.deref(), cx);
+    context.update(|window, cx| window.draw(cx).clear(cx));
+
+    context.update(|_, cx| {
+        let typography = gpui_base::Theme::global(cx).tokens.typography.clone();
+        assert_eq!(
+            typography.md.size,
+            gpui::px(12.),
+            "the size the script stated is the one the theme carries"
+        );
+        assert_eq!(
+            typography.md.line_height,
+            gpui_base::TypographyTokens::default().md.line_height,
+            "and an entry it left out keeps the value it had"
+        );
+        assert_eq!(
+            typography.sans,
+            gpui_base::TypographyTokens::default().sans,
+            "including the font families, which it never mentioned"
+        );
+        assert_eq!(
+            typography.sm.size,
+            gpui_base::TypographyTokens::default().sm.size,
+            "and the steps beside the one it named"
+        );
+    });
+}
+
+/// A size that cannot be drawn is refused rather than applied.
+#[gpui::test]
+fn a_type_scale_of_zero_is_refused(cx: &mut TestAppContext) {
+    cx.update(|cx| crate::init(cx));
+    let runtime = ShellRuntime::new_isolated().expect("runtime");
+    cx.update(|cx| runtime.set_global(cx));
+    let source = r##"
+import { View, div } from "gpui";
+import { set_theme } from "gpui-base";
+const color = "#111111";
+export default class ZeroScale extends View {
+  init() {
+    this.refused = "";
+    try {
+      set_theme({ appearance: "light", tokens: {
+        colors: {
+          background: color, foreground: color, surface: color, surface_foreground: color,
+          primary: color, primary_foreground: color, secondary: color, secondary_foreground: color,
+          muted: color, muted_foreground: color, accent: color, accent_foreground: color,
+          destructive: color, destructive_foreground: color, border: color, input: color,
+          ring: color, selection: color,
+        },
+        spacing: { xxs: 2, xs: 4, sm: 8, md: 12, lg: 16, xl: 24, xxl: 32 },
+        radius: { none: 0, sm: 3, md: 6, lg: 8, xl: 12, full: 9999 },
+        typography: { md: { size: 0 } },
+      }});
+    } catch (error) {
+      this.refused = String(error && error.message ? error.message : error);
+    }
+  }
+  render(cx) { return div().child(this.refused || "applied"); }
+}
+"##;
+    let view_type = runtime.load_source("zero-scale", source).expect("load");
+    let loaded = runtime.clone();
+    let window = cx.add_window(move |window, cx| {
+        let object = loaded.instantiate(&view_type, window, cx).unwrap();
+        ScriptView::new(loaded, object)
+    });
+    let mut context = VisualTestContext::from_window(*window.deref(), cx);
+    context.update(|window, cx| window.draw(cx).clear(cx));
+
+    context.update(|_, cx| {
+        assert_eq!(
+            gpui_base::Theme::global(cx).tokens.typography.md.size,
+            gpui_base::TypographyTokens::default().md.size,
+            "a refused scale leaves the one that was working alone"
+        );
+    });
+}
+
 /// The todo list exists to exercise the whole runtime at once: retained input
 /// state, controlled checkboxes, a dialog, a toast, capability-gated storage,
 /// and a filter that must survive every mutation. If a subsystem regresses,

--- a/crates/shell/src/theme_tokens.rs
+++ b/crates/shell/src/theme_tokens.rs
@@ -3,7 +3,9 @@
 use std::cell::RefCell;
 
 use gpui::{App, Hsla, Pixels};
-use gpui_base::{ColorTokens, RadiusTokens, SemanticThemeTokens, SpacingTokens, Theme};
+use gpui_base::{
+    ColorTokens, RadiusTokens, SemanticThemeTokens, SpacingTokens, Theme, TypographyTokens,
+};
 
 use crate::scope::with_current_app;
 
@@ -49,6 +51,17 @@ pub(crate) fn token_spacing(name: &str) -> Option<Pixels> {
 
 pub(crate) fn token_radius(name: &str) -> Option<Pixels> {
     with_tokens(|tokens| resolve_radius(&tokens.radius, name)).flatten()
+}
+
+/// The whole type scale, rather than one entry by name.
+///
+/// The colour, spacing and radius lookups above answer one token at a time
+/// because a description names them one at a time -- `bg("surface")`. Nothing
+/// names a text style that way: the scale is read whole, to be reported back
+/// to a script, and six lookups that each clone two font families to return
+/// one of them would cost more than the copy this makes.
+pub(crate) fn typography_tokens() -> Option<TypographyTokens> {
+    with_tokens(|tokens| tokens.typography.clone())
 }
 
 pub(crate) const COLOR_TOKEN_NAMES: &[&str] = &[

--- a/crates/shell/src/typings.rs
+++ b/crates/shell/src/typings.rs
@@ -3206,19 +3206,62 @@ const BASE: &str = r#"  /** A row. */
     readonly none: number; readonly sm: number; readonly md: number;
     readonly lg: number; readonly xl: number; readonly full: number;
   }
+  /** One entry in the type scale, aligned with `gpui_base::TextStyleToken`. */
+  export interface TextStyleToken {
+    readonly size: number;
+    readonly line_height: number;
+    /** The CSS range: 100 is thin, 400 regular, 700 bold. */
+    readonly weight: number;
+  }
+  /**
+   * Semantic type scale, aligned with `gpui_base::TypographyTokens`.
+   *
+   * `md` is the window's base text size: everything the shell draws for itself
+   * — toasts, sheets, dialog chrome — inherits it, so an application that
+   * draws densely says so here rather than restating a size per component.
+   */
+  export interface TypographyTokens {
+    /** The face the scale is set in, and the scale itself. */
+    readonly sans: string;
+    readonly xs: TextStyleToken; readonly sm: TextStyleToken; readonly md: TextStyleToken;
+    readonly lg: TextStyleToken; readonly xl: TextStyleToken;
+    /**
+     * Code: a face and one size, not a sixth step of the scale. `mono_md` is
+     * the size `mono` is set at, and the two are read together.
+     */
+    readonly mono: string;
+    readonly mono_md: TextStyleToken;
+  }
   export interface SemanticThemeTokens {
     readonly colors: ColorTokens;
     readonly spacing: SpacingTokens;
     readonly radius: RadiusTokens;
+    readonly typography: TypographyTokens;
   }
 
   /**
    * Replaces gpui-base's active semantic tokens for the current application.
    * Legal only from an event handler or task backed by a live host call.
+   *
+   * Colours, spacing and radius are stated in full: a palette with half its
+   * roles missing is a window drawn in two themes. Typography is an override —
+   * every entry is optional, and one left out keeps the value it has — so a
+   * theme that only wants a smaller base says `{ md: { size: 12 } }` rather
+   * than restating two font families and six line heights it has no opinion
+   * about. A theme that says nothing about type is drawn as it always was.
    */
   export function set_theme(theme: {
     readonly appearance: "light" | "dark";
-    readonly tokens: SemanticThemeTokens;
+    readonly tokens: Omit<SemanticThemeTokens, "typography"> & {
+      readonly typography?: {
+        readonly sans?: string;
+        readonly mono?: string;
+      } & {
+        readonly [Step in keyof Omit<TypographyTokens, "sans" | "mono">]?: {
+          readonly [Field in keyof TextStyleToken]?: number;
+        };
+      };
+    };
   }): void;
   /** The Base-aligned semantic tokens plus the current appearance. Read-only. */
   export interface Theme extends SemanticThemeTokens, ColorTokens {


### PR DESCRIPTION
A shell application could not say how large its text is.

`SemanticThemeTokens` carried `colors`, `spacing` and `radius` to scripts but
not `typography` — and nothing on the base/shell path read `typography.md`
either. Only `gpui_component::Theme` did, which `gpui-shell` does not depend
on. So `ShellRoot`'s own chrome stated no text size and inherited GPUI's 16px
default, while the components an application builds set their own: a window
drawn at 12px got 16px toasts over it, and had no way to say otherwise.

`md` is now the window's base text size, which is the convention
`gpui_component::Theme` already follows, and `set_theme` accepts a
`typography` block.

Colors, spacing and radius stay required — a palette with half its roles
missing is a window drawn in two themes — but typography is an override, entry
by entry, so an application states the one size it has an opinion about rather
than restating two font families and six line heights it does not.

## Compatibility

The default `md` is the same 16px, so a theme that says nothing about type is
drawn exactly as before.

## Verification

`gpui-shell` and `gpui-base` tests pass, `cargo check --workspace
--all-targets` is clean, and `cargo fmt --check` and `cargo clippy` are clean.
Two tests are new: the partial-override semantics, and a refused zero size.

Measured against a real application that states `md: 12`, the front toast went
from 104 physical pixels tall to 91 — 52 logical to 45.5, matching
`1+12+24+12+1` and `1+12+16+12+1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQKtA1oDfX9bYjGun5FtxA