### PR TITLE
table: Fix column header drag crossing the fixed columns boundary

### DIFF
--- a/crates/ui/src/table/state.rs
+++ b/crates/ui/src/table/state.rs
@@ -1203,10 +1203,20 @@ where
     fn drag_gap_at(&self, x: Pixels, drag_col_ix: usize) -> Option<usize> {
         let fixed_count = self.fixed_left_cols_count();
 
+        // A column can only be reordered within its own region: rendering
+        // pins the first `fixed_count` columns, so a cross-region move would
+        // change which columns are pinned without updating their `fixed`
+        // flags.
+        let drag_in_fixed = drag_col_ix < fixed_count;
+        let pointer_in_fixed = fixed_count > 0 && x < self.fixed_head_cols_bounds.right();
+        if drag_in_fixed != pointer_in_fixed {
+            return None;
+        }
+
         // Columns scrolled beneath the fixed region keep stale bounds, so
         // resolve `x` against the fixed columns alone when it falls in that
         // region, and against the visible scrollable columns otherwise.
-        let candidates = if fixed_count > 0 && x < self.fixed_head_cols_bounds.right() {
+        let candidates = if pointer_in_fixed {
             0..fixed_count
         } else {
             self.calculate_visible_leaf_col_range(fixed_count).0


### PR DESCRIPTION
## Description

Dragging a column header across the fixed-columns boundary corrupted the pinned state: `move_column` only reorders `col_groups` without touching `column.fixed`, while rendering pins the first `fixed_left_cols_count()` columns as a prefix. Dragging a fixed column into the scrollable region (or a scrollable column into the fixed region) kept the pinned count unchanged but broke the prefix assumption — an unrelated column became pinned while the dragged one still carried a stale `fixed` flag.

Now `drag_gap_at` resolves the dragged column's region from its index and the drop region from the pointer position, and returns no gap when they differ. Columns reorder freely within their own region; the insertion indicator no longer appears across the boundary, and dropping there is a no-op.