### PR TITLE
button: Keep the ghost DropdownButton surfaced while its menu is open

### DIFF
--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -202,6 +202,7 @@ pub struct Button {
     border_edges: Edges<bool>,
     dropdown_caret: bool,
     hover_group: Option<SharedString>,
+    hover_group_held: bool,
     size: Size,
     compact: bool,
     tooltip: Option<(
@@ -261,6 +262,7 @@ impl Button {
             loading_icon: None,
             dropdown_caret: false,
             hover_group: None,
+            hover_group_held: false,
             tab_index: 0,
             tab_stop: true,
         }
@@ -312,6 +314,13 @@ impl Button {
     /// button reads as one control with the hovered part emphasized.
     pub(crate) fn hover_group(mut self, group: impl Into<SharedString>) -> Self {
         self.hover_group = Some(group.into());
+        self
+    }
+
+    /// Keep the hover group's idle surface up without a pointer, for as long as
+    /// the group is held engaged, such as while a sibling's menu is open.
+    pub(crate) fn hover_group_held(mut self, held: bool) -> Self {
+        self.hover_group_held = held;
         self
     }
 
@@ -522,6 +531,7 @@ impl RenderOnce for Button {
         let disabled = self.disabled;
         let loading = self.loading;
         let hover_group = self.hover_group;
+        let hover_group_held = self.hover_group_held;
         let mut base = self.base;
         let children = self.children;
         let instance_style = base.style().clone();
@@ -631,8 +641,9 @@ impl RenderOnce for Button {
                                 .text_color(active_style.fg)
                         })
                         .when_some(hover_group, |this, group| {
-                            let hover_style = style.hovered(self.outline, cx);
-                            this.group_hover(group, |this| this.bg(hover_style.bg.opacity(0.5)))
+                            let idle_bg = style.hovered(self.outline, cx).bg.opacity(0.5);
+                            this.when(hover_group_held, |this| this.bg(idle_bg))
+                                .group_hover(group, |this| this.bg(idle_bg))
                         })
                     })
             })

--- a/crates/ui/src/button/dropdown_button.rs
+++ b/crates/ui/src/button/dropdown_button.rs
@@ -18,7 +18,8 @@ const HALVES_GROUP: &str = "dropdown-button";
 ///
 /// The two halves stay visually joined. A `ghost` split is transparent at
 /// rest; hovering either half surfaces the whole control with the hovered half
-/// emphasized, so the pair reads as one control rather than two buttons.
+/// emphasized, and it stays surfaced while the menu is open, so the pair reads
+/// as one control rather than two buttons.
 ///
 #[derive(IntoElement)]
 pub struct DropdownButton {
@@ -145,7 +146,7 @@ impl Selectable for DropdownButton {
 }
 
 impl RenderOnce for DropdownButton {
-    fn render(self, _: &mut Window, _: &mut App) -> impl IntoElement {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         debug_assert!(
             self.button.is_some() || self.menu.is_some(),
             "a DropdownButton needs a `button`, a `dropdown_menu`, or both"
@@ -155,8 +156,11 @@ impl RenderOnce for DropdownButton {
         let size = self.effective_size();
         let selected = self.selected || self.button.as_ref().is_some_and(Selectable::is_selected);
         // Only a ghost split has no surface at rest, so only it needs hovering
-        // one half to reveal the other.
+        // one half to reveal the other, and the action half to stay revealed
+        // while the menu holds the trigger pressed.
         let is_ghost = variant.is_ghost();
+        let menu_open = window.use_keyed_state(self.id.clone(), cx, |_, _| false);
+        let is_menu_open = *menu_open.read(cx);
 
         div()
             .id(self.id)
@@ -179,7 +183,10 @@ impl RenderOnce for DropdownButton {
                         .when(self.outline, |this| this.outline())
                         .with_size(size)
                         .with_variant(variant)
-                        .when(is_ghost, |this| this.hover_group(HALVES_GROUP)),
+                        .when(is_ghost, |this| {
+                            this.hover_group(HALVES_GROUP)
+                                .hover_group_held(is_menu_open)
+                        }),
                 )
             })
             .when_some(self.menu, |this, menu| {
@@ -204,7 +211,13 @@ impl RenderOnce for DropdownButton {
                         .with_size(size)
                         .with_variant(variant)
                         .when(is_ghost, |this| this.hover_group(HALVES_GROUP))
-                        .dropdown_menu_with_anchor(self.anchor, menu),
+                        .dropdown_menu_with_anchor(self.anchor, menu)
+                        .on_open_change(move |open, _, cx| {
+                            menu_open.update(cx, |state, cx| {
+                                *state = *open;
+                                cx.notify();
+                            })
+                        }),
                 )
             })
     }

--- a/crates/ui/src/menu/dropdown_menu.rs
+++ b/crates/ui/src/menu/dropdown_menu.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 
 use gpui::{
-    Anchor, Context, DismissEvent, ElementId, Entity, Focusable, InteractiveElement, IntoElement,
-    RenderOnce, SharedString, StyleRefinement, Styled, Window,
+    Anchor, App, Context, DismissEvent, ElementId, Entity, Focusable, InteractiveElement,
+    IntoElement, RenderOnce, SharedString, StyleRefinement, Styled, Window, prelude::FluentBuilder,
 };
 
 use crate::{Selectable, button::Button, menu::PopupMenu, popover::Popover};
@@ -39,6 +39,7 @@ pub struct DropdownMenuPopover<T: Selectable + IntoElement + 'static> {
     anchor: Anchor,
     trigger: T,
     builder: Rc<dyn Fn(PopupMenu, &mut Window, &mut Context<PopupMenu>) -> PopupMenu>,
+    on_open_change: Option<Rc<dyn Fn(&bool, &mut Window, &mut App)>>,
 }
 
 impl<T> DropdownMenuPopover<T>
@@ -57,6 +58,7 @@ where
             anchor: anchor.into(),
             trigger,
             builder: Rc::new(builder),
+            on_open_change: None,
         }
     }
 
