### PR TITLE
website: Add a release notes page and keep page titles off the toolbar

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -211,7 +211,7 @@ function createNav(prefix = "", locale: "en" | "zh" = "en") {
         },
         {
           text: releasesText,
-          link: "https://github.com/longbridge/gpui-kit/releases",
+          link: `${prefix}/releases`,
         },
         {
           text: issuesText,

--- a/website/.vitepress/theme/style.css
+++ b/website/.vitepress/theme/style.css
@@ -701,6 +701,21 @@ html[lang^="ja"] :is(h1, h2, h3, h4) {
   }
 }
 
+/* `layout: home` is how the site's own surfaces — App Stories, Skills,
+   Contributors, Releases — opt out of the docs shell. VitePress pads only the
+   hero and feature bands it would render there, and these pages render
+   neither, so their markdown started flush against the toolbar. Give the
+   content the same top offset as a docs page. */
+.VPContent.is-home .VPHome > .vp-doc {
+  padding-top: 2rem;
+}
+
+@media (min-width: 768px) {
+  .VPContent.is-home .VPHome > .vp-doc {
+    padding-top: 3rem;
+  }
+}
+
 .vp-doc {
   color: var(--vp-c-text-1);
 

--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -124,6 +124,11 @@ Two constraints that are easy to get wrong:
   height, and the hamburger opens onto nothing.
 - The hero is two columns: copy, and a macOS window holding a real snippet from
   the Quick Start guide. Its vertical rhythm is 20 / 20 / 24 / 24 / 20 px.
+- Pages that are the site's own surfaces — App Stories, Skills, Contributors,
+  Releases — use `layout: home` to leave the docs shell, and a shared rule in
+  `style.css` gives their content the same top offset as a docs page. VitePress
+  pads only the hero it would render there, so without that rule a title sits
+  against the toolbar. A page must not add its own offset on top.
 - Live WASM examples belong to their component documentation, next to the API
   and guidance they demonstrate. The homepage links into that documentation
   instead of maintaining a separate gallery surface.
@@ -214,6 +219,9 @@ through motion alone.
   never `cargo add`, and the UI must not display a version number.
 - Code samples must be real API, verified against `crates/component` and
   `crates/base`.
+- The release notes page is rendered at build time from GitHub Releases
+  (`data/releases.data.js`) by the docs markdown pipeline; it holds no copy of
+  its own, so a release is written once, on GitHub.
 - Capability copy tracks the README's feature list — 120 FPS rendering, complex
   data tables, virtualized lists, the 200K-line editor, freeform docking,
   multi-theme support. Update it when the README's features change.

--- a/website/contributors.vue
+++ b/website/contributors.vue
@@ -62,7 +62,8 @@ const suffixText = computed(() => (isZh.value ? "。" : " on GitHub."));
 @reference "./.vitepress/theme/style.css";
 
 .contributors-page {
-    @apply py-10 pt-30;
+    /* The shared `layout: home` offset supplies the first 3rem. */
+    @apply py-10 pt-18;
     background: url("/contributors.svg") no-repeat;
     background-position: top 20px right 20px;
 }

--- a/website/data/releases.data.js
+++ b/website/data/releases.data.js
@@ -1,0 +1,97 @@
+import { fileURLToPath } from "node:url";
+import { createMarkdownRenderer } from "vitepress";
+import { darkTheme, lightTheme } from "../.vitepress/language";
+
+const REPO = "longbridge/gpui-kit";
+const API_URL = `https://api.github.com/repos/${REPO}/releases?per_page=100`;
+const SRC_DIR = fileURLToPath(new URL("..", import.meta.url));
+
+function requestHeaders() {
+  const headers = { Accept: "application/vnd.github+json" };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+// GitHub turns `#1652` and `@login` into links when it shows a release; the
+// API hands back the markdown as typed. Only bare references are linked, so a
+// `#` inside a URL fragment or an `@` inside an address stays as it is.
+function linkReferences(markdown) {
+  return markdown
+    .replace(
+      /(^|[\s(])#(\d+)(?=[\s.,;:)]|$)/gm,
+      `$1[#$2](https://github.com/${REPO}/issues/$2)`,
+    )
+    .replace(
+      /(^|[\s(])@([A-Za-z\d](?:[A-Za-z\d-]{0,37}[A-Za-z\d])?)(?=[\s.,;:)]|$)/gm,
+      "$1[@$2](https://github.com/$2)",
+    );
+}
+
+// The site renderer adds an id and a permalink to every heading. Release
+// notes repeat their headings across versions, so those ids would collide;
+// the version headings the page adds itself are the anchors readers need.
+function stripHeadingAnchors(html) {
+  return html
+    .replace(/<a class="header-anchor"[^>]*>[\s\S]*?<\/a>/g, "")
+    .replace(/<h([1-6]) id="[^"]*"/g, "<h$1")
+    .replace(/<h([1-6]) id='[^']*'/g, "<h$1");
+}
+
+async function fetchReleases() {
+  try {
+    const res = await fetch(API_URL, { headers: requestHeaders() });
+    const items = await res.json();
+    if (!res.ok || !Array.isArray(items)) {
+      console.warn(
+        `[releases] GitHub API returned ${res.status}: ${items?.message ?? "unexpected response"}`,
+      );
+      return [];
+    }
+    return items;
+  } catch (error) {
+    console.warn(`[releases] Failed to fetch releases: ${error}`);
+    return [];
+  }
+}
+
+export default {
+  async load() {
+    const items = await fetchReleases();
+    if (items.length === 0) {
+      return [];
+    }
+
+    // The same renderer the docs use, so code in the notes gets the docs'
+    // highlighting and adaptive theme.
+    const md = await createMarkdownRenderer(
+      SRC_DIR,
+      {
+        languages: ["rust"],
+        languageAlias: { rs: "rust" },
+        defaultHighlightLang: "rust",
+        theme: { light: lightTheme, dark: darkTheme },
+      },
+      "/",
+    );
+
+    return items
+      .filter((item) => !item.draft)
+      .sort((a, b) => Date.parse(b.published_at) - Date.parse(a.published_at))
+      .map((item) => {
+        const body = linkReferences((item.body ?? "").replace(/\r\n/g, "\n"));
+        return {
+          tag: item.tag_name,
+          name: item.name || item.tag_name,
+          // The date alone; the page shows it as written, so the server and
+          // the browser cannot disagree on its format.
+          date: item.published_at.slice(0, 10),
+          url: item.html_url,
+          prerelease: item.prerelease,
+          html: stripHeadingAnchors(md.render(body)),
+        };
+      });
+  },
+};

--- a/website/releases.md
+++ b/website/releases.md
@@ -1,0 +1,11 @@
+---
+title: Release Notes
+layout: home
+description: Every published version of GPUI Kit, with the notes from its GitHub release.
+---
+
+<script setup>
+import Releases from './releases.vue'
+</script>
+
+<Releases />

--- a/website/releases.vue
+++ b/website/releases.vue
@@ -1,0 +1,304 @@
+<template>
+    <div class="releases-page">
+        <div class="releases-hero">
+            <span class="releases-kicker">{{ copy.kicker }}</span>
+            <h1>{{ copy.title }}</h1>
+            <p class="releases-lead">{{ copy.lead }}</p>
+            <ul v-if="releases.length" class="releases-signals">
+                <li><Tag /> {{ copy.latest }} {{ releases[0].name }}</li>
+                <li><Layers /> {{ copy.count }}</li>
+                <li>
+                    <Github />
+                    <a
+                        :href="`https://github.com/${REPO}/releases`"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        >{{ copy.github }}</a
+                    >
+                </li>
+            </ul>
+        </div>
+
+        <p v-if="!releases.length" class="releases-empty">
+            {{ copy.empty }}
+            <a
+                :href="`https://github.com/${REPO}/releases`"
+                target="_blank"
+                rel="noopener noreferrer"
+                >{{ copy.emptyLink }}</a
+            >
+        </p>
+
+        <article
+            v-for="(release, index) in releases"
+            :id="release.tag"
+            :key="release.tag"
+            class="release"
+        >
+            <header class="release__header">
+                <h2 class="release__version">
+                    <a :href="`#${release.tag}`">{{ release.name }}</a>
+                </h2>
+                <div class="release__meta">
+                    <time :datetime="release.date">{{ release.date }}</time>
+                    <span v-if="index === 0" class="release__badge">
+                        {{ copy.latestBadge }}
+                    </span>
+                    <span v-if="release.prerelease" class="release__badge">
+                        {{ copy.prerelease }}
+                    </span>
+                    <a
+                        :href="release.url"
+                        class="release__link"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        GitHub <ArrowUpRight />
+                    </a>
+                </div>
+            </header>
+            <!-- Rendered at build time from the GitHub release body, by the
+                 same markdown pipeline as the docs. -->
+            <div class="release__body" v-html="release.html" />
+        </article>
+    </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { useData } from "vitepress";
+import { ArrowUpRight, Github, Layers, Tag } from "lucide-vue-next";
+import { data as releases } from "./data/releases.data";
+
+const REPO = "longbridge/gpui-kit";
+
+const { localeIndex } = useData();
+const isZh = computed(() => localeIndex.value === "zh-CN");
+
+const copy = computed(() =>
+    isZh.value
+        ? {
+              kicker: "版本发布",
+              title: "发布说明",
+              lead: "GPUI Kit 每个已发布版本，以及它在 GitHub Release 中的说明，最新版本在最前。说明保留 GitHub 上的英文原文。",
+              latest: "最新版本",
+              count: `${releases.length} 个版本`,
+              github: "在 GitHub 上查看全部版本",
+              latestBadge: "最新",
+              prerelease: "预发布",
+              empty: "构建时未能读取发布说明。",
+              emptyLink: "前往 GitHub 查看版本发布。",
+          }
+        : {
+              kicker: "Releases",
+              title: "Release notes",
+              lead: "Every published version of GPUI Kit, with the notes from its GitHub release. The newest version comes first.",
+              latest: "Latest",
+              count: `${releases.length} releases`,
+              github: "All releases on GitHub",
+              latestBadge: "Latest",
+              prerelease: "Pre-release",
+              empty: "The release notes could not be loaded when this page was built.",
+              emptyLink: "See the releases on GitHub.",
+          },
+);
+</script>
+
+<style scoped>
+.releases-page {
+    color: var(--foreground);
+}
+
+/* -------------------------------------------------------------- hero */
+
+.releases-hero {
+    max-width: 46rem;
+    margin-bottom: clamp(2.5rem, 5vw, 3.5rem);
+}
+
+.releases-kicker {
+    display: block;
+    margin-bottom: 0.9rem;
+    color: var(--muted-foreground);
+    font-family: var(--vp-font-family-mono, ui-monospace, monospace);
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+html[lang^="zh"] .releases-kicker {
+    letter-spacing: 0.06em;
+}
+
+.releases-hero h1 {
+    margin: 0;
+    border: 0;
+    padding: 0;
+    font-size: clamp(2rem, 3.6vw, 3rem);
+    font-weight: 660;
+    letter-spacing: -0.045em;
+    line-height: 1.1;
+}
+
+html[lang^="zh"] .releases-hero h1 {
+    letter-spacing: normal;
+}
+
+.releases-lead {
+    margin: 1.1rem 0 0;
+    color: var(--muted-foreground);
+    font-size: 1.05rem;
+    line-height: 1.7;
+}
+
+.releases-signals {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
+    margin: 1.6rem 0 0;
+    padding: 0;
+    list-style: none;
+    color: var(--muted-foreground);
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.releases-signals li {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin: 0;
+}
+
+.releases-signals :deep(svg) {
+    width: 0.95rem;
+    height: 0.95rem;
+    opacity: 0.7;
+}
+
+.releases-empty {
+    max-width: 46rem;
+    color: var(--muted-foreground);
+}
+
+/* ----------------------------------------------------------- release */
+
+/* Each version is a band under a hairline: the version and date on the
+   left stay in view while its notes scroll, so a reader skimming down the
+   page always knows which release they are in. */
+.release {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem 3rem;
+    border-top: 1px solid var(--border);
+    padding: 2rem 0 2.5rem;
+}
+
+@media (min-width: 960px) {
+    .release {
+        grid-template-columns: 13rem minmax(0, 1fr);
+        padding: 2.5rem 0 3rem;
+    }
+}
+
+.release__header {
+    align-self: start;
+}
+
+@media (min-width: 960px) {
+    .release__header {
+        position: sticky;
+        top: calc(var(--vp-nav-height) + 1.5rem);
+    }
+}
+
+.release__version {
+    margin: 0;
+    border: 0;
+    padding: 0;
+    font-size: 1.35rem;
+    font-weight: 640;
+    letter-spacing: -0.022em;
+    line-height: 1.2;
+    font-variant-numeric: tabular-nums;
+}
+
+.release__version a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.release__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem 0.75rem;
+    margin-top: 0.6rem;
+    color: var(--muted-foreground);
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.release__badge {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.05rem 0.55rem;
+    font-size: 0.72rem;
+    line-height: 1.5;
+}
+
+.release__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    color: inherit;
+    text-decoration: none;
+}
+
+.release__link:hover {
+    color: var(--foreground);
+}
+
+.release__link :deep(svg) {
+    width: 0.85rem;
+    height: 0.85rem;
+}
+
+/* The notes are GitHub markdown: mostly lists, with a heading per component
+   in the larger releases. Docs-level heading rhythm would be too loud for a
+   changelog, so headings inside a release are compact and unruled. */
+.release__body {
+    min-width: 0;
+    max-width: 46rem;
+}
+
+.release__body :deep(h1),
+.release__body :deep(h2),
+.release__body :deep(h3),
+.release__body :deep(h4) {
+    margin: 1.5rem 0 0.5rem;
+    border: 0;
+    padding: 0;
+    font-size: 1rem;
+    font-weight: 640;
+    letter-spacing: -0.012em;
+    line-height: 1.4;
+}
+
+.release__body :deep(> :first-child) {
+    margin-top: 0;
+}
+
+.release__body :deep(p),
+.release__body :deep(ul),
+.release__body :deep(ol) {
+    max-width: none;
+}
+
+.release__body :deep(img) {
+    max-width: 100%;
+    height: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-card);
+}
+</style>

--- a/website/zh-CN/releases.md
+++ b/website/zh-CN/releases.md
@@ -1,0 +1,11 @@
+---
+title: 发布说明
+layout: home
+description: GPUI Kit 每个已发布版本及其 GitHub Release 说明。
+---
+
+<script setup>
+import Releases from '../releases.vue'
+</script>
+
+<Releases />


### PR DESCRIPTION
## Description

Two things on the site.

**Page titles sat against the toolbar.** App Stories and Skills use `layout: home` to leave the docs shell, and VitePress pads only the hero and feature bands it would render there. These pages render neither, so their first line started at the navbar's bottom edge (measured: 0px on `/skills` and `/apps`, 48px on a docs page). Contributors avoided it by padding itself 120px by hand. A shared rule in `style.css` now gives every `layout: home` page the docs page's top offset, and Contributors drops that much of its own padding so its total is unchanged. `DESIGN.md` records the rule so a new page does not add its own offset on top.

| Page | Before | After |
| --- | --- | --- |
| `/skills` | 0px | 48px |
| `/apps` | 0px | 48px |
| `/contributors` | 120px | 120px |
| `/docs/installation` | 48px | 48px |

**A release notes page.** The Releases entry in the Resources menu opened GitHub; it now opens `/releases` (and `/zh-CN/releases`). The page is rendered at build time by a VitePress data loader (`data/releases.data.js`): it reads the GitHub Releases API, links `#1234` and `@login` references the way GitHub does, renders each body with the same markdown pipeline as the docs (so code blocks get the docs' highlighting), and strips the per-heading anchors so headings repeated across versions do not produce duplicate ids. Each version is a band with a sticky version/date column, following the App Stories hero style. When the API cannot be reached at build time the page shows a link to GitHub, matching the contributors loader.

## How to Test

1. `bun run dev` in `website/`, open `/skills`, `/apps`, `/contributors`: the title now sits 48px below the toolbar, the same as a docs page.
2. Open `/releases` and `/zh-CN/releases`: eight versions, newest first, with linked PR and user references.
3. `bun run build` in `website/`: `dist/releases.html` contains the rendered notes; no anchors are emitted inside release bodies.

Written with AI assistance (Claude Code): the measurement, the offset rule, and the release notes loader and page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtHQQsTaKJSgR6SboZLxup
