### PR TITLE
fps: Grade a window that draws on demand by frame cost, not rate

### DIFF
--- a/crates/fps/src/monitor.rs
+++ b/crates/fps/src/monitor.rs
@@ -180,7 +180,10 @@ impl FpsMonitor {
     /// frame rate the application *can* sustain, not the rate it happens to be
     /// drawing at. Turn it off to measure the real workload — the HUD then only
     /// updates when the window redraws for its own reasons, and reads zero
-    /// while the window is idle.
+    /// while the window is idle. A low rate is then not a finding, so the
+    /// headline is graded by what a frame cost rather than by how many there
+    /// were, and an overrun counts as a dropped frame only when another redraw
+    /// was already waiting on it.
     pub fn continuous(mut self, continuous: bool) -> Self {
         self.continuous = continuous;
         self
@@ -280,7 +283,12 @@ impl FpsMonitor {
             // at this cadence would be an arbitrary sample.
             frame_millis: self.sampler.mean_draw().as_secs_f32() * 1000.,
             percentile_millis: self.sampler.percentile_draw(FRAME_PERCENTILE).as_secs_f32() * 1000.,
-            dropped_percent: self.sampler.over_budget_ratio(self.frame_budget) * 100.,
+            // Drawing on demand, an overrun drops a frame only if another
+            // redraw was already waiting on it; see `dropped_ratio`.
+            dropped_percent: self
+                .sampler
+                .dropped_ratio(self.frame_budget, !self.continuous)
+                * 100.,
             invalidations: self.sampler.mean_invalidations(),
         };
         self.readout_at = Some(now);
@@ -433,7 +441,19 @@ impl Render for FpsMonitor {
             dropped_percent: dropped,
             invalidations,
         } = self.readout;
-        let fps_color = fps_color(fps, budget, style);
+        // Continuous, the rate is the rate the window can sustain, and falling
+        // short of the target is the finding. Passive, it is only how often
+        // the application had a reason to draw: a window that redraws six
+        // times a second because six things changed is idle, not slow, and a
+        // red headline over it reports a problem that is not there. So the
+        // headline takes its colour from what those frames cost instead --
+        // the same grade as the FRAME row, which is the reading that says
+        // whether a redraw stutters.
+        let fps_color = if self.continuous {
+            fps_color(fps, budget, style)
+        } else {
+            passive_fps_color(fps, frame_millis, budget, style)
+        };
         let resources = self.resources.filter(|_| self.show_resources);
         let compact = self.compact;
 
@@ -478,10 +498,10 @@ impl Render for FpsMonitor {
                             "FRAME",
                             format!("{frame_millis:.1} ms"),
                             // Graded against the budget, not against the frame
-                            // rate. An idle window draws a handful of frames a
-                            // second, so the headline goes red while every one
-                            // of those frames was in fact drawn well inside the
-                            // budget; this row is what says so.
+                            // rate: an idle window draws a handful of frames a
+                            // second, every one of them well inside the budget,
+                            // and this row is what says so. Drawing on demand,
+                            // the headline follows this grade too.
                             style.level_color(frame_millis / 1000., budget.as_secs_f32()),
                             style,
                         ))
@@ -583,6 +603,18 @@ fn fps_color(fps: f32, budget: Duration, style: FpsStyle) -> Hsla {
     } else {
         style.bad
     }
+}
+
+/// Grades the headline of a window that draws only when asked.
+///
+/// The rate says nothing about health there — it is the number of things
+/// that changed — so the colour is the FRAME row's: what a frame cost against
+/// the budget. Zero frames is still the idle grey.
+fn passive_fps_color(fps: f32, frame_millis: f32, budget: Duration, style: FpsStyle) -> Hsla {
+    if fps <= 0. {
+        return style.muted;
+    }
+    style.level_color(frame_millis / 1000., budget.as_secs_f32())
 }
 
 /// A row carrying two [`pair`]s, pushed to either inner edge.
