### PR TITLE
button: Surface the whole ghost DropdownButton when a half is hovered

### DIFF
--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -201,6 +201,7 @@ pub struct Button {
     border_corners: Corners<bool>,
     border_edges: Edges<bool>,
     dropdown_caret: bool,
+    hover_group: Option<SharedString>,
     size: Size,
     compact: bool,
     tooltip: Option<(
@@ -259,6 +260,7 @@ impl Button {
             outline: false,
             loading_icon: None,
             dropdown_caret: false,
+            hover_group: None,
             tab_index: 0,
             tab_stop: true,
         }
@@ -302,6 +304,14 @@ impl Button {
     /// Set the border edges of the Button.
     pub(crate) fn border_edges(mut self, edges: impl Into<Edges<bool>>) -> Self {
         self.border_edges = edges.into();
+        self
+    }
+
+    /// Join a hover group: while any member is hovered, an idle member shows
+    /// its hover surface at half strength, so a composite such as a split
+    /// button reads as one control with the hovered part emphasized.
+    pub(crate) fn hover_group(mut self, group: impl Into<SharedString>) -> Self {
+        self.hover_group = Some(group.into());
         self
     }
 
@@ -511,6 +521,7 @@ impl RenderOnce for Button {
         let hoverable = self.hoverable();
         let disabled = self.disabled;
         let loading = self.loading;
+        let hover_group = self.hover_group;
         let mut base = self.base;
         let children = self.children;
         let instance_style = base.style().clone();
@@ -618,6 +629,10 @@ impl RenderOnce for Button {
                             this.bg(active_style.bg)
                                 .border_color(active_style.border)
                                 .text_color(active_style.fg)
+                        })
+                        .when_some(hover_group, |this, group| {
+                            let hover_style = style.hovered(self.outline, cx);
+                            this.group_hover(group, |this| this.bg(hover_style.bg.opacity(0.5)))
                         })
                     })
             })
@@ -1174,7 +1189,9 @@ impl ButtonVariant {
             Self::Default => cx.theme().tokens.button_active.into(),
             Self::Primary => cx.theme().tokens.button_primary_active.into(),
             Self::Secondary => cx.theme().tokens.button_secondary_active.into(),
-            Self::Ghost => cx.theme().tokens.secondary_active.into(),
+            // Every other variant selects with its active surface; the ghost
+            // token sits too close to its hover to read as pressed.
+            Self::Ghost => self.active(outline, cx).bg,
             Self::Danger => cx.theme().tokens.button_danger_active.into(),
             Self::Warning => cx.theme().tokens.button_warning_active.into(),
             Self::Success => cx.theme().tokens.button_success_active.into(),

--- a/crates/ui/src/button/dropdown_button.rs
+++ b/crates/ui/src/button/dropdown_button.rs
@@ -11,11 +11,14 @@ use crate::{
 
 use super::{Button, ButtonVariant, ButtonVariants};
 
+/// Group name shared by both halves, so hovering one can style the other.
+const HALVES_GROUP: &str = "dropdown-button";
+
 /// A split button: an action button with an attached menu trigger.
 ///
-/// The two halves stay visually joined, except for a `ghost` button that is not
-/// selected — a toolbar reads better when an idle ghost pair looks like two
-/// separate buttons.
+/// The two halves stay visually joined. A `ghost` split is transparent at
+/// rest; hovering either half surfaces the whole control with the hovered half
+/// emphasized, so the pair reads as one control rather than two buttons.
 ///
 #[derive(IntoElement)]
 pub struct DropdownButton {
@@ -151,11 +154,13 @@ impl RenderOnce for DropdownButton {
         let variant = self.effective_variant();
         let size = self.effective_size();
         let selected = self.selected || self.button.as_ref().is_some_and(Selectable::is_selected);
+        // Only a ghost split has no surface at rest, so only it needs hovering
+        // one half to reveal the other.
         let is_ghost = variant.is_ghost();
-        let attached = !(is_ghost && !selected);
 
         div()
             .id(self.id)
+            .when(is_ghost, |this| this.group(HALVES_GROUP))
             .h_flex()
             .refine_style(&self.style)
             .when_some(self.button, |this, button| {
@@ -164,16 +169,17 @@ impl RenderOnce for DropdownButton {
                     button
                         .border_corners(Corners {
                             top_left: true,
-                            top_right: !attached,
+                            top_right: false,
                             bottom_left: true,
-                            bottom_right: !attached,
+                            bottom_right: false,
                         })
                         .border_edges(Edges::all(true))
                         .selected(selected)
                         .disabled(disabled)
                         .when(self.outline, |this| this.outline())
                         .with_size(size)
-                        .with_variant(variant),
+                        .with_variant(variant)
+                        .when(is_ghost, |this| this.hover_group(HALVES_GROUP)),
                 )
             })
             .when_some(self.menu, |this, menu| {
@@ -181,13 +187,13 @@ impl RenderOnce for DropdownButton {
                     Button::new("popup")
                         .dropdown_caret(true)
                         .border_corners(Corners {
-                            top_left: !attached,
+                            top_left: false,
                             top_right: true,
-                            bottom_left: !attached,
+                            bottom_left: false,
                             bottom_right: true,
                         })
                         .border_edges(Edges {
-                            left: !attached,
+                            left: false,
                             top: true,
                             right: true,
                             bottom: true,
@@ -197,6 +203,7 @@ impl RenderOnce for DropdownButton {
                         .when(self.outline, |this| this.outline())
                         .with_size(size)
                         .with_variant(variant)
+                        .when(is_ghost, |this| this.hover_group(HALVES_GROUP))
                         .dropdown_menu_with_anchor(self.anchor, menu),
                 )
             })


### PR DESCRIPTION
## Summary

- keep the two halves of a `DropdownButton` joined for every variant; an unselected ghost split no longer renders as two separate rounded buttons
- add a crate-private `Button::hover_group`: while any member of the group is hovered, an idle member shows its hover surface at half strength. A ghost split puts both halves in one group, so hovering either half surfaces the whole control with the hovered half emphasized, the way GitHub's split buttons read
- register the group hover inside `Button::render`, next to `hover` and `active`, so it yields to `selected`, `disabled` and loading. The caret keeps its pressed color while the menu is open, even with the pointer still over the control
- select a ghost button with its `active` surface instead of `tokens.secondary_active`, which sat too close to its hover to read as pressed; every other variant already selects with its active surface

### Before

https://github.com/user-attachments/assets/8483650e-3dcf-49de-9b41-218de885f0e5

### After

https://github.com/user-attachments/assets/8167a4a0-f688-45d5-b23f-9a748205e005

## Compatibility

Visual change without an API change. Selected ghost buttons get slightly darker in the light theme and stay about the same in the dark theme.

## Test Plan

- `cargo fmt --check`
- `cargo clippy -p gpui-component -- --deny warnings`
- `cargo test -p gpui-component --lib button::` — 37 passed
- `typos` on the touched files
- In the DropdownButton story, the ghost split under "Inherited styling": hover either half, open the menu from the caret, move the pointer over the menu and back over the action half, then dismiss
