### PR TITLE
button/tab: Fix descenders being hidden

### DIFF
--- a/crates/ui/src/button/button.rs
+++ b/crates/ui/src/button/button.rs
@@ -654,9 +654,8 @@ impl RenderOnce for Button {
                 this.child(
                     div()
                         .min_w_0()
-                        .overflow_hidden()
                         .whitespace_nowrap()
-                        .truncate()
+                        .text_ellipsis()
                         .line_height(relative(1.))
                         .child(label),
                 )

--- a/crates/ui/src/tab/tab.rs
+++ b/crates/ui/src/tab/tab.rs
@@ -730,7 +730,11 @@ impl RenderOnce for Tab {
                     .map(|this| match (self.label, max_width) {
                         // Text always takes its natural width, so it needs a box
                         // that is allowed to shrink to ellipsize inside of.
-                        (Some(label), Some(_)) => this.child(div().truncate().child(label)),
+                        (Some(label), Some(_)) => this.child(div()
+                            .min_w_0()
+                            .whitespace_nowrap()
+                            .text_ellipsis()
+                            .child(label)),
                         (Some(label), None) => this.child(label),
                         (None, _) => this,
                     })


### PR DESCRIPTION
Closes #2883

## Description

Don't use overflow_hidden, because the glyphs of characters like "g, y, etc." extend slightly outside the bounding box.

I tried with overflow_x_hidden, but that doesn't work either, the descenders are still hidden.

The button text should still stay on a single line because of whitespace_nowrap and text_ellipsis.

Another fix I found is to change line_height from 1.0 to a little bit more like 1.1 or 1.2. If you want to keep the overflow_hidden I think that is another option

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| <img width="499" height="44" alt="image" src="https://github.com/user-attachments/assets/1f031bc2-bc4b-49d5-915f-b2490b4e4f56" /> | <img width="502" height="46" alt="image" src="https://github.com/user-attachments/assets/87139c59-7113-451a-8cee-565387d4d88e" /> |

## How to Test

Open button story

## Checklist

- [X] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [X] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [X] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
