### PR TITLE
dock: Resolve tiles resize by pointer travel, and keep the handles hittable

### DIFF
--- a/crates/base/src/dock/tiles_geometry.rs
+++ b/crates/base/src/dock/tiles_geometry.rs
@@ -84,24 +84,30 @@ pub enum ResizeSide {
     BottomRight,
 }
 
-/// In-flight state for a resize drag: which side is moving, and the pointer
-/// position and tile bounds recorded at the last processed move event.
+/// In-flight state for a resize drag: which side is moving, where the pointer
+/// began the drag, and the tile bounds recorded at the last processed move
+/// event.
+///
+/// Pointer positions arrive in window coordinates while tile bounds live in
+/// canvas coordinates, so the start position is kept for the only measure
+/// meaningful across the two: how far the pointer has travelled since the
+/// drag began.
 #[derive(Clone, Copy, Debug)]
 pub struct ResizeDrag {
     side: ResizeSide,
-    last_position: Point<Pixels>,
+    start_position: Point<Pixels>,
     last_bounds: Bounds<Pixels>,
 }
 
 impl ResizeDrag {
     pub fn new(
         side: ResizeSide,
-        last_position: Point<Pixels>,
+        start_position: Point<Pixels>,
         last_bounds: Bounds<Pixels>,
     ) -> Self {
         Self {
             side,
-            last_position,
+            start_position,
             last_bounds,
         }
     }
@@ -110,13 +116,12 @@ impl ResizeDrag {
         self.side
     }
 
-    pub fn last_bounds(&self) -> Bounds<Pixels> {
-        self.last_bounds
+    pub fn start_position(&self) -> Point<Pixels> {
+        self.start_position
     }
 
-    pub fn with_last_position(mut self, last_position: Point<Pixels>) -> Self {
-        self.last_position = last_position;
-        self
+    pub fn last_bounds(&self) -> Bounds<Pixels> {
+        self.last_bounds
     }
 
     pub fn with_last_bounds(mut self, last_bounds: Bounds<Pixels>) -> Self {

--- a/crates/base/src/dock/tiles_state.rs
+++ b/crates/base/src/dock/tiles_state.rs
@@ -374,26 +374,32 @@ impl TilesState {
             return;
         };
         let previous = resize.drag.last_bounds();
+        // The pointer is in window coordinates and the bounds in canvas
+        // coordinates, so the moving edge is derived from how far the pointer
+        // has travelled since the drag began, applied to the bounds it began
+        // with — never from the pointer's position itself.
+        let initial = resize.initial_bounds;
+        let delta = pointer - resize.drag.start_position();
         let (new_x, new_y, new_width, new_height) = match resize.drag.side() {
-            ResizeSide::Left => (Some(pointer.x), None, None, None),
+            ResizeSide::Left => (Some(initial.origin.x + delta.x), None, None, None),
             ResizeSide::Right => (
                 None,
                 None,
-                Some((pointer.x - previous.origin.x).max(MINIMUM_SIZE.width)),
+                Some((initial.size.width + delta.x).max(MINIMUM_SIZE.width)),
                 None,
             ),
-            ResizeSide::Top => (None, Some(pointer.y), None, None),
+            ResizeSide::Top => (None, Some(initial.origin.y + delta.y), None, None),
             ResizeSide::Bottom => (
                 None,
                 None,
                 None,
-                Some((pointer.y - previous.origin.y).max(MINIMUM_SIZE.height)),
+                Some((initial.size.height + delta.y).max(MINIMUM_SIZE.height)),
             ),
             ResizeSide::BottomRight => (
                 None,
                 None,
-                Some((pointer.x - previous.origin.x).max(MINIMUM_SIZE.width)),
-                Some((pointer.y - previous.origin.y).max(MINIMUM_SIZE.height)),
+                Some((initial.size.width + delta.x).max(MINIMUM_SIZE.width)),
+                Some((initial.size.height + delta.y).max(MINIMUM_SIZE.height)),
             ),
         };
 
@@ -408,10 +414,7 @@ impl TilesState {
         );
 
         self.resizing = Some(TileResize {
-            drag: resize
-                .drag
-                .with_last_position(pointer)
-                .with_last_bounds(bounds),
+            drag: resize.drag.with_last_bounds(bounds),
             ..resize
         });
         self.apply_bounds(resize.panel, bounds, cx);
@@ -1004,6 +1007,56 @@ mod tests {
             order.borrow().content,
             Some(size(px(240.), px(100.))),
             "the overlay is given the canvas's scrollable extent"
+        );
+    }
+
+    /// A resize is resolved against the pointer's travel since the drag
+    /// began, never against the pointer's position: pointer positions are
+    /// window coordinates and tile bounds are canvas coordinates, and the two
+    /// differ by the canvas's own offset in the window. Reading the position
+    /// directly widened the tile by that offset the moment a drag started.
+    #[gpui::test]
+    fn a_resize_tracks_the_pointer_travel_not_its_window_position(cx: &mut TestAppContext) {
+        let (area, order, cx) = setup_order(cx);
+
+        cx.update(|window, cx| {
+            let panel = TestPanel::new("Only", cx);
+            let layout = DockLayout::tiles().tile(
+                panel,
+                Bounds {
+                    origin: point(px(20.), px(20.)),
+                    size: size(px(100.), px(100.)),
+                },
+            );
+            area.update(cx, |area, cx| area.set_center(layout, window, cx));
+        });
+        cx.run_until_parked();
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+        let tile = order.borrow().tiles.last().cloned().expect("the tile drew");
+
+        // The pointer's window position is nowhere near the tile's canvas
+        // bounds, as it never is once the canvas sits offset in the window.
+        let start = point(px(500.), px(300.));
+        cx.update(|window, cx| tile.begin_resize(ResizeSide::Right, start, window, cx));
+        cx.update(|window, cx| tile.resize_to(start, window, cx));
+        cx.run_until_parked();
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+        assert_eq!(
+            order.borrow().tiles.last().unwrap().bounds().size.width,
+            px(100.),
+            "a pointer that has not moved must not resize the tile"
+        );
+
+        // 32px of travel: 100 + 32 puts the right edge at 152, and the
+        // ten-pixel grid rounds it to 150.
+        cx.update(|window, cx| tile.resize_to(start + point(px(32.), px(0.)), window, cx));
+        cx.update(|window, cx| tile.end_resize(window, cx));
+        cx.run_until_parked();
+        cx.update(|window, cx| window.draw(cx).clear(cx));
+        assert_eq!(
+            order.borrow().tiles.last().unwrap().bounds().size.width,
+            px(130.),
+            "the tile grows by the pointer's travel, grid-rounded"
         );
     }
 

--- a/crates/ui/src/dock/tiles.rs
+++ b/crates/ui/src/dock/tiles.rs
@@ -210,7 +210,9 @@ impl TilesRenderer for TilesSkin {
         v_flex()
             .id(("tile", tile.panel_id().as_u64()))
             .occlude()
-            .overflow_hidden()
+            // No `overflow_hidden` here: the resize handles hang past the
+            // tile's edge, and a content mask would cut their hit areas down
+            // to the sliver inside it. The panel is clipped by `panel_frame`.
             .bg(cx.theme().tokens.background)
             .border_1()
             .border_color(cx.theme().border)
@@ -263,7 +265,12 @@ impl TilesRenderer for TilesSkin {
             .pl_3()
             .pr_2()
             .when_some(title_style, |this, style| {
-                this.bg(style.background).text_color(style.foreground)
+                // The tile frame does not clip its children, so a painted
+                // title bar rounds its own top corners to stay inside the
+                // frame's.
+                this.bg(style.background)
+                    .text_color(style.foreground)
+                    .rounded_t(cx.theme().tile_radius)
             })
             .child(
                 div()

--- a/crates/ui/src/dock/tiles.rs
+++ b/crates/ui/src/dock/tiles.rs
@@ -226,6 +226,15 @@ impl TilesRenderer for TilesSkin {
             // at all on a zoomed one — how a zoomed tile fills the dock is
             // this skin's decision.
             .when(tile.is_zoomed(), |this| this.size_full())
+            // One extra pixel past the stored bounds, so a snapped neighbor's
+            // border overlaps this tile's instead of stacking beside it into
+            // a double-width line. Base pins `w`/`h` to the stored bounds
+            // after this hook, so the growth rides on the min size, which
+            // wins over the pinned size and which base leaves alone.
+            .when(!tile.is_zoomed(), |this| {
+                this.min_w(tile.bounds().size.width + px(1.))
+                    .min_h(tile.bounds().size.height + px(1.))
+            })
             .on_mouse_down(MouseButton::Left, {
                 let tile = tile.clone();
                 move |_, window, cx| tile.bring_to_front(window, cx)


### PR DESCRIPTION
## Description

Resizing a tile jumped the moment the drag started: the resize math read the pointer's window position as if it were in canvas coordinates, so the tile instantly grew by the canvas's offset in the window. `ResizeDrag` now records where the drag began, and each move is resolved as the pointer's travel since then, applied to the bounds the drag began with. A regression test resizes with the pointer far from the tile's canvas bounds.

The tile frame also drops `overflow_hidden`: the resize handles hang past the tile's edge, and the content mask cut their hit areas down to the sliver inside it. A painted title bar now rounds its own top corners since the frame no longer clips it.

Each non-zoomed tile also grows one pixel past its stored bounds via its min size, so a snapped neighbor's border overlaps its own instead of stacking into a double-width line.