### PR TITLE
perf(shell): avoid redundant clean-frame work

### DIFF
--- a/crates/fps/src/lib.rs
+++ b/crates/fps/src/lib.rs
@@ -23,9 +23,10 @@
 //! # }
 //! ```
 //!
-//! The call takes no options. Anything else — a different corner, frame
-//! budget, palette, or an embedded rather than overlaid HUD — is built by
-//! composing the two pieces they use, [`FpsMonitor`] and [`FpsOverlay`].
+//! The returned overlay can change its corner, frame budget, and whether it
+//! continuously drives the window's animation loop. A custom palette or an
+//! embedded rather than overlaid HUD is built by composing [`FpsMonitor`] and
+//! [`FpsOverlay`] directly.
 //!
 //! This crate depends only on `gpui`, so it can be used from any GPUI
 //! application.

--- a/crates/fps/src/monitor.rs
+++ b/crates/fps/src/monitor.rs
@@ -186,6 +186,15 @@ impl FpsMonitor {
         self
     }
 
+    pub(crate) fn set_frame_budget(&mut self, budget: Duration) {
+        self.frame_budget = budget;
+        self.axis_max = budget.as_secs_f32() * 2.;
+    }
+
+    pub(crate) fn set_continuous(&mut self, continuous: bool) {
+        self.continuous = continuous;
+    }
+
     /// Whether to sample and show CPU, memory and GPU usage. Defaults to
     /// `true`, and is always off on the web.
     ///

--- a/crates/fps/src/overlay.rs
+++ b/crates/fps/src/overlay.rs
@@ -2,6 +2,7 @@ use gpui::{
     Anchor, App, Entity, IntoElement, ParentElement, Pixels, RenderOnce, Styled, Window, div,
     prelude::FluentBuilder as _, px,
 };
+use std::time::Duration;
 
 use crate::monitor::FpsMonitor;
 
