### PR TITLE
resizable: Keep the handle's divider line from being crushed to zero size

### DIFF
--- a/crates/base/src/resizable/resize_handle.rs
+++ b/crates/base/src/resizable/resize_handle.rs
@@ -205,6 +205,10 @@ impl<T: 'static, E: 'static + Render> Element for ResizeHandle<T, E> {
                         })
                         .unwrap_or_else(|| {
                             div()
+                                // The handle's border box is HANDLE_SIZE wide but
+                                // padded by HANDLE_PADDING, so its content area is
+                                // zero and a shrinkable child collapses with it.
+                                .flex_none()
                                 .bg(bg_color)
                                 .group_hover("handle", |this| this.bg(bg_color))
                                 .when(axis.is_horizontal(), |this| this.h_full().w(HANDLE_SIZE))


### PR DESCRIPTION
## Description

The built-in divider line inside `ResizeHandle` never renders: it is crushed to zero size by the handle's own padding. This PR gives the line child `flex_none()` so it keeps its 1px size.

The handle div combines a fixed main-axis size with padding on the same axis — for a horizontal axis:

```rust
.w(HANDLE_SIZE)      // 1px
.px(HANDLE_PADDING)  // 4px each side
```

Under taffy's border-box sizing the border box resolves to `max(1px, 4px + 4px) = 8px`, leaving a **0px content area**. The line child is 1px wide with the default `flex_shrink: 1`, so it is shrunk to fit that 0px content area and disappears. The 8px hit area and drag still work — only the visible line is lost, so a panel divider is only visible today when the panel content itself draws a border.

Verified with a standalone taffy 0.13.0 layout test mirroring the handle's styles:

```
flex_shrink=1 (current): handle 8x600 | line at x=4, size 0x600   ← invisible
flex_shrink=0 (fixed):   handle 8x600 | line at x=4, size 1x600   ← 1px line, centered in the hit area
```

With `flex_none()` the line keeps its 1px size, overflows the empty content box (overflow is visible by default), and paints at the padding offset — centered in the 8px hit area, where the divider was always meant to be. The same reasoning applies to the vertical axis (`h(HANDLE_SIZE)` + `py(HANDLE_PADDING)`) and the `Side::Left` dock special case.

This is a follow-up to the earlier `handle_color` fix: that made the fallback color non-transparent, but the box it fills still has zero size.

## How to Test

- Standalone taffy 0.13.0 layout test above (same taffy version as the workspace lockfile).
- `cargo test -p gpui-base resizable` passes.
- In the gallery's Resizable story, drag handles between panels: before, no divider line is drawn between panels; after, a 1px line in the theme's `border` color appears, and highlights with `ring` while dragging.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