@@ -691,6 +723,19 @@ mod tests {
         assert_eq!(fps_color(45., budget, style), style.warn);
         assert_eq!(fps_color(20., budget, style), style.bad);
         assert_eq!(fps_color(0., budget, style), style.muted);
+    }
+
+    #[test]
+    fn a_window_drawing_on_demand_is_graded_by_frame_cost_not_rate() {
+        let style = FpsStyle::dark();
+        let budget = DEFAULT_FRAME_BUDGET;
+
+        // Six cheap frames a second is an idle window, not a slow one.
+        assert_eq!(passive_fps_color(6., 4., budget, style), style.good);
+        // The same six frames, each over budget, is what a stutter looks like.
+        assert_eq!(passive_fps_color(6., 24., budget, style), style.warn);
+        assert_eq!(passive_fps_color(6., 40., budget, style), style.bad);
+        assert_eq!(passive_fps_color(0., 0., budget, style), style.muted);
     }
 
     #[test]

--- a/crates/fps/src/sampler.rs
+++ b/crates/fps/src/sampler.rs
@@ -96,17 +96,27 @@ impl FrameSampler {
         self.capacity
     }
 
-    /// Share of the retained frames that overran `budget`, in `0..1`.
-    pub(crate) fn over_budget_ratio(&self, budget: Duration) -> f32 {
+    /// Share of the retained frames that dropped one, in `0..1`.
+    ///
+    /// A frame is dropped when it overran `budget` *and something was waiting
+    /// on it*. Drawing back to back, that is every overrun: the next vsync was
+    /// missed. Drawing only when asked, an overrun with nothing queued behind
+    /// it missed nothing — the window redrew because one thing changed, took
+    /// its time, and went back to idle — so with `contended_only` an overrun
+    /// counts only when at least one more redraw had already been coalesced
+    /// into it. The cost of such a frame still shows in the draw times; what
+    /// this reading says is whether anything was thrown away.
+    pub(crate) fn dropped_ratio(&self, budget: Duration, contended_only: bool) -> f32 {
         if self.samples.is_empty() {
             return 0.;
         }
-        let over = self
+        let dropped = self
             .samples
             .iter()
             .filter(|sample| sample.draw > budget)
+            .filter(|sample| !contended_only || sample.invalidations > 1)
             .count();
-        over as f32 / self.samples.len() as f32
+        dropped as f32 / self.samples.len() as f32
     }
 
     /// Mean draw time across the retained frames.
@@ -415,6 +425,31 @@ mod tests {
             sampler.ingest(vec![timing(window_id, Duration::from_millis(*millis))], now);
         }
         sampler
+    }
+
+    #[test]
+    fn an_overrun_with_nothing_waiting_drops_nothing_on_an_idle_window() {
+        let window_id = WindowId::from(1);
+        let mut sampler = FrameSampler::new(window_id, 8);
+        let now = Instant::now();
+        let budget = Duration::from_millis(16);
+
+        sampler.ingest(
+            vec![
+                timing(window_id, Duration::from_millis(8)),
+                // Slow, but the only thing the window had to do.
+                timing(window_id, Duration::from_millis(24)),
+                // Slow, and two more redraws were already queued behind it.
+                coalesced(window_id, Duration::from_millis(24), 3),
+                timing(window_id, Duration::from_millis(9)),
+            ],
+            now,
+        );
+
+        // Back to back, every overrun missed a vsync.
+        assert_eq!(sampler.dropped_ratio(budget, false), 0.5);
+        // Drawing on demand, only the contended one cost a frame.
+        assert_eq!(sampler.dropped_ratio(budget, true), 0.25);
     }
 
     #[test]

