### PR TITLE
a11y: Expose sidebar items and keep input semantics on the focus node

### DIFF
--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -4,11 +4,12 @@
 //! https://github.com/zed-industries/zed/blob/main/crates/gpui/examples/input.rs
 use gpui::TextAlign;
 use gpui::{
-    Action, App, AppContext, Bounds, ClipboardItem, Context, Edges, Entity, EntityInputHandler,
-    EventEmitter, FocusHandle, Focusable, InteractiveElement as _, IntoElement, KeyBinding,
-    KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _,
-    Pixels, Point, Render, ScrollHandle, ScrollWheelEvent, SharedString, Styled as _, Subscription,
-    UTF16Selection, Window, actions, div, point, prelude::FluentBuilder as _, px,
+    AccessibleAction, Action, App, AppContext, Bounds, ClipboardItem, Context, Edges, Entity,
+    EntityInputHandler, EventEmitter, FocusHandle, Focusable, InteractiveElement as _, IntoElement,
+    KeyBinding, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent,
+    ParentElement as _, Pixels, Point, Render, Role, ScrollHandle, ScrollWheelEvent, SharedString,
+    StatefulInteractiveElement as _, Styled as _, Subscription, UTF16Selection, Window, actions,
+    div, point, prelude::FluentBuilder as _, px,
 };
 use ropey::{Rope, RopeSlice};
 use serde::Deserialize;