@@ -71,6 +73,17 @@ where
         self.style = style;
         self
     }
+
+    /// Add a callback to be called when the menu opens or closes.
+    ///
+    /// The `&bool` parameter is the **new open state**.
+    pub fn on_open_change(
+        mut self,
+        callback: impl Fn(&bool, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_open_change = Some(Rc::new(callback));
+        self
+    }
 }
 
 #[derive(Default)]
@@ -82,7 +95,7 @@ impl<T> RenderOnce for DropdownMenuPopover<T>
 where
     T: Selectable + IntoElement + 'static,
 {
-    fn render(self, window: &mut Window, cx: &mut gpui::App) -> impl IntoElement {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let builder = self.builder.clone();
         let menu_state =
             window.use_keyed_state(self.id.clone(), cx, |_, _| DropdownMenuState::default());
@@ -93,6 +106,9 @@ where
             .trigger(self.trigger)
             .trigger_style(self.style)
             .anchor(self.anchor)
+            .when_some(self.on_open_change, |this, callback| {
+                this.on_open_change(move |open, window, cx| callback(open, window, cx))
+            })
             .content(move |_, window, cx| {
                 // Here is special logic to only create the PopupMenu once and reuse it.
                 // Because this `content` will called in every time render, so we need to store the menu


### PR DESCRIPTION
## Summary

- keep a ghost `DropdownButton` surfaced for as long as its menu is open: the caret already holds its pressed color through `selected`, and the action half now keeps the idle surface it shows while the group is hovered, so the whole control reads engaged instead of only the caret. Follows up on #2911
- add `Button::hover_group_held` (crate-private) to hold a hover group's idle surface without a pointer; hover and active still layer over it
- expose `DropdownMenuPopover::on_open_change`, mirroring `Popover`, so a composite trigger can follow the menu's open state. `DropdownButton` records it in keyed state and passes it to the action half

## Compatibility

Additive: `DropdownMenuPopover::on_open_change` is new and optional. No existing API changes. The visual change is limited to a ghost `DropdownButton` while its menu is open.

## Test Plan

- `cargo fmt --check`
- `cargo clippy -p gpui-component -- --deny warnings`
- `cargo test -p gpui-component --lib button::` — 37 passed
- `cargo test -p gpui-component --lib menu::` — 11 passed
- `typos` on the touched files
- In the DropdownButton story, open the menu from the ghost split's caret and move the pointer onto the menu: the action half keeps its light surface and the caret stays pressed until the menu closes
