### PR TITLE
base: Stop drag auto scroll when the content mask collapses

### DIFF
--- a/crates/base/src/text_selection.rs
+++ b/crates/base/src/text_selection.rs
@@ -1472,6 +1472,14 @@ impl WindowSelectionState {
         // moves, so selection keeps scrolling the same related region even
         // after the anchor text has moved out of view.
         let visible_bounds = registration.registration.hitbox.content_mask.bounds;
+        // The mask can collapse to a degenerate rect when the scrollable
+        // ancestor itself gets clipped away mid-drag (e.g. scrolled out of
+        // view by this very auto scroll). There is nothing sensible left to
+        // scroll, and clamping into an empty range below panics — stop.
+        if visible_bounds.size.width < px(2.) || visible_bounds.size.height < px(2.) {
+            self.stop_anchor_auto_scroll(cx);
+            return;
+        }
         let delta = AutoScroll::compute_delta(position.y, visible_bounds);
         let Some(window) = window else {
             participant.update(cx, |state, cx| state.set_auto_scroll(delta, cx));
@@ -3093,6 +3101,45 @@ mod tests {
         cx.run_until_parked();
         assert!(commands.borrow().iter().any(Option::is_some));
         assert_eq!(commands.borrow().last(), Some(&None));
+    }
+
+    #[gpui::test]
+    fn drag_auto_scroll_stops_when_the_content_mask_collapses(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, cx| WindowSelectionView {
+            selection: TextSelectionHandle::new("unused", cx),
+        });
+        window
+            .update(cx, |_, window, cx| {
+                let state = cx.new(|_| WindowSelectionState::default());
+                let participant = FakeParticipant::new("participant", cx);
+                state.update(cx, |state, cx| {
+                    participant.register(state, 0., TextSelectionScopeId::default(), 0, cx);
+                    state.begin(point(px(1.), px(1.)), false, cx);
+                });
+                // The scrollable ancestor got clipped away mid-drag, so the
+                // refreshed registration carries a collapsed content mask.
+                let collapsed = Bounds::new(point(px(0.), px(0.)), size(px(100.), px(0.)));
+                state.update(cx, |state, cx| {
+                    state.register_participant(
+                        participant.selection.clone(),
+                        TextSelectionRegistration::new(
+                            Hitbox {
+                                id: HitboxId::placeholder(),
+                                bounds: collapsed,
+                                content_mask: ContentMask { bounds: collapsed },
+                                behavior: HitboxBehavior::Normal,
+                            },
+                            collapsed,
+                        )
+                        .with_text_bounds(vec![collapsed]),
+                        cx,
+                    );
+                    state.update_in_window(point(px(1.), px(50.)), window, cx);
+                    assert!(!state.auto_scroll.is_active());
+                    assert!(state.auto_scroll.last_drag_position.is_none());
+                });
+            })
+            .unwrap();
     }
 
     #[gpui::test]

--- a/crates/base/src/text_selection.rs
+++ b/crates/base/src/text_selection.rs
@@ -1472,11 +1472,14 @@ impl WindowSelectionState {
         // moves, so selection keeps scrolling the same related region even
         // after the anchor text has moved out of view.
         let visible_bounds = registration.registration.hitbox.content_mask.bounds;
-        // The mask can collapse to a degenerate rect when the scrollable
-        // ancestor itself gets clipped away mid-drag (e.g. scrolled out of
-        // view by this very auto scroll). There is nothing sensible left to
-        // scroll, and clamping into an empty range below panics — stop.
-        if visible_bounds.size.width < px(2.) || visible_bounds.size.height < px(2.) {
+        // Keeps the synthesized wheel event strictly inside the mask so
+        // hit-testing reaches the scrollable.
+        const EVENT_INSET: Pixels = px(1.);
+        // A mask narrower than both insets (e.g. the scrollable ancestor got
+        // clipped away mid-drag) leaves an empty clamp range below — stop.
+        if visible_bounds.size.width < EVENT_INSET * 2.
+            || visible_bounds.size.height < EVENT_INSET * 2.
+        {
             self.stop_anchor_auto_scroll(cx);
             return;
         }
@@ -1488,12 +1491,12 @@ impl WindowSelectionState {
 
         let event_position = point(
             position.x.clamp(
-                visible_bounds.left() + px(1.),
-                visible_bounds.right() - px(1.),
+                visible_bounds.left() + EVENT_INSET,
+                visible_bounds.right() - EVENT_INSET,
             ),
             position.y.clamp(
-                visible_bounds.top() + px(1.),
-                visible_bounds.bottom() - px(1.),
+                visible_bounds.top() + EVENT_INSET,
+                visible_bounds.bottom() - EVENT_INSET,
             ),
         );
         self.auto_scroll.last_drag_position = Some(event_position);

--- a/crates/base/src/text_selection.rs
+++ b/crates/base/src/text_selection.rs
@@ -1472,13 +1472,11 @@ impl WindowSelectionState {
         // moves, so selection keeps scrolling the same related region even
         // after the anchor text has moved out of view.
         let visible_bounds = registration.registration.hitbox.content_mask.bounds;
-        // Keeps the synthesized wheel event strictly inside the mask so
-        // hit-testing reaches the scrollable.
-        const EVENT_INSET: Pixels = px(1.);
-        // A mask narrower than both insets (e.g. the scrollable ancestor got
-        // clipped away mid-drag) leaves an empty clamp range below — stop.
-        if visible_bounds.size.width < EVENT_INSET * 2.
-            || visible_bounds.size.height < EVENT_INSET * 2.
+        // Keeps the synthesized wheel event hit-testing inside the mask.
+        const HIT_TEST_INSET: Pixels = px(1.);
+        // A collapsed mask leaves an empty clamp range below — stop.
+        if visible_bounds.size.width < HIT_TEST_INSET * 2.
+            || visible_bounds.size.height < HIT_TEST_INSET * 2.
         {
             self.stop_anchor_auto_scroll(cx);
             return;
@@ -1491,12 +1489,12 @@ impl WindowSelectionState {
 
         let event_position = point(
             position.x.clamp(
-                visible_bounds.left() + EVENT_INSET,
-                visible_bounds.right() - EVENT_INSET,
+                visible_bounds.left() + HIT_TEST_INSET,
+                visible_bounds.right() - HIT_TEST_INSET,
             ),
             position.y.clamp(
-                visible_bounds.top() + EVENT_INSET,
-                visible_bounds.bottom() - EVENT_INSET,
+                visible_bounds.top() + HIT_TEST_INSET,
+                visible_bounds.bottom() - HIT_TEST_INSET,
             ),
         );
         self.auto_scroll.last_drag_position = Some(event_position);


### PR DESCRIPTION
## Summary

- Fix a crash in `WindowSelectionState::update_auto_scroll`: drag-selection auto scroll can scroll the anchor's clipping viewport away, and once the registered content mask collapses below 2px, clamping the drag position into it panics (`Ord::clamp`: `assertion failed: min <= max`).
- Stop the anchor auto scroll when the mask is narrower than twice the hit-test inset (extracted as `HIT_TEST_INSET`) — there is nothing left to scroll.
- Add a regression test: begin a drag on a normal registration, re-register with a collapsed content mask, then drive `update_in_window` past the viewport edge.

## Test plan

- [x] `drag_auto_scroll_stops_when_the_content_mask_collapses` panics before the fix and passes after.
- [x] `cargo test -p gpui-base --lib text_selection` — all 48 tests pass.
- [x] `cargo run -p gpui-base --example components text-selection` — drag-selection auto scroll still behaves normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)