@@ -349,6 +350,7 @@ pub struct InputBaseState<M: InputModeKind> {
     /// colours once and then never see them as unset again, which is the same
     /// freeze in a different place.
     projected_editor_style: InputEditorStyle,
+    accessibility: InputAccessibility,
 
     /// The mask pattern for formatting the input text
     pub(crate) mask_pattern: MaskPattern,
@@ -400,6 +402,79 @@ pub struct InputBaseState<M: InputModeKind> {
     _subscriptions: Vec<Subscription>,
 
     pub(super) auto_scroll: AutoScroll,
+}
+
+/// Accessibility metadata projected by an input's presentation facade.
+///
+/// The editing state owns focus, so its rendered node must also own the role,
+/// name, value, and actions that assistive technology associates with that
+/// focus target.
+#[derive(Clone, Default)]
+pub struct InputAccessibility {
+    role: Option<Role>,
+    author_id: Option<SharedString>,
+    label: Option<SharedString>,
+    placeholder: Option<SharedString>,
+    value: Option<String>,
+    editable: bool,
+}
+
+impl InputAccessibility {
+    pub fn new(role: Option<Role>) -> Self {
+        Self {
+            role,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_author_id(mut self, author_id: Option<SharedString>) -> Self {
+        self.author_id = author_id;
+        self
+    }
+
+    pub fn with_label(mut self, label: Option<SharedString>) -> Self {
+        self.label = label;
+        self
+    }
+
+    pub fn with_placeholder(mut self, placeholder: Option<SharedString>) -> Self {
+        self.placeholder = placeholder;
+        self
+    }
+
+    pub fn with_value(mut self, value: Option<String>) -> Self {
+        self.value = value;
+        self
+    }
+
+    pub fn editable(mut self, editable: bool) -> Self {
+        self.editable = editable;
+        self
+    }
+
+    pub fn role(&self) -> Option<Role> {
+        self.role
+    }
+
+    pub fn author_id(&self) -> Option<&SharedString> {
+        self.author_id.as_ref()
+    }
+
+    pub fn label(&self) -> Option<&SharedString> {
+        self.label.as_ref()
+    }
+
+    pub fn placeholder(&self) -> Option<&SharedString> {
+        self.placeholder.as_ref()
+    }
+
+    pub fn value(&self) -> Option<&str> {
+        self.value.as_deref()
+    }
+
+    pub fn is_editable(&self) -> bool {
+        self.editable
+    }
 }
 
 /// Read-only styling data exposed to presentation facades.
@@ -660,6 +735,11 @@ impl<M: InputModeKind> InputBaseState<M> {
             mask_pattern_set: false,
             editor_style: InputEditorStyle::default(),
             projected_editor_style: InputEditorStyle::default(),
+            accessibility: InputAccessibility::new(Some(if M::MULTI_LINE {
+                Role::MultilineTextInput
+            } else {
+                Role::TextInput
+            })),
             diagnostic_popover: None,
             context_menu_handler: None,
             pending_context_menu: None,
@@ -750,6 +830,18 @@ impl<M: InputModeKind> InputBaseState<M> {
     pub fn set_editor_style(&mut self, style: InputEditorStyle) {
         self.editor_style = style.clone();
         self.projected_editor_style = style;
+    }
+
+    /// Project accessibility metadata onto the node that owns input focus.
+    #[doc(hidden)]
+    pub fn set_accessibility(&mut self, accessibility: InputAccessibility) {
+        self.accessibility = accessibility;
+    }
+
+    /// Read the metadata currently projected onto the focused input node.
+    #[doc(hidden)]
+    pub fn accessibility(&self) -> &InputAccessibility {
+        &self.accessibility
     }
 
     /// Set presentation padding for multi-line text and its scrollbar layout.
@@ -3070,6 +3162,15 @@ impl<M: InputModeKind> Render for InputBaseState<M> {
             .projected_editor_style
             .resolved(&crate::Theme::global(cx).tokens);
         let entity = cx.entity();
+        let InputAccessibility {
+            role,
+            author_id,
+            label,
+            placeholder,
+            value,
+            editable,
+        } = self.accessibility.clone();
+        let accessibility_entity = entity.clone();
         if self._pending_update {
             self.mode.update_highlighter::<M>(
                 super::mode::HighlighterUpdate {
@@ -3090,6 +3191,25 @@ impl<M: InputModeKind> Render for InputBaseState<M> {
 
         let element = div()
             .id("input-state")
+            .when_some(role, |this, role| this.role(role))
+            .when_some(author_id, |this, author_id| {
+                this.accessibility_id(author_id)
+            })
+            .when_some(label, |this, label| this.aria_label(label))
+            .when_some(placeholder, |this, placeholder| {
+                this.aria_placeholder(placeholder)
+            })
+            .when_some(value, |this, value| this.aria_value(value))
+            .when(editable, |this| {
+                this.on_a11y_action(AccessibleAction::SetValue, move |data, window, cx| {
+                    let Some(gpui::accesskit::ActionData::Value(value)) = data else {
+                        return;
+                    };
+                    accessibility_entity.update(cx, |state, cx| {
+                        state.replace_all(value.to_string(), window, cx);
+                    });
+                })
+            })
             .key_context(CONTEXT)
             .track_focus(&self.focus_handle)
             .when(self.is_editable(), |this| {

--- a/crates/ui/locales/ui.yml
+++ b/crates/ui/locales/ui.yml
@@ -174,12 +174,14 @@ Dock:
     it: Zoom Out
   Collapse:
     en: Collapse
+    pl: Zwiń
     zh-CN: 隐藏
     zh-HK: 隱藏
     zh-TW: 收合
     it: Nascondi
   Expand:
     en: Expand
+    pl: Rozwiń
     zh-CN: 展开
     zh-HK: 展開
     zh-TW: 展開
@@ -308,6 +310,7 @@ Input:
 Settings:
   search_placeholder:
     en: Search...
+    pl: Szukaj...
     zh-CN: 搜索...
     zh-HK: 搜索...
     zh-TW: 搜尋...

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -2,9 +2,9 @@ use std::rc::Rc;
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    AccessibleAction, AnyElement, App, DefiniteLength, Edges, Entity, Hsla,
-    InteractiveElement as _, IntoElement, ParentElement as _, Rems, RenderOnce, Role, SharedString,
-    StatefulInteractiveElement as _, StyleRefinement, Styled, TextAlign, Window, div, px, relative,
+    AnyElement, App, DefiniteLength, Edges, Entity, Hsla, InteractiveElement as _, IntoElement,
+    ParentElement as _, Rems, RenderOnce, Role, SharedString, StyleRefinement, Styled, TextAlign,
+    Window, div, px, relative,
 };
 
 use crate::button::{Button, ButtonRounded, ButtonVariants as _};
@@ -15,7 +15,7 @@ use crate::{ActiveTheme, Colorize, v_flex};
 use crate::{IconName, Size};
 use crate::{RoleOverride, Selectable, StyledExt, h_flex};
 use crate::{Sizable, StyleSized};
-use gpui_base::InputBase as BaseInput;
+use gpui_base::{InputBase as BaseInput, input::InputAccessibility};
 use rust_i18n::t;
 
 use super::state::{TextInputState, sync_focused_input_registry};
@@ -331,18 +331,6 @@ impl Input {
             })
     }
 
-    fn handle_accessibility_set_value(
-        state: &TextInputState,
-        data: Option<&gpui::accesskit::ActionData>,
-        window: &mut Window,
-        cx: &mut App,
-    ) {
-        let Some(gpui::accesskit::ActionData::Value(value)) = data else {
-            return;
-        };
-        state.replace_all(value.to_string(), window, cx);
-    }
-
     /// This method must after the refine_style.
     fn render_editor(
         input_state: TextInputState,
@@ -481,7 +469,6 @@ impl RenderOnce for Input {
         let disabled = self.disabled;
         let is_multi_line = presentation.is_multi_line();
         let accessibility_role = accessibility_role(is_multi_line, content_type, self.role);
-        let accessibility_state = state.clone();
         // Materializing the whole rope is only observable through the
         // accessibility tree, so skip it when no client is listening.
         let accessibility_value = (window.is_a11y_active()
@@ -492,14 +479,7 @@ impl RenderOnce for Input {
         if input_focused {
             sync_native_content_type(window, content_type, presentation.is_editable());
         }
-        let frame_focus_handle = window
-            .use_keyed_state(("input-frame-focus", state.entity_id()), cx, |_, cx| {
-                cx.focus_handle()
-            })
-            .read(cx)
-            .clone();
-        let focused = input_focused
-            || (frame_focus_handle.contains_focused(window, cx) && !presentation.is_disabled());
+        let focused = input_focused;
 
         let gap_x = match self.size {
             Size::Small => px(4.),
@@ -538,10 +518,19 @@ impl RenderOnce for Input {
             None if placeholder_is_mask => None,
             None => placeholder.clone(),
         };
+        state.set_accessibility(
+            InputAccessibility::new(accessibility_role)
+                .with_author_id(self.accessibility_id)
+                .with_label(aria_label)
+                .with_placeholder(placeholder)
+                .with_value(accessibility_value)
+                .editable(presentation.is_editable()),
+            cx,
+        );
         BaseInput::new(("input", state.entity_id()))
             .focused(focused)
             .disabled(disabled)
-            .track_focus(&frame_focus_handle)
+            .track_focus(presentation.focus_handle())
             .styles(|styles| {
                 styles.focused(|style| {
                     style.when(
@@ -550,18 +539,7 @@ impl RenderOnce for Input {
                     )
                 })
             })
-            .role(accessibility_role)
-            .when_some(self.accessibility_id, |this, id| this.accessibility_id(id))
-            .when_some(aria_label, |this, label| this.aria_label(label))
-            .when_some(placeholder, |this, placeholder| {
-                this.aria_placeholder(placeholder)
-            })
-            .when_some(accessibility_value, |this, value| this.aria_value(value))
-            .when(!disabled, |this| {
-                this.on_a11y_action(AccessibleAction::SetValue, move |data, window, cx| {
-                    Self::handle_accessibility_set_value(&accessibility_state, data, window, cx);
-                })
-            })
+            .role(RoleOverride::Presentational)
             .flex()
             .size_full()
             .line_height(LINE_HEIGHT)
@@ -778,120 +756,57 @@ mod tests {
     }
 
     #[gpui::test]
-    fn editable_input_offers_accessibility_write_action(cx: &mut gpui::TestAppContext) {
-        use crate::ElementExt as _;
-        use gpui::{AppContext as _, Element as _, IntoElement as _, Render};
-        use std::sync::{Arc, Mutex};
+    fn input_projects_accessibility_onto_focused_state(cx: &mut gpui::TestAppContext) {
+        use gpui::{AppContext as _, Render};
 
-        type EmittedState = Option<(Option<String>, bool)>;
-
-        struct InputA11yProbe {
+        struct Probe {
             state: Entity<InputState>,
-            emitted: Arc<Mutex<EmittedState>>,
         }
 
-        impl Render for InputA11yProbe {
+        impl Render for Probe {
             fn render(
                 &mut self,
                 _window: &mut Window,
                 _cx: &mut gpui::Context<Self>,
             ) -> impl IntoElement {
-                let state = self.state.clone();
-                let emitted = self.emitted.clone();
-                div().on_prepaint(move |_, window, cx| {
-                    let input = Input::new(&state).render(window, cx).into_element();
-                    let mut node = gpui::accesskit::Node::new(Role::TextInput);
-                    input.write_a11y_info(&mut node);
-                    *emitted.lock().unwrap() = Some((
-                        node.value().map(ToOwned::to_owned),
-                        node.supports_action(AccessibleAction::SetValue),
-                    ));
-                })
+                Input::new(&self.state)
+                    .accessibility_id("search.query")
+                    .aria_label("Search")
             }
         }
 
         cx.update(crate::init);
-        let emitted = Arc::new(Mutex::new(None));
-        let captured = emitted.clone();
-        let (probe, cx) = cx.add_window_view(move |window, cx| InputA11yProbe {
-            state: cx.new(|cx| InputState::new(window, cx).default_value("initial")),
-            emitted,
+        let (probe, cx) = cx.add_window_view(|window, cx| Probe {
+            state: cx.new(|cx| {
+                InputState::new(window, cx)
+                    .placeholder("Find settings")
+                    .default_value("initial")
+            }),
         });
         cx.update(|window, cx| {
             let _ = window.draw(cx);
         });
-        // No assistive technology is attached in tests, so the value stays
-        // unmaterialized while `SetValue` is still advertised.
-        assert_eq!(*captured.lock().unwrap(), Some((None, true)));
 
         let state = probe.read_with(cx, |probe, _| probe.state.clone());
-        let base: TextInputState = state.clone().into();
-        cx.update(|window, cx| {
-            Input::handle_accessibility_set_value(&base, None, window, cx);
+        state.read_with(cx, |state, _| {
+            let accessibility = state.accessibility();
+            assert_eq!(accessibility.role(), Some(Role::TextInput));
+            assert_eq!(
+                accessibility.author_id().map(SharedString::as_ref),
+                Some("search.query")
+            );
+            assert_eq!(
+                accessibility.label().map(SharedString::as_ref),
+                Some("Search")
+            );
+            assert_eq!(
+                accessibility.placeholder().map(SharedString::as_ref),
+                Some("Find settings")
+            );
+            // Values are only materialized while an accessibility client is active.
+            assert_eq!(accessibility.value(), None);
+            assert!(accessibility.is_editable());
         });
-        assert_eq!(state.read_with(cx, |state, _| state.value()), "initial");
-
-        let action = gpui::accesskit::ActionData::Value("updated".into());
-        cx.update(|window, cx| {
-            Input::handle_accessibility_set_value(&base, Some(&action), window, cx);
-        });
-        assert_eq!(state.read_with(cx, |state, _| state.value()), "updated");
-    }
-
-    #[gpui::test]
-    fn input_emits_accessibility_id(cx: &mut gpui::TestAppContext) {
-        use crate::ElementExt as _;
-        use gpui::{AppContext as _, Element as _, IntoElement as _, Render};
-        use std::sync::{Arc, Mutex};
-
-        type EmittedIds = Vec<Option<String>>;
-
-        struct InputA11yProbe {
-            state: Entity<InputState>,
-            emitted: Arc<Mutex<EmittedIds>>,
-        }
-
-        impl Render for InputA11yProbe {
-            fn render(
-                &mut self,
-                _window: &mut Window,
-                _cx: &mut gpui::Context<Self>,
-            ) -> impl IntoElement {
-                let state = self.state.clone();
-                let emitted = self.emitted.clone();
-                div().on_prepaint(move |_, window, cx| {
-                    let mut author_id_of = |input: Input| {
-                        let mut node = gpui::accesskit::Node::new(Role::TextInput);
-                        input
-                            .render(window, cx)
-                            .into_element()
-                            .write_a11y_info(&mut node);
-                        node.author_id().map(ToOwned::to_owned)
-                    };
-
-                    *emitted.lock().unwrap() = vec![
-                        author_id_of(Input::new(&state)),
-                        author_id_of(Input::new(&state).accessibility_id("search.query")),
-                    ];
-                })
-            }
-        }
-
-        cx.update(crate::init);
-        let emitted = Arc::new(Mutex::new(Vec::new()));
-        let captured = emitted.clone();
-        let (_, cx) = cx.add_window_view(move |window, cx| InputA11yProbe {
-            state: cx.new(|cx| InputState::new(window, cx)),
-            emitted,
-        });
-        cx.update(|window, cx| {
-            let _ = window.draw(cx);
-        });
-
-        assert_eq!(
-            *captured.lock().unwrap(),
-            vec![None, Some("search.query".into())]
-        );
     }
 
     #[test]

--- a/crates/ui/src/input/input.rs
+++ b/crates/ui/src/input/input.rs
@@ -530,7 +530,6 @@ impl RenderOnce for Input {
         BaseInput::new(("input", state.entity_id()))
             .focused(focused)
             .disabled(disabled)
-            .track_focus(presentation.focus_handle())
             .styles(|styles| {
                 styles.focused(|style| {
                     style.when(
@@ -539,7 +538,7 @@ impl RenderOnce for Input {
                     )
                 })
             })
-            .role(RoleOverride::Presentational)
+            .role(Role::Group)
             .flex()
             .size_full()
             .line_height(LINE_HEIGHT)

--- a/crates/ui/src/input/state.rs
+++ b/crates/ui/src/input/state.rs
@@ -102,6 +102,15 @@ impl TextInputState {
             .update(cx, |state, _| state.set_editor_style(style)))
     }
 
+    pub(crate) fn set_accessibility(
+        &self,
+        accessibility: gpui_base::input::InputAccessibility,
+        cx: &mut App,
+    ) {
+        dispatch!(self, |state| state
+            .update(cx, |state, _| state.set_accessibility(accessibility)))
+    }
+
     pub(crate) fn set_editor_paddings(&self, paddings: gpui::Edges<gpui::Pixels>, cx: &mut App) {
         dispatch!(self, |state| state
             .update(cx, |state, _| state.set_editor_paddings(paddings)))
@@ -142,11 +151,6 @@ impl TextInputState {
         dispatch!(self, |state| super::overlay::render_overlays(
             state, window, cx
         ))
-    }
-
-    pub(crate) fn replace_all(&self, value: String, window: &mut Window, cx: &mut App) {
-        dispatch!(self, |state| state
-            .update(cx, |state, cx| state.replace_all(value, window, cx)))
     }
 
     /// The text element itself, as a child to place in the frame.

--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -383,6 +383,9 @@ impl SidebarItem for SidebarMenuItem {
                             )
                             .on_click({
                                 move |_, _, cx| {
+                                    // Keep expanding/collapsing independent from
+                                    // activating the parent menu item.
+                                    cx.stop_propagation();
                                     open_state.update(cx, |is_open, cx| {
                                         *is_open = !*is_open;
                                         cx.notify();

--- a/crates/ui/src/sidebar/menu.rs
+++ b/crates/ui/src/sidebar/menu.rs
@@ -1,7 +1,5 @@
 use crate::{
-    ActiveTheme as _, Collapsible, Icon, IconName, Placement, Sizable as _, StyledExt,
-    button::{Button, ButtonVariants as _},
-    h_flex,
+    ActiveTheme as _, Collapsible, Icon, IconName, Placement, StyledExt, h_flex,
     menu::{ContextMenuExt, PopupMenu},
     sidebar::SidebarItem,
     tooltip::{ManagedTooltipExt as _, Tooltip},
@@ -9,9 +7,11 @@ use crate::{
 };
 use gpui::{
     AnyElement, App, ClickEvent, ElementId, InteractiveElement as _, IntoElement,
-    ParentElement as _, SharedString, StatefulInteractiveElement as _, StyleRefinement, Styled,
-    Window, div, percentage, prelude::FluentBuilder,
+    ParentElement as _, SharedString, StyleRefinement, Styled, Window, div, percentage,
+    prelude::FluentBuilder,
 };
+use gpui_base::Button as BaseButton;
+use rust_i18n::t;
 use std::rc::Rc;
 
 /// Menu for the [`super::Sidebar`]
@@ -260,126 +260,138 @@ impl SidebarItem for SidebarMenuItem {
             .as_ref()
             .map_or(false, |s| !is_collapsed && *s.read(cx));
 
+        let item = BaseButton::new("item")
+            .accessibility_label(self.label.clone())
+            .disabled(is_disabled)
+            .h_full()
+            .flex_1()
+            .min_w_0()
+            .overflow_x_hidden()
+            .p_2()
+            .gap_x_2()
+            .rounded(cx.theme().radius)
+            .text_sm()
+            .when(is_hoverable, |this| {
+                this.hover(|this| {
+                    this.bg(cx.theme().sidebar_accent.opacity(0.8))
+                        .text_color(cx.theme().sidebar_accent_foreground)
+                })
+            })
+            .when(is_active, |this| {
+                this.font_medium()
+                    .bg(cx.theme().tokens.sidebar_accent)
+                    .text_color(cx.theme().sidebar_accent_foreground)
+            })
+            .focus_visible(|this| {
+                this.bg(cx.theme().sidebar_accent)
+                    .text_color(cx.theme().sidebar_accent_foreground)
+            })
+            .when_some(self.icon.clone(), |this, icon| this.child(icon))
+            .when(is_collapsed, |this| {
+                this.justify_center().when(is_active, |this| {
+                    this.bg(cx.theme().tokens.sidebar_accent)
+                        .text_color(cx.theme().sidebar_accent_foreground)
+                })
+            })
+            .when(!is_collapsed, |this| {
+                this.h_7().child(
+                    h_flex()
+                        .flex_1()
+                        .gap_x_2()
+                        .justify_between()
+                        .overflow_x_hidden()
+                        .child(
+                            h_flex()
+                                .flex_1()
+                                .overflow_x_hidden()
+                                .child(self.label.clone()),
+                        )
+                        .when_some(self.suffix.clone(), |this, suffix| {
+                            this.child(suffix(window, cx).into_any_element())
+                        }),
+                )
+            })
+            .when(is_disabled, |this| {
+                this.text_color(cx.theme().muted_foreground)
+            })
+            .when(!is_disabled, |this| {
+                this.on_click({
+                    let open_state = open_state.clone();
+                    move |ev, window, cx| {
+                        if click_to_open {
+                            if let Some(ref s) = open_state {
+                                s.update(cx, |is_open: &mut bool, cx| {
+                                    *is_open = true;
+                                    cx.notify();
+                                });
+                            }
+                        } else if click_to_toggle {
+                            if let Some(ref s) = open_state {
+                                s.update(cx, |is_open: &mut bool, cx| {
+                                    *is_open = !*is_open;
+                                    cx.notify();
+                                });
+                            }
+                        }
+                        handler(ev, window, cx)
+                    }
+                })
+            })
+            .map(|this| {
+                if let Some(tooltip) = collapsed_tooltip {
+                    this.managed_tooltip_at(Placement::Right, move |window, cx| {
+                        Tooltip::new(tooltip.clone()).build(window, cx)
+                    })
+                } else {
+                    this
+                }
+            })
+            .map(|this| {
+                if let Some(context_menu) = self.context_menu {
+                    this.context_menu(move |menu, window, cx| context_menu(menu, window, cx))
+                        .into_any_element()
+                } else {
+                    this.into_any_element()
+                }
+            });
+
         div()
             .id(id.clone())
             .w_full()
-            .child(
-                h_flex()
-                    .size_full()
-                    .id("item")
-                    .overflow_x_hidden()
-                    .flex_shrink_0()
-                    .p_2()
-                    .gap_x_2()
-                    .rounded(cx.theme().radius)
-                    .text_sm()
-                    .when(is_hoverable, |this| {
-                        this.hover(|this| {
-                            this.bg(cx.theme().sidebar_accent.opacity(0.8))
-                                .text_color(cx.theme().sidebar_accent_foreground)
-                        })
-                    })
-                    .when(is_active, |this| {
-                        this.font_medium()
-                            .bg(cx.theme().tokens.sidebar_accent)
-                            .text_color(cx.theme().sidebar_accent_foreground)
-                    })
-                    .when_some(self.icon.clone(), |this, icon| this.child(icon))
-                    .when(is_collapsed, |this| {
-                        this.justify_center().when(is_active, |this| {
-                            this.bg(cx.theme().tokens.sidebar_accent)
-                                .text_color(cx.theme().sidebar_accent_foreground)
-                        })
-                    })
-                    .when(!is_collapsed, |this| {
-                        this.h_7()
+            .child(h_flex().size_full().gap_x_1().child(item).when_some(
+                open_state.clone(),
+                |this, open_state| {
+                    let action = if is_open {
+                        t!("Dock.Collapse")
+                    } else {
+                        t!("Dock.Expand")
+                    };
+                    this.child(
+                        BaseButton::new("caret")
+                            .accessibility_label(format!("{action} {}", self.label))
+                            .disabled(is_disabled)
+                            .size_5()
+                            .flex_shrink_0()
+                            .justify_center()
+                            .rounded(cx.theme().radius)
+                            .hover(|this| this.bg(cx.theme().sidebar_accent.opacity(0.8)))
+                            .focus_visible(|this| this.bg(cx.theme().sidebar_accent))
                             .child(
-                                h_flex()
-                                    .flex_1()
-                                    .gap_x_2()
-                                    .justify_between()
-                                    .overflow_x_hidden()
-                                    .child(
-                                        h_flex()
-                                            .flex_1()
-                                            .overflow_x_hidden()
-                                            .child(self.label.clone()),
-                                    )
-                                    .when_some(self.suffix.clone(), |this, suffix| {
-                                        this.child(suffix(window, cx).into_any_element())
-                                    }),
+                                Icon::new(IconName::ChevronRight)
+                                    .size_4()
+                                    .when(is_open, |this| this.rotate(percentage(90. / 360.))),
                             )
-                            .when_some(open_state.clone(), |this, open_state| {
-                                this.child(
-                                    Button::new("caret")
-                                        .xsmall()
-                                        .ghost()
-                                        .icon(
-                                            Icon::new(IconName::ChevronRight)
-                                                .size_4()
-                                                .when(is_open, |this| {
-                                                    this.rotate(percentage(90. / 360.))
-                                                }),
-                                        )
-                                        .on_click({
-                                            move |_, _, cx| {
-                                                // Avoid trigger item click, just expand/collapse submenu
-                                                cx.stop_propagation();
-                                                open_state.update(cx, |is_open, cx| {
-                                                    *is_open = !*is_open;
-                                                    cx.notify();
-                                                })
-                                            }
-                                        }),
-                                )
-                            })
-                    })
-                    .when(is_disabled, |this| {
-                        this.text_color(cx.theme().muted_foreground)
-                    })
-                    .when(!is_disabled, |this| {
-                        this.on_click({
-                            let open_state = open_state.clone();
-                            move |ev, window, cx| {
-                                if click_to_open {
-                                    if let Some(ref s) = open_state {
-                                        s.update(cx, |is_open: &mut bool, cx| {
-                                            *is_open = true;
-                                            cx.notify();
-                                        });
-                                    }
-                                } else if click_to_toggle {
-                                    if let Some(ref s) = open_state {
-                                        s.update(cx, |is_open: &mut bool, cx| {
-                                            *is_open = !*is_open;
-                                            cx.notify();
-                                        });
-                                    }
+                            .on_click({
+                                move |_, _, cx| {
+                                    open_state.update(cx, |is_open, cx| {
+                                        *is_open = !*is_open;
+                                        cx.notify();
+                                    })
                                 }
-                                handler(ev, window, cx)
-                            }
-                        })
-                    })
-                    .map(|this| {
-                        if let Some(tooltip) = collapsed_tooltip {
-                            this.managed_tooltip_at(Placement::Right, move |window, cx| {
-                                Tooltip::new(tooltip.clone()).build(window, cx)
-                            })
-                        } else {
-                            this
-                        }
-                    })
-                    .map(|this| {
-                        if let Some(context_menu) = self.context_menu {
-                            this.context_menu(move |menu, window, cx| {
-                                context_menu(menu, window, cx)
-                            })
-                            .into_any_element()
-                        } else {
-                            this.into_any_element()
-                        }
-                    }),
-            )
+                            }),
+                    )
+                },
+            ))
             .when(is_open, |this| {
                 this.child(
                     v_flex()


### PR DESCRIPTION
`SidebarMenuItem` and `Input` currently render the visible control separately
from the node that owns keyboard focus. On Windows this leaves NVDA/UI Automation
with unnamed, non-focusable settings entries or causes AccessKit to fall back to
announcing the whole window.

## Changes

- render sidebar menu entries as semantic `gpui_base::Button`s with stable names,
  keyboard focus, and Enter/Space activation;
- expose a named caret button for expandable entries and keep caret clicks from
  activating the parent item;
- project input role, label, placeholder, value, and SetValue onto the focused
  editor node;
- keep the decorative input frame as a non-interactive group so the tree has a
  single actionable text field.

## Testing

- `RUSTFLAGS=-D warnings cargo test -p gpui-component input::input::tests --lib`
- `RUSTFLAGS=-D warnings cargo test -p gpui-component sidebar --lib`
- Windows UI Automation smoke test with NVDA running: Settings entries are
  named buttons and the search field is a named Edit control.

Real hardware was not required for this library-level change; OpenLogi hardware
verification remains pending.
