### PR TITLE
chore: Let the doctests written for gpui-kit users compile

### DIFF
--- a/crates/component/src/highlighter/highlighter.rs
+++ b/crates/component/src/highlighter/highlighter.rs
@@ -1049,6 +1049,7 @@ impl SyntaxHighlighter {
     /// # Example
     ///
     /// ```no_run
+    /// # mod gpui_kit { pub extern crate gpui_component as component; }
     /// use gpui_kit::component::highlighter::{HighlightTheme, SyntaxHighlighter};
     /// use ropey::Rope;
     ///
@@ -1059,7 +1060,7 @@ impl SyntaxHighlighter {
     ///
     /// let theme = HighlightTheme::default_dark();
     /// let range = 0..code.len();
-    /// let styles = highlighter.styles(&range, &theme);
+    /// let styles = highlighter.styles(&range, &*theme);
     /// ```
     pub fn styles(
         &self,

--- a/crates/component/src/status_bar.rs
+++ b/crates/component/src/status_bar.rs
@@ -23,6 +23,7 @@ use crate::{ActiveTheme, StyledExt, h_flex};
 /// otherwise (only `right`, or neither — like a plain container).
 ///
 /// ```
+/// # mod gpui_kit { pub extern crate gpui_component as component; }
 /// use gpui_kit::component::status_bar::StatusBar;
 ///
 /// let _ = StatusBar::new().left("Ln 1, Col 1").right("UTF-8");

--- a/crates/component/src/title_bar.rs
+++ b/crates/component/src/title_bar.rs
@@ -70,6 +70,7 @@ impl TitleBar {
     /// [`crate::TitleBar`], so the title bar owns dragging and double clicking itself:
     ///
     /// ```no_run
+    /// # mod gpui_kit { pub use gpui::*; pub extern crate gpui_component as component; }
     /// # use gpui_kit::WindowOptions;
     /// # use gpui_kit::component::TitleBar;
     /// let options = WindowOptions {


### PR DESCRIPTION
## Description

`cargo test -p gpui-component --doc` fails on `main` since #2929 (macOS CI runs it; see the `Test (aarch64-apple-darwin)` job):

```text
error[E0433]: cannot find module or crate `gpui_kit` in this scope
  --> crates/component/src/status_bar.rs:26:5
```

The examples on `StatusBar` and `TitleBar::window_options` import through `gpui_kit`, which is what an application writes, but a doctest links only the crate under test and its dependencies, and gpui-component cannot depend on gpui-kit without a cycle.

Each example now opens with a hidden line that maps those paths onto the crates the doctest can see:

```rust
# mod gpui_kit { pub use gpui::*; pub extern crate gpui_component as component; }
use gpui_kit::component::TitleBar;
```

The rendered docs still show `gpui_kit::…`, as before. The same line goes on the `SyntaxHighlighter::styles` example, which is compiled only with the `tree-sitter` feature; that example also passed `&Arc<HighlightTheme>` where `styles` takes `&dyn HighlightStyleResolver`, so it is `&*theme` now.

## How to Test

```bash
cargo test -p gpui-component --doc
cargo test -p gpui-component --doc --features tree-sitter
```

Both pass locally: 2 and 3 doctests respectively, the rest ignored as before.

Written with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtHQQsTaKJSgR6SboZLxup