--- a/crates/shell/src/engine/quickjs/mod.rs
+++ b/crates/shell/src/engine/quickjs/mod.rs
@@ -3404,8 +3404,47 @@ impl ShellRuntime {
         window: &mut Window,
         cx: &mut App,
     ) {
+        self.dispatch_item(id, "item click", window, cx, |_, handler, context| {
+            handler.call::<_, ()>((key, context))
+        });
+    }
+
+    /// Delivers a secondary press on a virtual list row: the row's key, then
+    /// the press exactly as `on_mouse_down` would report it, with
+    /// `local_position` measured from the row's own box.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn dispatch_item_mouse_button(
+        self: &Rc<Self>,
+        id: CallbackId,
+        key: &str,
+        button: gpui::MouseButton,
+        position: gpui::Point<gpui::Pixels>,
+        click_count: usize,
+        modifiers: gpui::Modifiers,
+        bounds: Option<gpui::Bounds<gpui::Pixels>>,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        self.dispatch_item(id, "item press", window, cx, |ctx, handler, context| {
+            let event =
+                mouse_button_payload(ctx, button, position, click_count, modifiers, bounds)?;
+            handler.call::<_, ()>((key, event, context))
+        });
+    }
+
+    /// The lifetime checks, scope entry and job drain every row-level dispatch
+    /// shares. The call itself is the caller's, because the two row events
+    /// hand the handler different argument lists.
+    fn dispatch_item(
+        self: &Rc<Self>,
+        id: CallbackId,
+        what: &str,
+        window: &mut Window,
+        cx: &mut App,
+        call: impl for<'js> FnOnce(&Ctx<'js>, Function<'js>, Object<'js>) -> JsResult<()>,
+    ) {
         let Some(entry) = self.callbacks.borrow().get(id) else {
-            tracing::debug!("item callback {id} belongs to a superseded render pass");
+            tracing::debug!("{what} callback {id} belongs to a superseded render pass");
             return;
         };
 
@@ -3414,12 +3453,12 @@ impl ShellRuntime {
             .as_ref()
             .is_some_and(|application| !application.is_active())
         {
-            tracing::debug!("item callback {id} belongs to a retired application");
+            tracing::debug!("{what} callback {id} belongs to a retired application");
             return;
         }
 
         let Some(view) = entry.live_view() else {
-            tracing::debug!("item callback {id} owner has been released");
+            tracing::debug!("{what} callback {id} owner has been released");
             return;
         };
         let policy = view
@@ -3438,11 +3477,12 @@ impl ShellRuntime {
 
         let result = self.with_js(|ctx| {
             let handler = entry.value.clone().restore(ctx)?;
-            handler.call::<_, ()>((key, context_object(ctx, ContextBinding::Call(generation))?))
+            let context = context_object(ctx, ContextBinding::Call(generation))?;
+            call(ctx, handler, context)
         });
 
         if let Err(error) = result {
-            tracing::error!("error in item click handler: {error}");
+            tracing::error!("error in {what} handler: {error}");
         }
         scheduler::drain_runtime_jobs(self, window, cx);
     }
@@ -3895,19 +3935,7 @@ impl ShellRuntime {
         cx: &mut App,
     ) {
         self.dispatch_simple_event(id, "mouse button", window, cx, move |ctx| {
-            let payload = Object::new(ctx.clone())?;
-            payload.set(
-                "button",
-                match button {
-                    gpui::MouseButton::Right => "right",
-                    gpui::MouseButton::Middle => "middle",
-                    _ => "left",
-                },
-            )?;
-            payload.set("click_count", click_count as u32)?;
-            set_pointer_geometry(ctx, &payload, position, bounds)?;
-            payload.set("modifiers", modifiers_object(ctx, modifiers)?)?;
-            Ok(payload)
+            mouse_button_payload(ctx, button, position, click_count, modifiers, bounds)
         });
     }
 
@@ -6682,6 +6710,7 @@ impl ShellRuntime {
                 "aria_level",
                 "keep_mounted",
                 "on_item_click",
+                "on_item_secondary_click",
                 "on_change",
                 "on_open_change",
                 "on_confirm",
@@ -7626,6 +7655,7 @@ impl ShellRuntime {
             | "on_dismiss"
             | "on_step"
             | "on_item_click"
+            | "on_item_secondary_click"
             | "on_mouse_move"
             | "on_hover"
             | "on_key_down"
@@ -7656,8 +7686,10 @@ impl ShellRuntime {
                             "`{method}` cannot be registered from a virtual list's item \
                              renderer: the rows are rebuilt every frame, so a handler \
                              registered there would pile up for as long as the view stood. \
-                             Use `on_item_click((key, cx) => ...)` on the list itself, and \
-                             read the row out of your own data with the stable key it gives you"
+                             Use `on_item_click((key, cx) => ...)` or \
+                             `on_item_secondary_click((key, event, cx) => ...)` on the list \
+                             itself, and read the row out of your own data with the stable key \
+                             it gives you"
                         ),
                     ));
                 }
@@ -8956,6 +8988,32 @@ fn modifiers_object<'js>(ctx: &Ctx<'js>, modifiers: gpui::Modifiers) -> JsResult
 /// that has not been prepainted yet, so a script reading `undefined` knows the
 /// geometry was unavailable instead of being told the press landed at its
 /// top-left corner.
