### PR TITLE
gpui-pre: Audit licenses before publishing and state GPUI's origin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,8 +179,8 @@ constant in the script; keep that version in step with the hand-published one.
 
 The script runs on [Bun](https://bun.sh) and needs Cargo 1.90+ (for `cargo publish --workspace`)
 and a crates.io token from `cargo login`. It stages a standalone workspace in
-`target/gpui-pre/workspace`, verifies it with `cargo publish --dry-run`, then
-builds and tests this repository against the staged crates (the same `check`,
+`target/gpui-pre/workspace`, audits its licenses, verifies it with
+`cargo publish --dry-run`, then builds and tests this repository against the staged crates (the same `check`,
 `clippy` and `test` commands CI runs, injected with `--config patch.crates-io`
 so nothing in the checkout changes), and only then uploads. Applications
 depend on `gpui-pre` with a caret requirement and pick up new snapshots on
@@ -190,6 +190,23 @@ instead of reaching users; adapt the repository first, then publish. Pass
 the first run waits between batches; re-running resumes from where it stopped.
 Pass `--zed <path>` to reuse a local Zed checkout and `--stage-only` to inspect
 the generated workspace.
+
+GPUI is Apache-2.0, and the snapshots are a redistribution of it, so the
+script keeps Zed's terms intact and refuses to publish anything else:
+
+- Every crate keeps its `license`, its `repository` and Zed's copyright
+  notices, ships Zed's `LICENSE-APACHE` beside its sources, and would carry a
+  `NOTICE` file if Zed added one. The Zed commit is recorded in the
+  description and `[package.metadata.gpui-pre]`, and the three files the
+  script rewrites (`gpui/src/action.rs`, `gpui_macros/src/lib.rs`,
+  `gpui_apple/build.rs`) start with a line saying what changed.
+- Staging fails if a selected crate is not `Apache-2.0`. Zed's application
+  crates are GPL-3.0-or-later and live in the same workspace, so a new
+  internal dependency can pull one into the closure; `zlog` did exactly that
+  before Zed relicensed it.
+- The audit step runs `cargo metadata` on the staged workspace and fails on
+  any copyleft dependency, whether it comes from Zed or from crates.io, so a
+  license change upstream stops the release instead of reaching users.
 
 Depend on the result with:
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,6 @@ See the [comparison with Iced, egui and Qt 6](https://gpui-kit.com/docs/comparis
 
 Apache-2.0
 
-- Built on [GPUI](https://github.com/zed-industries/zed), the UI framework created by Zed Industries and released under Apache-2.0. The `gpui-pre-*` crates are snapshots of it that keep Zed's license, copyright notices and attribution.
-- GPUI Kit is an independent project and is not affiliated with or endorsed by Zed Industries.
+- Built on [GPUI](https://github.com/zed-industries/zed), the UI framework from Zed Industries, also Apache-2.0. The `gpui-pre-*` crates are snapshots of it, published with Zed's license and notices intact.
 - UI design based on [shadcn/ui](https://ui.shadcn.com), some from [Reui](https://reui.io).
 - Icons from [Lucide](https://lucide.dev).

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ See the [comparison with Iced, egui and Qt 6](https://gpui-kit.com/docs/comparis
 
 Apache-2.0
 
-- Built on [GPUI](https://github.com/zed-industries/zed), the UI framework behind Zed, also Apache-2.0.
+- Built on [GPUI](https://github.com/zed-industries/zed), the UI framework created by Zed Industries and released under Apache-2.0. The `gpui-pre-*` crates are snapshots of it that keep Zed's license, copyright notices and attribution.
+- GPUI Kit is an independent project and is not affiliated with or endorsed by Zed Industries.
 - UI design based on [shadcn/ui](https://ui.shadcn.com), some from [Reui](https://reui.io).
 - Icons from [Lucide](https://lucide.dev).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -214,7 +214,6 @@ cargo run -p window_title
 
 Apache-2.0
 
-- 基于 [GPUI](https://github.com/zed-industries/zed) 构建。GPUI 由 Zed Industries 创建并以 Apache-2.0 许可证发布；`gpui-pre-*` 是它的快照，保留了 Zed 的许可证、版权声明与署名。
-- GPUI Kit 是独立项目，与 Zed Industries 没有隶属关系，也未获得其背书。
+- 基于 Zed Industries 的 [GPUI](https://github.com/zed-industries/zed) 构建，GPUI 同样采用 Apache-2.0。`gpui-pre-*` 是它的快照，发布时保留 Zed 的许可证与声明。
 - UI 设计基于 [shadcn/ui](https://ui.shadcn.com)，部分来自 [Reui](https://reui.io)。
 - 图标来自 [Lucide](https://lucide.dev)。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -214,6 +214,7 @@ cargo run -p window_title
 
 Apache-2.0
 
-- 基于 Zed 团队的 [GPUI](https://github.com/zed-industries/zed) 构建，GPUI 同样采用 Apache-2.0。
+- 基于 [GPUI](https://github.com/zed-industries/zed) 构建。GPUI 由 Zed Industries 创建并以 Apache-2.0 许可证发布；`gpui-pre-*` 是它的快照，保留了 Zed 的许可证、版权声明与署名。
+- GPUI Kit 是独立项目，与 Zed Industries 没有隶属关系，也未获得其背书。
 - UI 设计基于 [shadcn/ui](https://ui.shadcn.com)，部分来自 [Reui](https://reui.io)。
 - 图标来自 [Lucide](https://lucide.dev)。

--- a/script/bump-gpui.ts
+++ b/script/bump-gpui.ts
@@ -17,8 +17,16 @@
  * 4. Drop optional dependencies that come from git without a crates.io
  *    version (crates.io rejects those), together with the features that
  *    enable them. Non-optional ones abort the run.
- * 5. Write a standalone workspace to `target/gpui-pre/workspace`, verify it
- *    with `cargo publish --workspace --dry-run`, then publish it.
+ * 5. Write a standalone workspace to `target/gpui-pre/workspace`. Every
+ *    crate keeps Zed's `license`, copyright notices and `LICENSE-APACHE`,
+ *    gets any `NOTICE` Zed ships, and the few files this script rewrites
+ *    carry a notice saying so (Apache-2.0 §4).
+ * 6. Audit the licenses: a republished crate must be Apache-2.0, and the
+ *    dependency graph of the staged workspace must not pull in a copyleft
+ *    crate. Zed's own application crates are GPL-3.0-or-later, and one of
+ *    them reaching the closure would change the terms for every consumer.
+ * 7. Verify with `cargo publish --workspace --dry-run`, build and test
+ *    gpui-kit against the staged crates, then publish.
  *
  * crates.io only accepts a handful of brand-new crates per ten minutes. The
  * publish step re-checks crates.io before every attempt, skips versions that
@@ -276,6 +284,7 @@ function loadWorkspace(zed: string): Workspace {
     }
   }
   const ws: Workspace = { root: zed, manifest, members, pruned: new Map() };
+  WORKSPACE_PACKAGE_LICENSE = manifest.workspace.package?.license;
   applyDependencyOverrides(ws);
   return ws;
 }
@@ -740,9 +749,12 @@ function crateManifest(
 ): Toml {
   const source = crate.manifest;
   const pkg: Toml = { ...source.package };
-  if (pkg.license === undefined && pkg["license-file"] === undefined) {
+  const license = packageLicense(crate);
+  if (license !== GPUI_LICENSE) {
     throw new BumpError(
-      `${crate.name}: no \`license\` in Cargo.toml; crates.io requires one`,
+      `${crate.name}: license is ${license === undefined ? "not declared" : `\`${license}\``}, ` +
+        `and only ${GPUI_LICENSE} crates are republished as ${PUBLISH_PREFIX}-*; ` +
+        "Zed's application crates are GPL-3.0-or-later and must not reach the closure",
     );
   }
 
@@ -908,9 +920,10 @@ function stageWorkspace(
       tomlDump(manifest),
     );
   }
-  installFacadeAwareMacroPaths(staging, crates);
-  makeDeclarativeMacrosCrateRelative(staging, crates);
-  vendorGpuiSourcesForApple(staging, crates);
+  installFacadeAwareMacroPaths(staging, crates, zedSha);
+  makeDeclarativeMacrosCrateRelative(staging, crates, zedSha);
+  vendorGpuiSourcesForApple(staging, crates, zedSha);
+  carryLicenseFiles(ws.root, staging, crates);
 
   writeFileSync(
     join(staging, "Cargo.toml"),
@@ -956,7 +969,11 @@ const PROC_MACRO_ATTRIBUTE = /^#\[proc_macro(?:_derive\([^\n]*\)|_attribute)?\]$
  * the known `actions!` derive crate-relative so it also works when re-exported
  * through gpui-kit (or when gpui-pre itself is renamed by a consumer).
  */
-function makeDeclarativeMacrosCrateRelative(staging: string, crates: Crate[]) {
+function makeDeclarativeMacrosCrateRelative(
+  staging: string,
+  crates: Crate[],
+  zedSha: string,
+) {
   const gpui = crates.find((crate) => crate.name === "gpui");
   if (gpui === undefined)
     throw new BumpError("gpui is missing from the staged crate set");
@@ -964,7 +981,11 @@ function makeDeclarativeMacrosCrateRelative(staging: string, crates: Crate[]) {
   if (!existsSync(actionPath))
     throw new BumpError("gpui declarative macro source does not exist: src/action.rs");
   const source = readFileSync(actionPath, "utf8");
-  writeFileSync(actionPath, rewriteDeclarativeMacroPaths(source));
+  writeFileSync(
+    actionPath,
+    modificationNotice(zedSha, "the `actions!` derive paths are crate-relative") +
+      rewriteDeclarativeMacroPaths(source),
+  );
   logInfo("gpui: made actions! derive paths crate-relative");
 }
 
@@ -1171,7 +1192,11 @@ fn rewrite_literal(literal: &Literal, facade: Option<&FacadePath>) -> Literal {
 `;
 }
 
-function installFacadeAwareMacroPaths(staging: string, crates: Crate[]) {
+function installFacadeAwareMacroPaths(
+  staging: string,
+  crates: Crate[],
+  zedSha: string,
+) {
   const macros = crates.find((crate) => crate.name === "gpui_macros");
   if (macros === undefined)
     throw new BumpError("gpui_macros is missing from the staged crate set");
@@ -1184,8 +1209,16 @@ function installFacadeAwareMacroPaths(staging: string, crates: Crate[]) {
   if (source.includes(FACADE_PATH_MARKER))
     throw new BumpError(`gpui_macros already declares \`${FACADE_PATH_MARKER}\``);
   const wrapped = wrapProcMacroEntrypoints(source);
-  writeFileSync(libPath, `${FACADE_PATH_MARKER}\n${wrapped.source}`);
-  writeFileSync(join(dirname(libPath), `${FACADE_PATH_MODULE}.rs`), facadePathModuleSource());
+  writeFileSync(
+    libPath,
+    modificationNotice(zedSha, "the proc-macro entry points resolve gpui through a facade") +
+      `${FACADE_PATH_MARKER}\n${wrapped.source}`,
+  );
+  writeFileSync(
+    join(dirname(libPath), `${FACADE_PATH_MODULE}.rs`),
+    modificationNotice(zedSha, "this module is added by the script") +
+      facadePathModuleSource(),
+  );
   logInfo(`gpui_macros: made ${wrapped.count} proc-macro entry points facade-aware`);
 }
 
@@ -1273,7 +1306,11 @@ const GPUI_APPLE_VENDORED = '.join("vendor/gpui")';
  * crates.io has no such sibling, so copy exactly the files it names into the
  * crate and point the build script at the copy.
  */
-function vendorGpuiSourcesForApple(staging: string, crates: Crate[]) {
+function vendorGpuiSourcesForApple(
+  staging: string,
+  crates: Crate[],
+  zedSha: string,
+) {
   const apple = crates.find((c) => c.name === "gpui_apple");
   const gpui = crates.find((c) => c.name === "gpui");
   if (apple === undefined || gpui === undefined) return;
@@ -1306,10 +1343,134 @@ function vendorGpuiSourcesForApple(staging: string, crates: Crate[]) {
   }
   writeFileSync(
     buildRs,
-    text.replaceAll(GPUI_APPLE_SIBLING, GPUI_APPLE_VENDORED),
+    modificationNotice(zedSha, "the gpui sources it reads are vendored under `vendor/gpui`") +
+      text.replaceAll(GPUI_APPLE_SIBLING, GPUI_APPLE_VENDORED),
   );
   logInfo(
     `gpui_apple: vendored ${sources.length} gpui source files for its shader bindings`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// License and attribution
+// ---------------------------------------------------------------------------
+
+/** The license GPUI is released under, and the only one a snapshot may carry. */
+const GPUI_LICENSE = "Apache-2.0";
+
+/**
+ * Licenses a dependency of the staged workspace must not have. Zed's
+ * application crates are GPL-3.0-or-later and sit in the same workspace as
+ * gpui, so a new internal dependency can pull one in without anyone noticing;
+ * a third-party crate can change its terms between snapshots just as quietly.
+ */
+const COPYLEFT_LICENSE = /\b(?:A?GPL|LGPL|SSPL|EUPL|OSL|CPAL|BUSL|CC-BY-SA)\b/i;
+
+/** Every alternative of an SPDX `OR` expression is copyleft. */
+function isCopyleft(license: string): boolean {
+  return license
+    .split(/\s+OR\s+|\//i)
+    .every((alternative) => COPYLEFT_LICENSE.test(alternative));
+}
+
+/** The crate's `license`, following `license.workspace = true`. */
+function packageLicense(crate: Crate): string | undefined {
+  const license = crate.manifest.package?.license;
+  if (typeof license === "string") return license;
+  if (isPlainObject(license) && license.workspace === true) {
+    return WORKSPACE_PACKAGE_LICENSE;
+  }
+  return undefined;
+}
+
+let WORKSPACE_PACKAGE_LICENSE: string | undefined;
+
+/**
+ * Apache-2.0 §4: a redistribution keeps the license text and every copyright
+ * notice, includes the NOTICE file if the work has one, and marks the files it
+ * changed. Copyright notices live in Zed's source files, which are copied
+ * untouched; this puts the license and any NOTICE beside every crate, and the
+ * functions above stamp the files the script rewrites.
+ */
+function carryLicenseFiles(zed: string, staging: string, crates: Crate[]) {
+  const licenseFile = join(zed, "LICENSE-APACHE");
+  if (!existsSync(licenseFile)) {
+    throw new BumpError(
+      "Zed has no LICENSE-APACHE at its root; check the license before publishing",
+    );
+  }
+  const notices = readdirSync(zed).filter(
+    (entry) =>
+      entry.startsWith("NOTICE") && statSync(join(zed, entry)).isFile(),
+  );
+  let copied = 0;
+  for (const crate of crates) {
+    const dir = join(staging, crate.relDir);
+    const destination = join(dir, "LICENSE-APACHE");
+    if (!existsSync(destination)) {
+      cpSync(licenseFile, destination);
+      copied += 1;
+    }
+    for (const notice of notices) cpSync(join(zed, notice), join(dir, notice));
+  }
+  logInfo(
+    `LICENSE-APACHE travels with every crate (${copied} added)` +
+      (notices.length ? `, with ${notices.join(", ")}` : "; Zed ships no NOTICE"),
+  );
+}
+
+/** A one-line header for a file the script rewrites (Apache-2.0 §4(b)). */
+function modificationNotice(zedSha: string, change: string): string {
+  return `// Modified for ${PUBLISH_PREFIX} (snapshot of zed@${zedSha.slice(0, 7)}): ${change}.\n`;
+}
+
+/**
+ * Check the staged workspace's whole dependency graph, not only the crates
+ * being published: what reaches a consumer is the closure, and it moves with
+ * every snapshot.
+ */
+async function auditLicenses(staging: string, crates: Crate[]) {
+  for (const crate of crates) {
+    if (!existsSync(join(staging, crate.relDir, "LICENSE-APACHE")))
+      throw new BumpError(`${crate.name}: LICENSE-APACHE is missing from the staged crate`);
+  }
+  // Not `--locked`: the lock file is Zed's, and the staged workspace is a
+  // subset of it with pruned dependencies, so it has to be updated here the
+  // way `cargo publish --dry-run` updates it in the next step.
+  const cmd = ["cargo", "metadata", "--format-version", "1"];
+  console.log(dim(`$ (cd ${staging} && ${cmd.join(" ")})`));
+  const process_ = Bun.spawn(cmd, { cwd: staging, stdout: "pipe", stderr: "inherit" });
+  const output = await new Response(process_.stdout).text();
+  if ((await process_.exited) !== 0)
+    throw new BumpError("cargo metadata failed on the staged workspace");
+  const metadata = JSON.parse(output);
+  const members = new Set<string>(metadata.workspace_members);
+  const copyleft: string[] = [];
+  const undeclared: string[] = [];
+  for (const pkg of metadata.packages as Toml[]) {
+    if (members.has(pkg.id)) continue;
+    const license: string | null = pkg.license;
+    if (license === null || license === undefined || license === "") {
+      undeclared.push(`${pkg.name} ${pkg.version}`);
+    } else if (isCopyleft(license)) {
+      copyleft.push(`${pkg.name} ${pkg.version} (${license})`);
+    }
+  }
+  if (copyleft.length > 0) {
+    throw new BumpError(
+      "copyleft crates in the dependency graph; a snapshot must not change " +
+        `the terms consumers get:\n  ${copyleft.join("\n  ")}`,
+    );
+  }
+  if (undeclared.length > 0) {
+    logWarn(
+      `${undeclared.length} dependencies declare a license file instead of an ` +
+        `SPDX expression; check them by hand: ${undeclared.join(", ")}`,
+    );
+  }
+  logSuccess(
+    `${crates.length} crates are ${GPUI_LICENSE}; ` +
+      `${metadata.packages.length - members.size} dependencies carry no copyleft license`,
   );
 }
 
@@ -1640,7 +1801,7 @@ async function main(argv: string[]): Promise<number> {
   if (Bun.which("cargo") === null)
     throw new BumpError("cargo is not installed");
 
-  const totalSteps = args.stageOnly ? 3 : args.dryRun ? 5 : 6;
+  const totalSteps = args.stageOnly ? 4 : args.dryRun ? 6 : 7;
   logHeader(`Publishing GPUI from Zed as ${PUBLISH_PREFIX}`);
   mkdirSync(WORK_DIR, { recursive: true });
 
@@ -1667,12 +1828,16 @@ async function main(argv: string[]): Promise<number> {
   logSuccess(`Workspace written to ${bold(staging)}`);
   logInfo(`Summary written to ${join(WORK_DIR, "gpui-pre.json")}`);
   console.log();
+
+  logStep(`4/${totalSteps}`, "Auditing licenses");
+  await auditLicenses(staging, crates);
+  console.log();
   if (args.stageOnly) return 0;
 
   if (args.noVerify) {
     logWarn("Skipping verification (--no-verify)");
   } else {
-    logStep(`4/${totalSteps}`, "Verifying with `cargo publish --dry-run`");
+    logStep(`5/${totalSteps}`, "Verifying with `cargo publish --dry-run`");
     const { code } = await runStreaming(
       ["cargo", "publish", "--workspace", "--dry-run", "--allow-dirty"],
       staging,
@@ -1688,7 +1853,7 @@ async function main(argv: string[]): Promise<number> {
   if (args.skipKitCheck) {
     logWarn("Skipping the gpui-kit compatibility check (--skip-kit-check)");
   } else {
-    logStep(`5/${totalSteps}`, "Building and testing gpui-kit against the staged crates");
+    logStep(`6/${totalSteps}`, "Building and testing gpui-kit against the staged crates");
     await verifyKitAgainstStaging(staging, crates, version);
     logSuccess(`gpui-kit builds and passes its tests against gpui-pre ${version}`);
   }
@@ -1698,7 +1863,7 @@ async function main(argv: string[]): Promise<number> {
     return 0;
   }
 
-  logStep(`6/${totalSteps}`, "Publishing to crates.io");
+  logStep(`7/${totalSteps}`, "Publishing to crates.io");
   await publish(staging, crates, version, !args.noWait);
   console.log();
 

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -148,12 +148,24 @@ function createFooter(prefix = "", locale: "en" | "zh" = "en") {
   const skillsText = "Skills";
   const reportBugText = locale === "zh" ? "报告问题" : "Report Bug";
   const discussionText = locale === "zh" ? "讨论" : "Discussion";
+  const iconCreditsText = locale === "zh" ? "图标资源来自" : "Icons by";
+  const andText = locale === "zh" ? "与" : "and";
+  const periodText = locale === "zh" ? "。" : ".";
+  // The attribution is stated once, here and in the landing page footer,
+  // and kept exact: GPUI's origin and license, and that GPUI Kit is neither
+  // Zed's project nor endorsed by Zed. Everywhere else the product is GPUI Kit.
   const message =
     locale === "zh"
       ? `GPUI Kit 是一个基于 Apache-2.0 许可证的开源项目，
-        由 <a href='https://longbridge.com' target='_blank'>Longbridge</a> 开发。`
+        由 <a href='https://longbridge.com' target='_blank'>Longbridge</a> 开发。
+        它构建于 <a href='https://github.com/zed-industries/zed' target='_blank'>GPUI</a> 之上，
+        GPUI 由 Zed Industries 创建并以 Apache-2.0 许可证发布。
+        GPUI Kit 是独立项目，与 Zed Industries 没有隶属关系，也未获得其背书。`
       : `GPUI Kit is an open source project under the Apache-2.0 License,
-        developed by <a href='https://longbridge.com' target='_blank'>Longbridge</a>.`;
+        developed by <a href='https://longbridge.com' target='_blank'>Longbridge</a>.
+        It is built on <a href='https://github.com/zed-industries/zed' target='_blank'>GPUI</a>,
+        the UI framework created by Zed Industries and released under Apache-2.0.
+        GPUI Kit is an independent project and is not affiliated with or endorsed by Zed Industries.`;
 
   return {
     message,
@@ -174,8 +186,8 @@ function createFooter(prefix = "", locale: "en" | "zh" = "en") {
       |
       <a href="https://github.com/longbridge/gpui-kit/discussions" target="_blank">${discussionText}</a>
       <br />
-      Icon resources are used <a href="https://lucide.dev" target="_blank">Lucide</a>,
-      <a href="https://isocons.app" target="_blank">Isocons</a>.
+      ${iconCreditsText} <a href="https://lucide.dev" target="_blank">Lucide</a>
+      ${andText} <a href="https://isocons.app" target="_blank">Isocons</a>${periodText}
     `,
   };
 }

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -151,21 +151,16 @@ function createFooter(prefix = "", locale: "en" | "zh" = "en") {
   const iconCreditsText = locale === "zh" ? "图标资源来自" : "Icons by";
   const andText = locale === "zh" ? "与" : "and";
   const periodText = locale === "zh" ? "。" : ".";
-  // The attribution is stated once, here and in the landing page footer,
-  // and kept exact: GPUI's origin and license, and that GPUI Kit is neither
-  // Zed's project nor endorsed by Zed. Everywhere else the product is GPUI Kit.
+  // GPUI's origin is stated once, here and in the landing page footer, in
+  // one plain line. Everywhere else the product is GPUI Kit.
   const message =
     locale === "zh"
       ? `GPUI Kit 是一个基于 Apache-2.0 许可证的开源项目，
-        由 <a href='https://longbridge.com' target='_blank'>Longbridge</a> 开发。
-        它构建于 <a href='https://github.com/zed-industries/zed' target='_blank'>GPUI</a> 之上，
-        GPUI 由 Zed Industries 创建并以 Apache-2.0 许可证发布。
-        GPUI Kit 是独立项目，与 Zed Industries 没有隶属关系，也未获得其背书。`
+        由 <a href='https://longbridge.com' target='_blank'>Longbridge</a> 开发，
+        基于 Zed Industries 的 <a href='https://github.com/zed-industries/zed' target='_blank'>GPUI</a> 构建。`
       : `GPUI Kit is an open source project under the Apache-2.0 License,
-        developed by <a href='https://longbridge.com' target='_blank'>Longbridge</a>.
-        It is built on <a href='https://github.com/zed-industries/zed' target='_blank'>GPUI</a>,
-        the UI framework created by Zed Industries and released under Apache-2.0.
-        GPUI Kit is an independent project and is not affiliated with or endorsed by Zed Industries.`;
+        developed by <a href='https://longbridge.com' target='_blank'>Longbridge</a>
+        and built on <a href='https://github.com/zed-industries/zed' target='_blank'>GPUI</a> from Zed Industries.`;
 
   return {
     message,

--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -260,3 +260,12 @@ navbar rather than inside the Resources menu. Submissions come from
 | `.vitepress/theme/components/ComponentExample.vue` | Windowed live example on component pages                                |
 | `.vitepress/config.mts`                            | Navigation, sidebar generation, locales                                 |
 | `src/*.theme.json`                                 | shiki syntax themes; the source of `--code-*`                           |
+
+## Attribution
+
+The footer is the one place the site states GPUI's origin: built on GPUI,
+created by Zed Industries and released under Apache-2.0, and GPUI Kit is an
+independent project that is neither Zed's nor endorsed by Zed. The landing
+page footer and the docs footer carry the same sentence. Keep it exact, and do
+not repeat it in the hero, tutorials or API pages, where the product is
+GPUI Kit.

--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -263,9 +263,8 @@ navbar rather than inside the Resources menu. Submissions come from
 
 ## Attribution
 
-The footer is the one place the site states GPUI's origin: built on GPUI,
-created by Zed Industries and released under Apache-2.0, and GPUI Kit is an
-independent project that is neither Zed's nor endorsed by Zed. The landing
-page footer and the docs footer carry the same sentence. Keep it exact, and do
-not repeat it in the hero, tutorials or API pages, where the product is
-GPUI Kit.
+The footer is the one place the site states GPUI's origin, in one plain
+line: built on GPUI, from Zed Industries, also Apache-2.0. The landing page
+footer and the docs footer say the same thing. Do not repeat it in the hero,
+tutorials or API pages, where the product is GPUI Kit, and do not grow it into
+a disclaimer.

--- a/website/index.vue
+++ b/website/index.vue
@@ -353,7 +353,17 @@
             <strong>GPUI Kit</strong>
             <p>
                 {{ copy.footerPrefix }}
-                <a href="https://longbridge.com" target="_blank">Longbridge</a>.
+                <a href="https://longbridge.com" target="_blank">Longbridge</a
+                >{{ copy.footerSuffix }}
+            </p>
+            <!-- The one place the landing page names GPUI's origin. Kept
+                 exact rather than prominent: what GPUI is, who made it, and
+                 that GPUI Kit is neither Zed's project nor endorsed by Zed. -->
+            <p>
+                {{ copy.footerBuiltOn }}
+                <a href="https://github.com/zed-industries/zed" target="_blank"
+                    >GPUI</a
+                >{{ copy.footerAttribution }}
             </p>
         </div>
         <nav :aria-label="copy.footerNav">
@@ -610,6 +620,10 @@ const copy = computed(() =>
               principleDetail:
                   "gpui-base 处理困难的交互机制：焦点、浮层定位、虚拟化与无障碍；你的产品决定它们最终呈现的样子。",
               footerPrefix: "基于 Apache-2.0 许可证开源，由",
+              footerSuffix: " 开发。",
+              footerBuiltOn: "构建于",
+              footerAttribution:
+                  " 之上，GPUI 由 Zed Industries 创建并以 Apache-2.0 许可证发布。GPUI Kit 是独立项目，与 Zed Industries 没有隶属关系，也未获得其背书。",
               footerNav: "页脚导航",
               contributors: "贡献者",
               reportBug: "报告问题",
@@ -717,6 +731,10 @@ const copy = computed(() =>
                   "gpui-base handles the difficult interaction mechanics — focus, overlay positioning, virtualization and accessibility. Your product decides how they should look and feel.",
               footerPrefix:
                   "Open source under the Apache-2.0 License, developed by",
+              footerSuffix: ".",
+              footerBuiltOn: "Built on",
+              footerAttribution:
+                  ", the UI framework created by Zed Industries and released under Apache-2.0. GPUI Kit is an independent project and is not affiliated with or endorsed by Zed Industries.",
               footerNav: "Footer navigation",
               contributors: "Contributors",
               reportBug: "Report Bug",

--- a/website/index.vue
+++ b/website/index.vue
@@ -356,9 +356,7 @@
                 <a href="https://longbridge.com" target="_blank">Longbridge</a
                 >{{ copy.footerSuffix }}
             </p>
-            <!-- The one place the landing page names GPUI's origin. Kept
-                 exact rather than prominent: what GPUI is, who made it, and
-                 that GPUI Kit is neither Zed's project nor endorsed by Zed. -->
+            <!-- The one place the landing page names GPUI's origin. -->
             <p>
                 {{ copy.footerBuiltOn }}
                 <a href="https://github.com/zed-industries/zed" target="_blank"
@@ -622,8 +620,7 @@ const copy = computed(() =>
               footerPrefix: "基于 Apache-2.0 许可证开源，由",
               footerSuffix: " 开发。",
               footerBuiltOn: "构建于",
-              footerAttribution:
-                  " 之上，GPUI 由 Zed Industries 创建并以 Apache-2.0 许可证发布。GPUI Kit 是独立项目，与 Zed Industries 没有隶属关系，也未获得其背书。",
+              footerAttribution: " 之上，GPUI 来自 Zed Industries，同样采用 Apache-2.0。",
               footerNav: "页脚导航",
               contributors: "贡献者",
               reportBug: "报告问题",
@@ -734,7 +731,7 @@ const copy = computed(() =>
               footerSuffix: ".",
               footerBuiltOn: "Built on",
               footerAttribution:
-                  ", the UI framework created by Zed Industries and released under Apache-2.0. GPUI Kit is an independent project and is not affiliated with or endorsed by Zed Industries.",
+                  ", the UI framework from Zed Industries, also Apache-2.0.",
               footerNav: "Footer navigation",
               contributors: "Contributors",
               reportBug: "Report Bug",


### PR DESCRIPTION
## Description

The `gpui-pre-*` crates republish GPUI from Zed's `main`, so what is clean today is not guaranteed clean at the next snapshot: a new internal dependency can pull one of Zed's GPL-3.0-or-later application crates into the closure (`zlog` was exactly that, via `sum_tree → ztracing → zlog`, until Zed relicensed it), and a crates.io dependency can change its terms. Apache-2.0 §4 also asks a redistribution to keep the license text and copyright notices, hand on any NOTICE, and mark modified files.

The published 0.3.2 crates already meet §4: every one carries `license = "Apache-2.0"`, `repository` pointing at Zed, Zed's `LICENSE-APACHE` byte-for-byte, and the Zed commit in its description and `[package.metadata.gpui-pre]`. What was missing is anything that keeps it that way.

`script/bump-gpui.ts`:

- Staging fails unless a selected crate's `license` is `Apache-2.0` (following `license.workspace = true`), with a message naming the GPL crates as the reason.
- `carryLicenseFiles` puts Zed's `LICENSE-APACHE` beside every crate that lacks one and copies any root `NOTICE*` into every crate.
- The three files the script rewrites (`gpui/src/action.rs`, `gpui_macros/src/lib.rs`, `gpui_apple/build.rs`) and the module it adds start with `// Modified for gpui-pre (snapshot of zed@…): …`.
- A new step 4, "Auditing licenses", runs `cargo metadata` on the staged workspace and fails on any dependency whose every SPDX alternative is copyleft (GPL, AGPL, LGPL, SSPL, EUPL, OSL, CPAL, BUSL, CC-BY-SA), warning about crates that declare only a license file. It runs for `--stage-only` too.

`CONTRIBUTING.md` documents the guarantees. The docs footer, the landing page footer and both READMEs now name the origin in one plain line: built on GPUI, from Zed Industries, also Apache-2.0. `DESIGN.md` records that this line lives in the footer only and must not grow into a disclaimer. While there, the Chinese landing footer's "由 Longbridge." is finished as "由 Longbridge 开发。" and the icon credit reads "Icons by Lucide and Isocons." / "图标资源来自 Lucide 与 Isocons。" instead of "Icon resources are used Lucide, Isocons." in both languages.

## How to Test

```bash
bun script/bump-gpui.ts --self-test
bun script/bump-gpui.ts --stage-only --zed <zed checkout>
```

Against Zed `b1a7ef0` the run ends with `✓ 25 crates are Apache-2.0; 746 dependencies carry no copyleft license`, every staged crate has `LICENSE-APACHE`, and `crates/gpui/src/action.rs` starts with the modification line. Against `ce48461`, where `gpui_util` had no `license` yet, staging stops with the new message.

`bun run build` in `website/` and check the footer of `dist/docs/installation.html`, `dist/zh-CN/docs/installation.html` and `dist/index.html`.

Written with AI assistance (Claude Code): the audit step, the license propagation, and the attribution copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtHQQsTaKJSgR6SboZLxup

