### PR TITLE
sheet: Fix sheet alignment on Linux

### DIFF
--- a/crates/ui/src/sheet.rs
+++ b/crates/ui/src/sheet.rs
@@ -3,8 +3,7 @@ use std::{rc::Rc, time::Duration};
 use gpui::{
     Animation, AnimationExt as _, AnyElement, App, ClickEvent, DefiniteLength, DismissEvent, Edges,
     EventEmitter, FocusHandle, InteractiveElement as _, IntoElement, ParentElement, Pixels,
-    RenderOnce, StyleRefinement, Styled, Window, anchored, div, point, prelude::FluentBuilder as _,
-    px,
+    RenderOnce, StyleRefinement, Styled, Window, div, prelude::FluentBuilder as _, px,
 };
 use gpui_base::{ElementExt as _, Sheet as BaseSheet, TextSelectionScopeId, actions::Cancel};
 use schemars::JsonSchema;
@@ -135,11 +134,11 @@ impl RenderOnce for Sheet {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let placement = self.placement;
         let selection_scope = self.selection_scope;
-        let window_paddings = crate::window_border::window_paddings(window);
+        let frame_insets = crate::window_border::window_content_insets(window);
         let size = window.viewport_size()
             - gpui::size(
-                window_paddings.left + window_paddings.right,
-                window_paddings.top + window_paddings.bottom,
+                frame_insets.left + frame_insets.right,
+                frame_insets.top + frame_insets.bottom,
             );
         let top = cx.theme().sheet.margin_top;
         let base_size = window.text_style().font_size;
@@ -243,20 +242,17 @@ impl RenderOnce for Sheet {
             );
         let surface = surface.text_selection_scope(selection_scope);
 
-        anchored()
-            .position(point(window_paddings.left, window_paddings.top))
-            .snap_to_window()
-            .child(
-                BaseSheet::new(cx)
-                    .w(size.width)
-                    .h(size.height)
-                    .focus_handle(self.focus_handle)
-                    .overlay_interactive(self.overlay)
-                    .overlay_closable(self.overlay && self.overlay_closable)
-                    .request_close(|window, cx| window.close_sheet(cx))
-                    .on_close(move |event, window, cx| (self.on_close)(event, window, cx))
-                    .overlay(overlay)
-                    .surface(surface),
-            )
+        BaseSheet::new(cx)
+            .top(frame_insets.top)
+            .left(frame_insets.left)
+            .w(size.width)
+            .h(size.height)
+            .focus_handle(self.focus_handle)
+            .overlay_interactive(self.overlay)
+            .overlay_closable(self.overlay && self.overlay_closable)
+            .request_close(|window, cx| window.close_sheet(cx))
+            .on_close(move |event, window, cx| (self.on_close)(event, window, cx))
+            .overlay(overlay)
+            .surface(surface)
     }
 }

--- a/crates/ui/src/window_border.rs
+++ b/crates/ui/src/window_border.rs
@@ -93,6 +93,34 @@ pub fn window_paddings(window: &Window) -> Edges<Pixels> {
     }
 }
 
+/// Per-side inset from the window bounds to the visible frame's content area.
+///
+/// This is [`window_paddings`] plus the frame's own border, which the window
+/// wrapper draws on every side it is not tiled against. Allows to lay an element
+/// flush against the inside of the window frame.
+pub(crate) fn window_content_insets(window: &Window) -> Edges<Pixels> {
+    let shadow_size = window.client_inset().unwrap_or(SHADOW_SIZE);
+    match window.window_decorations() {
+        Decorations::Server => Edges::all(px(0.0)),
+        Decorations::Client { tiling } => {
+            let mut insets = client_frame_insets(shadow_size, &tiling);
+            if !tiling.top {
+                insets.top += BORDER_SIZE;
+            }
+            if !tiling.bottom {
+                insets.bottom += BORDER_SIZE;
+            }
+            if !tiling.left {
+                insets.left += BORDER_SIZE;
+            }
+            if !tiling.right {
+                insets.right += BORDER_SIZE;
+            }
+            insets
+        }
+    }
+}
+
 impl ParentElement for WindowBorder {
     fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
         self.children.extend(elements);


### PR DESCRIPTION
## Description

On Linux, sheets are drawn  shifted about 20px, hanging into the window shadow on one side and leaving a gap before the border on the other, with left/right/top sheets riding up over the title bar.

Sheets are now offset and sized to the frame's content area, so they sit flush against its borders and start just below the title bar.

## Screenshot

Before (only 1 example, top/bottom/left alignments were wrong too):

<img width="1600" height="1200" alt="Copie d&#39;écran_20260901_105008" src="https://github.com/user-attachments/assets/f2daa898-9113-4560-a631-ee877a791aad" />

After:

<img width="1600" height="1200" alt="Copie d&#39;écran_20260901_142645" src="https://github.com/user-attachments/assets/35d98526-5809-47a8-b7fe-e8cfb5cebd29" />


## How to Test

Run ´cargo run´ , open the Sheets exampla and open a sheet. 

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
