### PR TITLE
settings: Better alignment between label and field

### DIFF
--- a/crates/ui/src/setting/item.rs
+++ b/crates/ui/src/setting/item.rs
@@ -275,7 +275,7 @@ impl SettingItem {
                         .when(disabled, |this| this.opacity(0.5))
                         .map(|this| {
                             if layout.is_horizontal() {
-                                this.h_flex().justify_between().items_start()
+                                this.h_flex().justify_between().items_center()
                             } else {
                                 this.v_flex()
                             }
@@ -290,7 +290,6 @@ impl SettingItem {
                                         this.w_full()
                                     }
                                 })
-                                .gap_1()
                                 .child(Label::new(title).text_sm())
                                 .when_some(description, |this, description| {
                                     this.child(


### PR DESCRIPTION
## Description

Previously, the settings label and settings field did not align well.
This PR makes the field line up with the label

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6341203a-c65b-47aa-8e47-ce14d7830434" /> | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8ead7b0b-9ad3-408d-b3b9-d155150c24d0" /> |

## How to Test

Open settings page in story

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