+/// The object an `on_mouse_down` or `on_mouse_up` handler is handed, built in
+/// one place so a press reported through a row carries the same fields as one
+/// reported through the element it landed on.
+fn mouse_button_payload<'js>(
+    ctx: &Ctx<'js>,
+    button: gpui::MouseButton,
+    position: gpui::Point<gpui::Pixels>,
+    click_count: usize,
+    modifiers: gpui::Modifiers,
+    bounds: Option<gpui::Bounds<gpui::Pixels>>,
+) -> JsResult<Object<'js>> {
+    let payload = Object::new(ctx.clone())?;
+    payload.set(
+        "button",
+        match button {
+            gpui::MouseButton::Right => "right",
+            gpui::MouseButton::Middle => "middle",
+            _ => "left",
+        },
+    )?;
+    payload.set("click_count", click_count as u32)?;
+    set_pointer_geometry(ctx, &payload, position, bounds)?;
+    payload.set("modifiers", modifiers_object(ctx, modifiers)?)?;
+    Ok(payload)
+}
+
 fn set_pointer_geometry<'js>(
     ctx: &Ctx<'js>,
     payload: &Object<'js>,
@@ -9440,6 +9498,7 @@ fn callback_op_name(method: &str) -> Option<&'static str> {
         "on_mouse_down_out" => "on_mouse_down_out",
         "on_scroll_wheel" => "on_scroll_wheel",
         "on_item_click" => "on_item_click",
+        "on_item_secondary_click" => "on_item_secondary_click",
         "on_resize" => "on_resize",
         "tab_bar" => "tab_bar",
         "empty_group" => "empty_group",

