### PR TITLE
shell: Keep theme reads on the JS fast path

### DIFF
--- a/crates/shell/src/engine/quickjs/mod.rs
+++ b/crates/shell/src/engine/quickjs/mod.rs
@@ -2887,6 +2887,10 @@ impl ShellRuntime {
         window: &mut Window,
         cx: &mut App,
     ) -> Result<RenderSnapshot> {
+        // One theme sync per description makes cx.theme() a JS-only cache read.
+        // The native snapshot crosses the boundary only when this revision
+        // changes, rather than once per component asking for the theme.
+        crate::theme_tokens::sync(cx);
         self.arena.borrow_mut().reset();
         let callbacks = self.callbacks.borrow_mut().begin();
 
@@ -4634,6 +4638,8 @@ impl ShellRuntime {
 
     fn call_render_once(&self, object: &ViewObject, generation: u64) -> Result<SpecId> {
         self.with_js(|ctx| {
+            let prepare_theme: Function = ctx.globals().get("__prepare_theme")?;
+            prepare_theme.call::<_, ()>(())?;
             let instance = object.value.clone().restore(ctx)?;
             let render: Function = instance.get("render").map_err(|_| {
                 Exception::throw_message(ctx, "view class has no render(cx) method")
@@ -6209,7 +6215,11 @@ globalThis.__gpui = (() => {
 
   let cachedThemeSource;
   let cachedTheme;
-  const currentTheme = () => {
+  let cachedThemeRevision = -1;
+  globalThis.__theme_dirty = true;
+  const refreshTheme = () => {
+    const revision = __theme_revision();
+    if (!globalThis.__theme_dirty && revision === cachedThemeRevision) return;
     const source = __theme_snapshot();
     if (source !== cachedThemeSource) {
       cachedThemeSource = source;
@@ -6219,6 +6229,12 @@ globalThis.__gpui = (() => {
       Object.freeze(cachedTheme.radius);
       Object.freeze(cachedTheme);
     }
+    cachedThemeRevision = revision;
+    globalThis.__theme_dirty = false;
+  };
+  globalThis.__prepare_theme = refreshTheme;
+  const currentTheme = () => {
+    if (globalThis.__theme_dirty || cachedTheme === undefined) refreshTheme();
     return cachedTheme;
   };
 

--- a/crates/shell/src/engine/quickjs/theme_api.rs
+++ b/crates/shell/src/engine/quickjs/theme_api.rs
@@ -91,6 +91,10 @@ struct TextStyleOverride {
 
 pub fn install(ctx: &Ctx<'_>, module: &Object<'_>) -> JsResult<()> {
     ctx.globals().set(
+        "__theme_revision",
+        Func::from(|| -> u32 { theme_tokens::revision() }),
+    )?;
+    ctx.globals().set(
         "__theme_snapshot",
         Func::from(|_: Ctx<'_>| -> JsResult<String> { Ok(snapshot_json().as_ref().clone()) }),
     )?;
@@ -138,14 +142,16 @@ fn set_theme<'js>(ctx: Ctx<'js>, value: Value<'js>) -> JsResult<()> {
         base.tokens = tokens;
         theme_tokens::sync(cx);
         cx.refresh_windows();
-        Ok(())
+        Ok::<(), rquickjs::Error>(())
     })
     .ok_or_else(|| {
         Exception::throw_type(
             &ctx,
             "set_theme(theme) needs a live host call; call it from an event handler",
         )
-    })?
+    })??;
+    ctx.globals().set("__theme_dirty", true)?;
+    Ok(())
 }
 
 fn apply_colors(
@@ -291,10 +297,8 @@ fn set_radius(t: &mut gpui_base::RadiusTokens, n: &str, v: f32) {
 }
 
 fn snapshot_json() -> Rc<String> {
-    let tokens = theme_tokens::current().unwrap_or_default();
-    let appearance =
-        crate::scope::with_current_app(|cx| Theme::global(cx).appearance).unwrap_or_default();
-    SNAPSHOT_CACHE.with(|cache| cache.borrow_mut().snapshot(&tokens, appearance))
+    let theme = theme_tokens::snapshot();
+    SNAPSHOT_CACHE.with(|cache| cache.borrow_mut().snapshot(&theme.tokens, theme.appearance))
 }
 
 fn build_snapshot_json(

--- a/crates/shell/src/tests/render.rs
+++ b/crates/shell/src/tests/render.rs
@@ -2358,6 +2358,66 @@ export default class Themed extends View {
 }
 
 #[gpui::test]
+fn repeated_theme_reads_cross_the_snapshot_boundary_once(cx: &mut TestAppContext) {
+    cx.update(crate::init);
+    let runtime = ShellRuntime::new_isolated().expect("runtime");
+    cx.update(|cx| runtime.set_global(cx));
+    let source = r#"
+import { View } from "gpui";
+
+let snapshotReads = 0;
+const readSnapshot = globalThis.__theme_snapshot;
+globalThis.__theme_snapshot = () => {
+  snapshotReads += 1;
+  return readSnapshot();
+};
+
+export default class Themed extends View {
+  render(cx) {
+    cx.theme();
+    cx.theme();
+    cx.theme();
+    return `${snapshotReads}:${cx.theme().appearance}`;
+  }
+}
+"#;
+    let view_type = runtime
+        .load_source("cached-context-theme.js", source)
+        .expect("load");
+    let window = cx.add_window(|_, _| Empty);
+    let mut context = VisualTestContext::from_window(*window.deref(), cx);
+    let object = context
+        .update(|window, cx| runtime.instantiate(&view_type, window, cx))
+        .expect("instantiate");
+
+    let first = context
+        .update(|window, cx| runtime.render_to_spec(&object, None, window, cx))
+        .expect("one render must transfer one theme snapshot");
+    assert!(
+        first.contains("text \"1:light\""),
+        "unexpected theme: {first}"
+    );
+    let unchanged = context
+        .update(|window, cx| runtime.render_to_spec(&object, None, window, cx))
+        .expect("an unchanged later render must reuse the transferred theme snapshot");
+    assert!(
+        unchanged.contains("text \"1:light\""),
+        "unchanged theme crossed the snapshot boundary again: {unchanged}"
+    );
+
+    context.update(|_, cx| {
+        gpui_base::Theme::global_mut(cx).appearance = gpui_base::ThemeAppearance::Dark;
+    });
+    let changed = context
+        .update(|window, cx| runtime.render_to_spec(&object, None, window, cx))
+        .expect("a changed appearance must refresh the transferred theme snapshot");
+    assert!(
+        changed.contains("text \"2:dark\""),
+        "changed theme did not cross the snapshot boundary exactly once: {changed}"
+    );
+}
+
+#[gpui::test]
 fn render_context_theme_snapshot_is_deeply_read_only(cx: &mut TestAppContext) {
     cx.update(crate::init);
     let runtime = ShellRuntime::new_isolated().expect("runtime");

--- a/crates/shell/src/tests/snapshot.rs
+++ b/crates/shell/src/tests/snapshot.rs
@@ -685,6 +685,25 @@ fn a_palette_change_rebuilds_the_snapshot(cx: &mut TestAppContext) {
     );
 }
 
+#[gpui::test]
+fn an_appearance_only_change_rebuilds_the_snapshot(cx: &mut TestAppContext) {
+    let (runtime, mut context, view) = script_view(cx, TOGGLE);
+
+    render_once(&mut context, &view);
+    assert_eq!(runtime.metrics().read().script_renders(), 1);
+
+    context.update(|_, cx| {
+        gpui_base::Theme::global_mut(cx).appearance = gpui_base::ThemeAppearance::Dark;
+    });
+    render_once(&mut context, &view);
+
+    assert_eq!(
+        runtime.metrics().read().script_renders(),
+        2,
+        "appearance is part of cx.theme(), so changing it must invalidate script views"
+    );
+}
+
 /// One GPUI frame containing this view.
 ///
 /// A real layout and paint pass rather than a direct call to `Render::render`:

--- a/crates/shell/src/theme_tokens.rs
+++ b/crates/shell/src/theme_tokens.rs
@@ -8,13 +8,37 @@ use gpui_base::{ColorTokens, RadiusTokens, SemanticThemeTokens, SpacingTokens, T
 use crate::scope::with_current_app;
 
 thread_local! {
-    static CACHED: RefCell<Option<SemanticThemeTokens>> = const { RefCell::new(None) };
+    static CACHED: RefCell<CachedTheme> = const { RefCell::new(CachedTheme {
+        key: None,
+        revision: 0,
+    }) };
 }
 
-pub(crate) fn sync(cx: &App) -> SemanticThemeTokens {
-    let tokens = Theme::global(cx).tokens;
-    CACHED.with(|cached| *cached.borrow_mut() = Some(tokens.clone()));
-    tokens
+#[derive(Clone, PartialEq)]
+pub(crate) struct ThemeSnapshotKey {
+    pub(crate) tokens: SemanticThemeTokens,
+    pub(crate) appearance: gpui_base::ThemeAppearance,
+}
+
+struct CachedTheme {
+    key: Option<ThemeSnapshotKey>,
+    revision: u32,
+}
+
+pub(crate) fn sync(cx: &App) -> ThemeSnapshotKey {
+    let theme = Theme::global(cx);
+    let key = ThemeSnapshotKey {
+        tokens: theme.tokens,
+        appearance: theme.appearance,
+    };
+    CACHED.with(|cached| {
+        let mut cached = cached.borrow_mut();
+        if cached.key.as_ref() != Some(&key) {
+            cached.key = Some(key.clone());
+            cached.revision = cached.revision.wrapping_add(1);
+        }
+    });
+    key
 }
 
 /// Lends the active palette to `read`, from the same two places in the same
@@ -36,11 +60,24 @@ fn with_tokens<R>(read: impl FnOnce(&SemanticThemeTokens) -> R) -> Option<R> {
     }
     // Materializing a description runs outside every call scope, so this is
     // the only palette that path can see.
-    CACHED.with(|cached| cached.borrow().as_ref().map(read))
+    CACHED.with(|cached| cached.borrow().key.as_ref().map(|key| read(&key.tokens)))
 }
 
-pub(crate) fn current() -> Option<SemanticThemeTokens> {
-    with_tokens(Clone::clone)
+pub(crate) fn snapshot() -> ThemeSnapshotKey {
+    CACHED.with(|cached| {
+        cached
+            .borrow()
+            .key
+            .clone()
+            .unwrap_or_else(|| ThemeSnapshotKey {
+                tokens: SemanticThemeTokens::default(),
+                appearance: gpui_base::ThemeAppearance::default(),
+            })
+    })
+}
+
+pub(crate) fn revision() -> u32 {
+    CACHED.with(|cached| cached.borrow().revision)
 }
 
 pub(crate) fn token_color(name: &str) -> Option<Hsla> {

--- a/crates/shell/src/view.rs
+++ b/crates/shell/src/view.rs
@@ -60,8 +60,8 @@ pub struct ScriptView {
     /// Set when the script-visible handle has been released. GPUI may retain
     /// the entity for an older frame, but it must never rebuild after release.
     retired: bool,
-    /// The palette the current snapshot resolved its colors against.
-    theme_tokens: Option<gpui_base::SemanticThemeTokens>,
+    /// The tokens and appearance the current snapshot resolved against.
+    theme: Option<crate::theme_tokens::ThemeSnapshotKey>,
     /// The failure of the most recent build, if it failed.
     ///
     /// Held rather than re-derived so a script that throws is not re-run on
@@ -124,7 +124,7 @@ impl ScriptView {
             dirty: true,
             retired: false,
             policy,
-            theme_tokens: None,
+            theme: None,
             error: None,
             ownership,
             runtime,
@@ -289,9 +289,9 @@ impl Render for ScriptView {
         if self.retired {
             return div().into_any_element();
         }
-        let tokens = crate::theme_tokens::sync(cx);
-        if self.theme_tokens.as_ref() != Some(&tokens) {
-            self.theme_tokens = Some(tokens);
+        let theme = crate::theme_tokens::sync(cx);
+        if self.theme.as_ref() != Some(&theme) {
+            self.theme = Some(theme);
             self.dirty = true;
         }
         if self.is_dirty() {

--- a/website/shell/performance.md
+++ b/website/shell/performance.md
@@ -152,7 +152,7 @@ The runtime counts the two events apart, and the host can read them with `runtim
 | Reading | The question it answers |
 | --- | --- |
 | `script_renders()` | How often JavaScript ran. Follows `cx.notify()`, reloads and theme changes — never frames |
-| `materializations()` | How often a Snapshot became elements. Follows frames |
+| `materializations()` | How often a dirty Snapshot became elements. Clean window frames reuse the cached GPUI subtree |
 | `mean_script_render()` | What one description costs, host calls included |
 | `mean_native()` | How much of that was inside HostModule functions rather than describing |
 | `slowest_script_render()` | The worst single build in the run |
@@ -165,6 +165,12 @@ What the shape of a reading says:
 - **`script_renders` reasonable, `mean_script_render` high** — the boundary is too large. Split the View.
 - **`mean_native` most of `mean_script_render`** — the cost is in the host functions the description calls, not in the description. Read them once into fields before `render`, not per node.
 - **`slowest_script_render` far above the mean** — one build is paying for something the rest are not: a collection materialized on first render, or a rarely-taken branch that describes far more than the common one. A mean that drifts as a whole is system load instead.
+
+Repeated `cx.theme()` calls do not repeatedly cross the native snapshot
+boundary. The runtime synchronizes a lightweight theme revision before a
+description starts; components then share one frozen JavaScript object until
+the semantic tokens or appearance change. Reading the theme in each component
+is therefore a cache lookup, not a reason to serialize the palette again.
 
 ## Where the Snapshot cache stops
 


### PR DESCRIPTION
## Summary

- synchronize a lightweight theme revision before each script description, then keep repeated `cx.theme()` reads entirely on the JavaScript fast path
- transfer and parse the serialized theme snapshot only when semantic tokens or appearance change
- treat appearance-only changes as ScriptView invalidations, and explicitly dirty the JS cache after `set_theme()`
- document the theme cache and correct the materialization counter description for cached clean frames

## Performance

The regression test wraps the native snapshot boundary and makes four `cx.theme()` calls per render:

| Scenario | Snapshot transfers |
| --- | ---: |
| First render | 1 |
| Unchanged later render | 0 |
| First render after appearance changes | 1 |

Before this PR, every `cx.theme()` call crossed the native boundary and cloned the complete serialized JSON snapshot, even though serialization itself was cached by #2908. A component-heavy render with roughly 70 theme reads therefore changes from roughly 70 full-string transfers to one lightweight revision read and, for an unchanged theme, zero snapshot transfers.

This follows up on the Render frequency story observation after #2908, where mean script describing time had already fallen from roughly 3 ms to 0.98 ms. That observation is directional rather than a controlled benchmark; this PR's automated performance contract is the exact boundary count above.

## Test Plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gpui-fps -p gpui-shell -- --test-threads=2`
  - `gpui-fps`: 23 passed
  - `gpui-shell`: 687 passed, 1 ignored
  - component registry integration: 4 passed
  - shell doctests: 4 passed, 2 ignored
- regression coverage verifies snapshot reuse across renders and exactly one refresh after an appearance-only change