@@ -33,6 +34,8 @@ const MARGIN: Pixels = px(12.);
 pub struct FpsOverlay {
     monitor: Entity<FpsMonitor>,
     anchor: Anchor,
+    frame_budget: Option<Duration>,
+    continuous: Option<bool>,
 }
 
 impl FpsOverlay {
@@ -40,6 +43,8 @@ impl FpsOverlay {
         Self {
             monitor: monitor.clone(),
             anchor: Anchor::TopRight,
+            frame_budget: None,
+            continuous: None,
         }
     }
 
@@ -48,10 +53,33 @@ impl FpsOverlay {
         self.anchor = anchor;
         self
     }
+
+    /// The per-frame budget used for chart grading and its vertical scale.
+    pub fn frame_budget(mut self, budget: Duration) -> Self {
+        self.frame_budget = Some(budget);
+        self
+    }
+
+    /// Whether the HUD requests another animation frame after every render.
+    /// Defaults to the monitor's current setting (`true` on first use).
+    pub fn continuous(mut self, continuous: bool) -> Self {
+        self.continuous = Some(continuous);
+        self
+    }
 }
 
 impl RenderOnce for FpsOverlay {
-    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        if self.frame_budget.is_some() || self.continuous.is_some() {
+            self.monitor.update(cx, |monitor, _| {
+                if let Some(budget) = self.frame_budget {
+                    monitor.set_frame_budget(budget);
+                }
+                if let Some(continuous) = self.continuous {
+                    monitor.set_continuous(continuous);
+                }
+            });
+        }
         let margin = MARGIN;
 
         // Corners are placed by their own two offsets so the overlay stays the

--- a/crates/shell/README.md
+++ b/crates/shell/README.md
@@ -173,7 +173,7 @@ import { fps_monitor } from "gpui-fps";
 | `h_flex()` / `v_flex()` | function | A row / column flex element |
 | `value` | function | A text element |
 | `svg(path)` / `image(path)` | functions | A theme-tinted vector icon / full-colour application asset |
-| `fps_monitor()` | function | The native `gpui-fps` performance HUD; place it in a `relative()` parent |
+| `fps_monitor()` | function | The native `gpui-fps` performance HUD; passive by default, with `.continuous(true)` for a sustained-frame test |
 | `Button.new(id)` | type | A base `Button`: activation, focus, disabled and selected state, no styling |
 | `Link.new(id)` | type | A base external link; pair it with `.href("https://…")` |
 | `Checkbox.new(id)` / `Switch.new(id)` | type | A base controlled toggle, no styling |

--- a/crates/shell/src/engine/quickjs/mod.rs
+++ b/crates/shell/src/engine/quickjs/mod.rs
@@ -5446,6 +5446,13 @@ globalThis.__gpui = (() => {
     return this;
   };
 
+  methods.frame_budget = function (milliseconds) {
+    __apply(this.__id, "frame_budget", [
+      finitePositive(milliseconds, "frame_budget"),
+    ]);
+    return this;
+  };
+
   // A popover opened by the wrong button is silence, not a visual mistake, so
   // an unknown button name is refused rather than falling back to the left one.
   methods.mouse_button = function (value) {
@@ -6697,6 +6704,7 @@ impl ShellRuntime {
                 "open",
                 "default_open",
                 "overlay_closable",
+                "continuous",
                 "with_item_to_measure_index",
             ]
             .into_iter()
@@ -7695,6 +7703,8 @@ impl ShellRuntime {
             | "default_open"
             | "overlay_closable"
             | "anchor"
+            | "continuous"
+            | "frame_budget"
             | "mouse_button"
             | "open_delay"
             | "close_delay"
@@ -7746,6 +7756,8 @@ impl ShellRuntime {
                     "default_open" => "default_open",
                     "overlay_closable" => "overlay_closable",
                     "anchor" => "anchor",
+                    "continuous" => "continuous",
+                    "frame_budget" => "frame_budget",
                     "mouse_button" => "mouse_button",
                     "open_delay" => "open_delay",
                     "close_delay" => "close_delay",

--- a/crates/shell/src/engine/quickjs/theme_api.rs
+++ b/crates/shell/src/engine/quickjs/theme_api.rs
@@ -3,7 +3,35 @@ use crate::{theme_tokens, value::Bridged};
 use gpui_base::{Theme, ThemeAppearance};
 use rquickjs::{Ctx, Exception, Object, Result as JsResult, Value, function::Func};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
+
+thread_local! {
+    static SNAPSHOT_CACHE: RefCell<ThemeSnapshotCache> = RefCell::new(ThemeSnapshotCache::default());
+}
+
+#[derive(Default)]
+struct ThemeSnapshotCache {
+    entry: Option<(gpui_base::SemanticThemeTokens, ThemeAppearance, Rc<String>)>,
+}
+
+impl ThemeSnapshotCache {
+    fn snapshot(
+        &mut self,
+        tokens: &gpui_base::SemanticThemeTokens,
+        appearance: ThemeAppearance,
+    ) -> Rc<String> {
+        if let Some((cached_tokens, cached_appearance, json)) = &self.entry
+            && cached_tokens == tokens
+            && *cached_appearance == appearance
+        {
+            return json.clone();
+        }
+
+        let json = Rc::new(build_snapshot_json(tokens, appearance));
+        self.entry = Some((tokens.clone(), appearance, json.clone()));
+        json
+    }
+}
 
 #[derive(Deserialize)]
 struct ScriptTheme {
@@ -64,7 +92,7 @@ struct TextStyleOverride {
 pub fn install(ctx: &Ctx<'_>, module: &Object<'_>) -> JsResult<()> {
     ctx.globals().set(
         "__theme_snapshot",
-        Func::from(|_: Ctx<'_>| -> JsResult<String> { Ok(snapshot_json()) }),
+        Func::from(|_: Ctx<'_>| -> JsResult<String> { Ok(snapshot_json().as_ref().clone()) }),
     )?;
     module.set("set_theme", Func::from(set_theme))?;
     Ok(())
@@ -262,11 +290,24 @@ fn set_radius(t: &mut gpui_base::RadiusTokens, n: &str, v: f32) {
     }
 }
 
-fn snapshot_json() -> String {
+fn snapshot_json() -> Rc<String> {
+    let tokens = theme_tokens::current().unwrap_or_default();
+    let appearance =
+        crate::scope::with_current_app(|cx| Theme::global(cx).appearance).unwrap_or_default();
+    SNAPSHOT_CACHE.with(|cache| cache.borrow_mut().snapshot(&tokens, appearance))
+}
+
+fn build_snapshot_json(
+    tokens: &gpui_base::SemanticThemeTokens,
+    appearance: ThemeAppearance,
+) -> String {
     let join = |v: Vec<String>| v.join(",");
     let pairs = theme_tokens::color_token_names()
         .iter()
-        .filter_map(|n| theme_tokens::token_color(n).map(|c| format!("\"{n}\":\"{}\"", hex(c))))
+        .filter_map(|n| {
+            theme_tokens::resolve_color(&tokens.colors, n)
+                .map(|c| format!("\"{n}\":\"{}\"", hex(c)))
+        })
         .collect::<Vec<_>>();
     let colors = join(pairs.clone());
     let direct = join(pairs);
@@ -274,7 +315,8 @@ fn snapshot_json() -> String {
         theme_tokens::spacing_token_names()
             .iter()
             .filter_map(|n| {
-                theme_tokens::token_spacing(n).map(|v| format!("\"{n}\":{}", f32::from(v)))
+                theme_tokens::resolve_spacing(&tokens.spacing, n)
+                    .map(|v| format!("\"{n}\":{}", f32::from(v)))
             })
             .collect(),
     );
@@ -282,37 +324,35 @@ fn snapshot_json() -> String {
         theme_tokens::radius_token_names()
             .iter()
             .filter_map(|n| {
-                theme_tokens::token_radius(n).map(|v| format!("\"{n}\":{}", f32::from(v)))
+                theme_tokens::resolve_radius(&tokens.radius, n)
+                    .map(|v| format!("\"{n}\":{}", f32::from(v)))
             })
             .collect(),
     );
-    let typography = theme_tokens::typography_tokens()
-        .map(|t| {
-            let style = |name: &str, s: &gpui_base::TextStyleToken| {
-                format!(
-                    "\"{name}\":{{\"size\":{},\"line_height\":{},\"weight\":{}}}",
-                    f32::from(s.size),
-                    f32::from(s.line_height),
-                    s.weight.0
-                )
-            };
-            let mut parts = vec![
-                format!("\"sans\":{}", json_string(&t.sans)),
-                format!("\"mono\":{}", json_string(&t.mono)),
-            ];
-            parts.extend([
-                style("xs", &t.xs),
-                style("sm", &t.sm),
-                style("md", &t.md),
-                style("lg", &t.lg),
-                style("xl", &t.xl),
-                style("mono_md", &t.mono_md),
-            ]);
-            join(parts)
-        })
-        .unwrap_or_default();
-    let appearance =
-        crate::scope::with_current_app(|cx| Theme::global(cx).appearance).unwrap_or_default();
+    let typography = {
+        let t = &tokens.typography;
+        let style = |name: &str, s: &gpui_base::TextStyleToken| {
+            format!(
+                "\"{name}\":{{\"size\":{},\"line_height\":{},\"weight\":{}}}",
+                f32::from(s.size),
+                f32::from(s.line_height),
+                s.weight.0
+            )
+        };
+        let mut parts = vec![
+            format!("\"sans\":{}", json_string(&t.sans)),
+            format!("\"mono\":{}", json_string(&t.mono)),
+        ];
+        parts.extend([
+            style("xs", &t.xs),
+            style("sm", &t.sm),
+            style("md", &t.md),
+            style("lg", &t.lg),
+            style("xl", &t.xl),
+            style("mono_md", &t.mono_md),
+        ]);
+        join(parts)
+    };
     let name = match appearance {
         ThemeAppearance::Light => "light",
         ThemeAppearance::Dark => "dark",
@@ -332,4 +372,32 @@ fn hex(color: gpui::Hsla) -> String {
     let c = gpui::Rgba::from(color);
     let b = |v: f32| (v.clamp(0., 1.) * 255.).round() as u8;
     format!("#{:02x}{:02x}{:02x}", b(c.r), b(c.g), b(c.b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unchanged_theme_snapshot_reuses_its_serialized_storage() {
+        let tokens = gpui_base::SemanticThemeTokens::default();
+        let mut cache = ThemeSnapshotCache::default();
+
+        let first = cache.snapshot(&tokens, ThemeAppearance::Light);
+        let second = cache.snapshot(&tokens, ThemeAppearance::Light);
+
+        assert!(std::rc::Rc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn changed_theme_snapshot_invalidates_serialized_storage() {
+        let tokens = gpui_base::SemanticThemeTokens::default();
+        let mut cache = ThemeSnapshotCache::default();
+
+        let first = cache.snapshot(&tokens, ThemeAppearance::Light);
+        let second = cache.snapshot(&tokens, ThemeAppearance::Dark);
+
+        assert!(!std::rc::Rc::ptr_eq(&first, &second));
+        assert_ne!(first, second);
+    }
 }

--- a/crates/shell/src/materialize.rs
+++ b/crates/shell/src/materialize.rs
@@ -501,6 +501,8 @@ struct Behavior {
     /// component's own default, and the two differ: a popover anchors top-left,
     /// a hover card top-center.
     anchor: Option<gpui::Anchor>,
+    continuous: Option<bool>,
+    frame_budget: Option<Duration>,
     /// The pointer button that opens a `Popover`.
     mouse_button: Option<MouseButton>,
     /// The label a hover shows over this element. A string rather than an
@@ -649,9 +651,9 @@ pub fn materialize(
     cx: &mut App,
 ) -> AnyElement {
     let ambient = window.text_style().color;
-    // Counted and timed because this is the half that follows frames: the story
-    // and the benchmark both read the two counters side by side, and the gap
-    // between them is the architecture.
+    // Counted and timed because this is the native half of rebuilding a dirty
+    // script view. Clean window frames reuse ShellRoot's cached subtree and do
+    // not enter here at all.
     let metrics = runtime.metrics();
     metrics.time_materialize(|| {
         materialize_node(
@@ -3109,6 +3111,8 @@ fn apply_behavior(behavior: &mut Behavior, name: &str, args: &[Bridged]) {
                 .and_then(|value| value.as_str().ok())
                 .and_then(|value| anchor_from_name(value));
         }
+        "continuous" => behavior.continuous = Some(flag.unwrap_or(true)),
+        "frame_budget" => behavior.frame_budget = milliseconds(args),
         "mouse_button" => {
             behavior.mouse_button =
                 args.first()

--- a/crates/shell/src/materialize/components/fps.rs
+++ b/crates/shell/src/materialize/components/fps.rs
@@ -19,5 +19,9 @@ pub(in crate::materialize) fn fps_monitor(
 
     gpui_fps::fps_monitor(window, cx)
         .when_some(behavior.anchor, |monitor, anchor| monitor.anchor(anchor))
+        .continuous(behavior.continuous.unwrap_or(false))
+        .when_some(behavior.frame_budget, |monitor, budget| {
+            monitor.frame_budget(budget)
+        })
         .into_any_element()
 }

--- a/crates/shell/src/metrics.rs
+++ b/crates/shell/src/metrics.rs
@@ -7,11 +7,13 @@
 //! [`RuntimeMetrics::script_renders`] has not moved, and the shell story shows
 //! both counters live while a feed drives the view.
 //!
-//! Two counters, and the gap between them is the whole point:
+//! Two counters, and the gap between them is the whole point. The window root
+//! caches a clean view's GPUI subtree, so neither counter follows frames that
+//! have no dirty script view:
 //!
 //! ```text
 //! script_renders    ── follows cx.notify(), reloads, theme changes
-//! materializations  ── follows GPUI frames
+//! materializations  ── follows dirty script-view renders
 //! ```
 //!
 //! # What a `VirtualList` does to the two
@@ -118,8 +120,8 @@ impl RuntimeMetrics {
         mean(self.native_time, self.script_renders)
     }
 
-    /// How many times a snapshot has been turned into GPUI elements. This one
-    /// follows frames.
+    /// How many times a snapshot has been turned into GPUI elements. A cached,
+    /// clean window frame does not move this counter.
     pub fn materializations(&self) -> u64 {
         self.materializations
     }

--- a/crates/shell/src/root.rs
+++ b/crates/shell/src/root.rs
@@ -18,8 +18,8 @@ use gpui::{
     Anchor, AnyElement, AnyView, App, AppContext as _, ClickEvent, ClipboardItem, Context,
     ElementId, Entity, FocusHandle, Global, Hsla, InteractiveElement as _, IntoElement, KeyBinding,
     MouseButton, MouseDownEvent, ParentElement as _, Render, SharedString,
-    StatefulInteractiveElement as _, Styled as _, WeakFocusHandle, Window, actions, deferred, div,
-    hsla, prelude::FluentBuilder as _, px,
+    StatefulInteractiveElement as _, StyleRefinement, Styled as _, WeakFocusHandle, Window,
+    actions, deferred, div, hsla, prelude::FluentBuilder as _, px,
 };
 use gpui_base::{
     ColorTokens, Dialog, POPUP_PRIORITY, Placement, RadiusTokens, Sheet, SpacingTokens,
@@ -771,7 +771,11 @@ impl Render for ShellRoot {
             .text_color(colors.foreground)
             // Painted back to front; see the stacking order on `ShellRoot`.
             .child(TextSelectionLayer)
-            .child(self.content.clone())
+            .child(
+                self.content
+                    .clone()
+                    .cached(StyleRefinement::default().size_full()),
+            )
             .children(self.sheet_layer(&colors, &spacing, cx))
             .children(self.dialog_layer(&colors, &radius, &spacing, cx))
             .child(self.toast_layer(&colors, &radius, &spacing, cx))

--- a/crates/shell/src/tests/render.rs
+++ b/crates/shell/src/tests/render.rs
@@ -4759,7 +4759,12 @@ import { fps_monitor } from "gpui-fps";
 
 export default class Monitor extends View {
   render(cx) {
-    return div().relative().size_full().child(fps_monitor().anchor("bottom_left"));
+    return div().relative().size_full().child(
+      fps_monitor()
+        .anchor("bottom_left")
+        .continuous(false)
+        .frame_budget(8.33)
+    );
   }
 }
 "#;
@@ -4774,8 +4779,10 @@ export default class Monitor extends View {
         .update(|window, cx| runtime.render_to_spec(&object, None, window, cx))
         .expect("render spec");
     assert!(
-        spec.contains("FpsMonitor :anchor"),
-        "the snapshot must retain the native monitor and its anchor: {spec}"
+        spec.contains("FpsMonitor :anchor")
+            && spec.contains(":continuous[Bool(false)]")
+            && spec.contains(":frame_budget[Number(8.33)]"),
+        "the snapshot must retain the native monitor and its performance options: {spec}"
     );
 
     let view = context.update(|_, cx| cx.new(|_| ScriptView::new(runtime, object)));

--- a/crates/shell/src/tests/snapshot.rs
+++ b/crates/shell/src/tests/snapshot.rs
@@ -44,6 +44,17 @@ export default class Toggle extends View {
 
 const ENTRY: &str = "toggle.js";
 
+const FPS_MONITOR: &str = r#"
+import { View, div } from "gpui";
+import { fps_monitor } from "gpui-fps";
+
+export default class Monitor extends View {
+  render() {
+    return div().relative().size_full().child(fps_monitor());
+  }
+}
+"#;
+
 const PATH: &str = r##"
 import { div, View, PathBuilder, Background } from "gpui";
 
@@ -198,6 +209,85 @@ fn repeated_gpui_renders_do_not_re_enter_the_script(cx: &mut TestAppContext) {
         runtime.metrics().read().script_renders(),
         1,
         "a clean view was materialized 65 times and must have entered the VM once"
+    );
+}
+
+#[gpui::test]
+fn shell_root_reuses_a_clean_views_materialized_subtree(cx: &mut TestAppContext) {
+    let (runtime, mut context, view) = script_view(cx, TOGGLE);
+    context.update(|window, cx| {
+        window.replace_root(cx, |window, cx| {
+            crate::root::ShellRoot::new(view.clone().into(), window, cx)
+        })
+    });
+
+    context.update(|window, cx| window.draw(cx).clear(cx));
+    let first = runtime.metrics().read();
+    let started = std::time::Instant::now();
+    for _ in 0..64 {
+        context.update(|window, cx| window.draw(cx).clear(cx));
+    }
+    let elapsed = started.elapsed();
+
+    let clean = runtime.metrics().read().since(&first);
+    eprintln!(
+        "clean_frames=64 elapsed={elapsed:?} materializations={} materialize_time={:?}",
+        clean.materializations(),
+        clean.materialize_time(),
+    );
+    assert_eq!(clean.script_renders(), 0);
+    assert_eq!(
+        clean.materializations(),
+        0,
+        "64 clean window frames must reuse the subtree produced by the first materialization"
+    );
+
+    view.update(&mut context, |view, cx| view.refresh(cx));
+    context.update(|window, cx| window.draw(cx).clear(cx));
+
+    let refreshed = runtime.metrics().read().since(&first);
+    assert_eq!(refreshed.script_renders(), 1);
+    assert_eq!(
+        refreshed.materializations(),
+        1,
+        "refreshing the script view must invalidate and replace the cached subtree once"
+    );
+}
+
+#[gpui::test]
+fn shell_fps_monitor_does_not_drive_the_window_unless_requested(cx: &mut TestAppContext) {
+    let (_runtime, mut context, view) = script_view(cx, FPS_MONITOR);
+    context.update(|window, cx| {
+        window.replace_root(cx, |window, cx| {
+            crate::root::ShellRoot::new(view.clone().into(), window, cx)
+        })
+    });
+
+    context.update(|window, cx| window.draw(cx).clear(cx));
+    let requested = context.update(|window, cx| window.simulate_next_frame(cx));
+
+    assert_eq!(
+        requested, 0,
+        "the diagnostic HUD must observe application frames rather than create a redraw loop"
+    );
+}
+
+#[gpui::test]
+fn shell_fps_monitor_can_explicitly_drive_a_sustained_frame_test(cx: &mut TestAppContext) {
+    let source = FPS_MONITOR.replace("fps_monitor()", "fps_monitor().continuous(true)");
+    let (_runtime, mut context, view) = script_view(cx, &source);
+    context.update(|window, cx| {
+        window.replace_root(cx, |window, cx| {
+            crate::root::ShellRoot::new(view.clone().into(), window, cx)
+        })
+    });
+
+    context.update(|window, cx| window.draw(cx).clear(cx));
+    let requested = context.update(|window, cx| window.simulate_next_frame(cx));
+
+    assert!(
+        requested > 0,
+        "continuous(true) must remain an explicit sustained-frame diagnostic mode"
     );
 }
 

--- a/crates/shell/src/theme_tokens.rs
+++ b/crates/shell/src/theme_tokens.rs
@@ -3,9 +3,7 @@
 use std::cell::RefCell;
 
 use gpui::{App, Hsla, Pixels};
-use gpui_base::{
-    ColorTokens, RadiusTokens, SemanticThemeTokens, SpacingTokens, Theme, TypographyTokens,
-};
+use gpui_base::{ColorTokens, RadiusTokens, SemanticThemeTokens, SpacingTokens, Theme};
 
 use crate::scope::with_current_app;
 
@@ -41,27 +39,12 @@ fn with_tokens<R>(read: impl FnOnce(&SemanticThemeTokens) -> R) -> Option<R> {
     CACHED.with(|cached| cached.borrow().as_ref().map(read))
 }
 
+pub(crate) fn current() -> Option<SemanticThemeTokens> {
+    with_tokens(Clone::clone)
+}
+
 pub(crate) fn token_color(name: &str) -> Option<Hsla> {
     with_tokens(|tokens| resolve_color(&tokens.colors, name)).flatten()
-}
-
-pub(crate) fn token_spacing(name: &str) -> Option<Pixels> {
-    with_tokens(|tokens| resolve_spacing(&tokens.spacing, name)).flatten()
-}
-
-pub(crate) fn token_radius(name: &str) -> Option<Pixels> {
-    with_tokens(|tokens| resolve_radius(&tokens.radius, name)).flatten()
-}
-
-/// The whole type scale, rather than one entry by name.
-///
-/// The colour, spacing and radius lookups above answer one token at a time
-/// because a description names them one at a time -- `bg("surface")`. Nothing
-/// names a text style that way: the scale is read whole, to be reported back
-/// to a script, and six lookups that each clone two font families to return
-/// one of them would cost more than the copy this makes.
-pub(crate) fn typography_tokens() -> Option<TypographyTokens> {
-    with_tokens(|tokens| tokens.typography.clone())
 }
 
 pub(crate) const COLOR_TOKEN_NAMES: &[&str] = &[
@@ -98,7 +81,7 @@ pub(crate) fn radius_token_names() -> &'static [&'static str] {
     RADIUS_TOKEN_NAMES
 }
 
-fn resolve_color(colors: &ColorTokens, name: &str) -> Option<Hsla> {
+pub(crate) fn resolve_color(colors: &ColorTokens, name: &str) -> Option<Hsla> {
     Some(match name {
         "background" => colors.background,
         "foreground" => colors.foreground,
@@ -122,7 +105,7 @@ fn resolve_color(colors: &ColorTokens, name: &str) -> Option<Hsla> {
     })
 }
 
-fn resolve_spacing(spacing: &SpacingTokens, name: &str) -> Option<Pixels> {
+pub(crate) fn resolve_spacing(spacing: &SpacingTokens, name: &str) -> Option<Pixels> {
     Some(match name {
         "xxs" => spacing.xxs,
         "xs" => spacing.xs,
@@ -135,7 +118,7 @@ fn resolve_spacing(spacing: &SpacingTokens, name: &str) -> Option<Pixels> {
     })
 }
 
-fn resolve_radius(radius: &RadiusTokens, name: &str) -> Option<Pixels> {
+pub(crate) fn resolve_radius(radius: &RadiusTokens, name: &str) -> Option<Pixels> {
     Some(match name {
         "none" => radius.none,
         "sm" => radius.sm,

--- a/crates/shell/src/typings.rs
+++ b/crates/shell/src/typings.rs
@@ -1791,6 +1791,10 @@ const ELEMENT_METHODS: &str = r#"    /**
      * edge is a preference rather than a promise.
      */
     anchor(value: Anchor): Element;
+    /** Whether an fps_monitor requests continuous whole-window redraws. Default false. */
+    continuous(value: boolean): Element;
+    /** Frame budget, in milliseconds, used by an fps_monitor's FRAME grading. */
+    frame_budget(milliseconds: number): Element;
     /** Which pointer button opens a `Popover`. Default `left`. */
     mouse_button(value: MouseButton): Element;
     /**
@@ -3842,6 +3846,8 @@ mod tests {
         "default_open",
         "overlay_closable",
         "anchor",
+        "continuous",
+        "frame_budget",
         "mouse_button",
         "open_delay",
         "close_delay",

--- a/crates/shell/src/view.rs
+++ b/crates/shell/src/view.rs
@@ -1,13 +1,14 @@
 //! The single bridge between a script view and GPUI's render loop.
 //!
 //! Every script-defined view, panel, or dialog body is carried by a `ScriptView`
-//! entity. GPUI calls `render` whenever the view is notified — and it is
-//! notified for reasons the script never hears about, from a hover to a cursor
-//! blink to an animation frame. So `render` here is deliberately *not* a script
-//! call:
+//! entity. [`ShellRoot`](crate::root::ShellRoot) mounts the entity through
+//! GPUI's cached-view path, so a clean window frame reuses its rendered subtree
+//! without calling this `render` at all. When the entity or one of its retained
+//! descendants is dirty, `render` remains deliberately *not* necessarily a
+//! script call:
 //!
 //! ```text
-//! GPUI render ──▶ snapshot still valid? ──yes──▶ materialize   (no VM)
+//! dirty view render ─▶ snapshot still valid? ──yes──▶ materialize   (no VM)
 //!                          │
 //!                          no
 //!                          ▼
@@ -16,8 +17,10 @@
 //!
 //! The script runs only when something invalidated its snapshot: `cx.notify()`
 //! from an event or a task, a hot reload, or a palette change. Everything else
-//! replays the description the script already produced. That is what keeps
-//! script cost proportional to application activity rather than to frame rate.
+//! replays the description the script already produced. Clean frames skip both
+//! operations through GPUI's subtree cache. That is what keeps script and
+//! materialization cost proportional to application activity rather than frame
+//! rate.
 
 use std::rc::Rc;
 


### PR DESCRIPTION
## Summary

- Cache the shell's full-size application view with GPUI's entity-backed subtree cache, so clean frames reuse layout, prepaint, and paint output while dirty views still invalidate normally.
- Cache serialized `cx.theme()` snapshots until the semantic tokens or appearance change.
- Expose `continuous` and `frame_budget` through `fps_monitor()`, and make the shell monitor passive by default so the HUD does not create the whole-window redraw loop it measures.

## Performance

Measured locally in release mode with five runs of:

```sh
cargo test --release -p gpui-shell shell_root_reuses_a_clean_views_materialized_subtree -- --nocapture
```

| 64 clean frames, small Toggle tree | `main` | This PR |
| --- | ---: | ---: |
| Materializations | 64 | 0 |
| Materialization time, median | 225.46 µs | 0 |
| Total test loop, median | 1.318 ms | 0.764 ms |

That is a 42.0% reduction in total loop time in this small-tree harness. The absolute wall-clock values are not representative of Longbridge's full UI; the deterministic result is that all 64 clean-frame materializations are eliminated, while refreshing the script view invalidates and materializes exactly once.

The motivating [Longbridge investigation](https://github.com/longbridge/longbridge-lite/pull/11) reported about 1.21 ms per view materialization and estimated roughly 2.42 ms per frame across two shell views, so clean larger trees should benefit more. Those figures are from the linked investigation and were not reproduced by this benchmark.

The FPS regression test also changes the default monitor's scheduled next-frame callbacks from 2 to 0. Explicit `.continuous(true)` mode still schedules frames for sustained-frame diagnostics.

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gpui-fps -p gpui-shell -- --test-threads=2`
  - `gpui-fps`: 23 passed
  - `gpui-shell`: 685 passed, 1 ignored
  - component registry integration: 4 passed
  - shell doctests: 4 passed, 2 ignored
- `cargo test --release -p gpui-shell shell_root_reuses_a_clean_views_materialized_subtree -- --nocapture` (five runs on both `main` and this branch)