--- a/crates/shell/src/materialize.rs
+++ b/crates/shell/src/materialize.rs
@@ -426,6 +426,10 @@ struct Behavior {
     /// deliberate limit rather than a convenience: see
     /// [`components::virtual_list`].
     on_item_click: Option<CallbackId>,
+    /// Reports a secondary press on a virtual list row, with the row's key and
+    /// the press itself. Registered on the list for the same reason
+    /// `on_item_click` is.
+    on_item_secondary_click: Option<CallbackId>,
     /// Which item a `VirtualList` measures to infer its cross-axis size.
     /// `None` keeps base's own default, which is the first.
     item_to_measure_index: Option<usize>,
@@ -2456,6 +2460,7 @@ pub(in crate::materialize) fn resolve_ops(
                 "on_confirm" => behavior.on_confirm = Some(*id),
                 "on_dismiss" => behavior.on_dismiss = Some(*id),
                 "on_item_click" => behavior.on_item_click = Some(*id),
+                "on_item_secondary_click" => behavior.on_item_secondary_click = Some(*id),
                 "tab_bar" => behavior.dock_chrome.tab_bar = Some(*id),
                 "empty_group" => behavior.dock_chrome.empty_group = Some(*id),
                 "drop_indicator" => behavior.dock_chrome.drop_indicator = Some(*id),

--- a/crates/shell/src/materialize/components/virtual_list.rs
+++ b/crates/shell/src/materialize/components/virtual_list.rs
@@ -54,14 +54,15 @@
 //! [`Scrollbar`]: gpui_base::Scrollbar
 
 use std::{
+    cell::Cell,
     ops::Range,
     rc::{Rc, Weak},
 };
 
 use gpui::{
-    AnyElement, App, Axis, Context, ElementId, Empty, InteractiveElement as _, IntoElement,
-    ParentElement as _, Refineable as _, Render, SharedString, StatefulInteractiveElement as _,
-    StyleRefinement, Styled as _, Window, div,
+    AnyElement, App, Axis, Bounds, Context, ElementId, Empty, InteractiveElement as _, IntoElement,
+    MouseButton, ParentElement as _, Pixels, Refineable as _, Render, SharedString,
+    StatefulInteractiveElement as _, StyleRefinement, Styled as _, Window, canvas, div,
 };
 use gpui_base::{VirtualListScrollHandle, h_virtual_list, v_virtual_list};
 
@@ -136,20 +137,15 @@ pub(in crate::materialize) fn virtual_list(
     let weak = Rc::downgrade(runtime);
     let get_key = spec.get_key();
     let render_items = spec.render_items();
-    let on_item_click = behavior.on_item_click;
+    let handlers = ItemHandlers {
+        click: behavior.on_item_click,
+        secondary_click: behavior.on_item_secondary_click,
+    };
     let describe = move |_: &mut VirtualItems,
                          range: Range<usize>,
                          window: &mut Window,
                          cx: &mut Context<VirtualItems>| {
-        render_range(
-            &weak,
-            get_key,
-            render_items,
-            on_item_click,
-            range,
-            window,
-            cx,
-        )
+        render_range(&weak, get_key, render_items, handlers, range, window, cx)
     };
 
     let sizes = spec.sizes().clone();
@@ -220,7 +216,7 @@ fn render_range(
     runtime: &Weak<ShellRuntime>,
     get_key: CallbackId,
     render_items: CallbackId,
-    on_item_click: Option<CallbackId>,
+    handlers: ItemHandlers,
     range: Range<usize>,
     window: &mut Window,
     cx: &mut App,
@@ -256,19 +252,37 @@ fn render_range(
             .zip(described.keys())
             .map(|(root, key)| {
                 let item = materialize_subtree(&runtime, described.arena(), *root, window, cx);
-                match on_item_click {
-                    Some(callback) => clickable(item, key.clone(), callback, &runtime),
-                    None => item,
+                if handlers.is_empty() {
+                    item
+                } else {
+                    clickable(item, key.clone(), handlers, &runtime)
                 }
             })
             .collect()
     })
 }
 
+/// The list-level handlers a row reports through. Both are optional, and a
+/// list that asked for neither gets its rows exactly as the renderer built
+/// them.
+#[derive(Clone, Copy, Default)]
+struct ItemHandlers {
+    /// `on_item_click`: the key, on a click.
+    click: Option<CallbackId>,
+    /// `on_item_secondary_click`: the key and the press, on a right press.
+    secondary_click: Option<CallbackId>,
+}
+
+impl ItemHandlers {
+    fn is_empty(self) -> bool {
+        self.click.is_none() && self.secondary_click.is_none()
+    }
+}
+
 /// Wraps one row in the hit box that reports its stable domain key.
 ///
-/// Only when the script asked for it: a list with no `on_item_click` gets its
-/// rows exactly as the renderer built them.
+/// Only when the script asked for it: a list with no row handler gets its rows
+/// exactly as the renderer built them.
 ///
 /// The key also becomes the row's element identity; index remains only the
 /// current coordinate used to ask the renderer for a window.
@@ -279,23 +293,67 @@ fn render_range(
 /// *measure* an item, a percentage has no parent size to resolve against and
 /// falls back to the content, so the wrapper cannot inflate the size the list
 /// infers for its cross axis.
+///
+/// A secondary press is reported with the row's own box, the way a press on
+/// any other element is reported with that element's, so `local_position`
+/// means the same thing in both handlers.
 fn clickable(
     item: AnyElement,
     key: String,
-    callback: CallbackId,
+    handlers: ItemHandlers,
     runtime: &Rc<ShellRuntime>,
 ) -> AnyElement {
-    let runtime = Rc::downgrade(runtime);
-    div()
+    let mut row = div()
         .id(ElementId::Name(SharedString::from(format!(
             "gpui-shell-virtual-item:{key}"
         ))))
-        .size_full()
-        .child(item)
-        .on_click(move |_, window, cx| {
+        .size_full();
+    if let Some(callback) = handlers.secondary_click {
+        let runtime = Rc::downgrade(runtime);
+        let key = key.clone();
+        let bounds = Rc::new(Cell::new(None::<Bounds<Pixels>>));
+        let writer = Rc::clone(&bounds);
+        row = row
+            // Captured at paint rather than prepaint, and attached before the
+            // row's content. Paint runs once, for the box that is actually on
+            // screen, where a prepaint capture also sees the passes that only
+            // measure. And an absolute child with no inset sits at its static
+            // position -- where it would have been in flow -- so placed after
+            // the content it would land one row down, and report a press ten
+            // pixels into a row as thirty pixels above it.
+            .child(
+                canvas(
+                    |_, _, _| (),
+                    move |bounds, _, _, _| writer.set(Some(bounds)),
+                )
+                .absolute()
+                .size_full(),
+            )
+            .on_mouse_down(MouseButton::Right, move |event, window, cx| {
+                if let Some(runtime) = runtime.upgrade() {
+                    runtime.dispatch_item_mouse_button(
+                        callback,
+                        &key,
+                        event.button,
+                        event.position,
+                        event.click_count,
+                        event.modifiers,
+                        bounds.get(),
+                        window,
+                        cx,
+                    );
+                }
+            });
+    }
+    row = row.child(item);
+    if let Some(callback) = handlers.click {
+        let runtime = Rc::downgrade(runtime);
+        let key = key.clone();
+        row = row.on_click(move |_, window, cx| {
             if let Some(runtime) = runtime.upgrade() {
                 runtime.dispatch_item_key(callback, &key, window, cx);
             }
-        })
-        .into_any_element()
+        });
+    }
+    row.into_any_element()
 }

--- a/crates/shell/src/tests/render.rs
+++ b/crates/shell/src/tests/render.rs
@@ -9635,6 +9635,98 @@ export default class Rows extends View {{
     )
 }
 
+#[gpui::test]
+fn a_secondary_press_on_a_row_reports_its_key_and_the_press(cx: &mut TestAppContext) {
+    cx.update(crate::init);
+    let runtime = ShellRuntime::new_isolated().expect("runtime");
+    cx.update(|cx| runtime.set_global(cx));
+    let source = r#"
+import { View, div } from "gpui";
+import { v_flex, v_virtual_list } from "gpui-base";
+
+export default class Rows extends View {
+  init() {
+    this.items = ["alpha", "beta", "gamma"];
+    this.pressed = "none";
+    this.clicked = "none";
+  }
+  render(cx) {
+    return v_flex()
+      .w(300)
+      .h(200)
+      .child(
+        v_virtual_list(
+          "rows",
+          this.items.length,
+          40,
+          (index) => this.items[index],
+          (range) => {
+            const rows = [];
+            for (let index = range.start; index < range.end; index++) {
+              rows.push(div().h(40).child(this.items[index]));
+            }
+            return rows;
+          },
+        )
+          .on_item_click((key, cx) => {
+            this.clicked = key;
+            cx.notify();
+          })
+          .on_item_secondary_click((key, event, cx) => {
+            this.pressed = `${key} ${event.button} at ${Math.round(event.local_position.y)} of ${Math.round(event.bounds.height)}`;
+            cx.notify();
+          }),
+      )
+      .child(`pressed ${this.pressed} clicked ${this.clicked}`);
+  }
+}
+"#;
+    let view_type = runtime
+        .load_source("pressed-list.js", source)
+        .expect("load");
+    let runtime_for_view = Rc::clone(&runtime);
+    let window = cx.add_window(move |window, cx| {
+        let view = runtime_for_view
+            .instantiate_view(&view_type, window, cx)
+            .expect("instantiate");
+        RootedScriptView(view)
+    });
+    let mut context = VisualTestContext::from_window(*window.deref(), cx);
+    context.update(|window, cx| window.draw(cx).clear(cx));
+    context.update(|window, cx| window.draw(cx).clear(cx));
+    let view = window
+        .root(&mut context)
+        .expect("view")
+        .read_with(&context, |root, _| root.0.clone());
+
+    // The second row spans 40..80; press ten pixels into it.
+    context.simulate_mouse_move(
+        point(px(150.), px(50.)),
+        gpui::MouseButton::Right,
+        Modifiers::default(),
+    );
+    context.simulate_mouse_down(
+        point(px(150.), px(50.)),
+        gpui::MouseButton::Right,
+        Modifiers::default(),
+    );
+    context.run_until_parked();
+    context.update(|window, cx| window.draw(cx).clear(cx));
+
+    let tree = context.update(|_, cx| {
+        view.read(cx)
+            .snapshot()
+            .map(crate::RenderSnapshot::debug_tree)
+            .unwrap_or_default()
+    });
+    // The key names the row, the press is measured from that row's own box,
+    // and a right press is not a click.
+    assert!(
+        tree.contains("pressed beta right at 10 of 40 clicked none"),
+        "a right press must reach the list's secondary handler with the row it landed on:\n{tree}"
+    );
+}
+
 /// Rebuilds the description so that what the item renderer recorded during the
 /// last layout shows up in the tree.
 ///

--- a/crates/shell/src/typings.rs
+++ b/crates/shell/src/typings.rs
@@ -1483,6 +1483,27 @@ const ELEMENT_METHODS: &str = r#"    /**
      */
     on_item_click(handler: (key: string, cx: Context) => void): Element;
     /**
+     * `handler(key, event, cx)` on a secondary press — the right button — over
+     * a row of a virtual list. `key` is what the list's `get_key(index)`
+     * returned for that row, and `event` is the press as `on_mouse_down`
+     * reports it: `position` in the window, `local_position` and `bounds`
+     * against the row's own box.
+     *
+     * A press rather than a click, because that is when a context menu opens:
+     * the row is still under the pointer, so the menu can name what it is for
+     * before it is drawn over it. And one handler for the list rather than one
+     * per row, for the reason `on_item_click` gives.
+     *
+     * It is delivered on the row, so a handler for the same button on an
+     * element around the list still fires after it, in the ordinary bubble
+     * order, with that element's own `local_position`. A menu drawn inside a
+     * pane learns which row was pressed from this handler and where in the
+     * pane to open from the pane's.
+     */
+    on_item_secondary_click(
+      handler: (key: string, event: MouseButtonEvent, cx: Context) => void,
+    ): Element;
+    /**
      * `handler(value, cx)`, on a toggle. The script owns the new value.
      *
      * A `Radio` only ever reports `true`. It cannot deselect itself, so an
@@ -3783,6 +3804,7 @@ mod tests {
         "aria_level",
         "keep_mounted",
         "on_item_click",
+        "on_item_secondary_click",
         "on_change",
         "on_step",
         "on_open_change",


### PR DESCRIPTION
With `continuous(false)` the HUD only sees the frames the application had a reason to draw, so the rate is how many things changed a second, not how fast the window can go. A quiet market terminal redrawing six times a second read a red "6" over frames that were each inside the budget, and its DROP figure counted every over-budget frame as dropped even though nothing was waiting behind it.

Passive, the headline now takes the FRAME row's grade — what a frame cost against the budget — and an overrun is a dropped frame only when at least one more redraw had already been coalesced into it (`invalidations > 1`). Continuous mode is unchanged: drawing back to back, every overrun misses a vsync.

## Tests

- `an_overrun_with_nothing_waiting_drops_nothing_on_an_idle_window` (sampler): the same overrun counts back to back and not on demand unless contended.
- `a_window_drawing_on_demand_is_graded_by_frame_cost_not_rate` (monitor): six cheap frames a second read green, six slow ones amber or red, none grey.

Stacked under it: #2914 (`shell/item-secondary-click`) is based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsgPF2Ri8gtjGQBmuZLu4X