### PR TITLE
chroe: Drop the unused reqwest_client dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,7 +3593,6 @@ dependencies = [
  "gpui-kit-assets",
  "gpui-pre",
  "gpui-pre-platform",
- "gpui-pre-reqwest-client",
  "gpui-pre-web",
 ]
 

--- a/crates/kit/Cargo.toml
+++ b/crates/kit/Cargo.toml
@@ -71,10 +71,6 @@ gpui-base.workspace = true
 gpui-component = { workspace = true, optional = true }
 gpui-kit-assets = { workspace = true, optional = true }
 
-# `reqwest_client` pulls in tokio's default runtime, which does not build on wasm.
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
-reqwest_client.workspace = true
-
 [target.'cfg(target_family = "wasm")'.dependencies]
 gpui_web.workspace = true
 


### PR DESCRIPTION
`gpui-kit` lists `reqwest_client` for every non-wasm target, but nothing in `crates/kit/src` refers to it and it is never re-exported, so no application can reach it either. What it does do is reach rustls through `gpui-pre-http-client-tls` with rustls' **default** features — and those select `aws-lc-rs`.

## Why it matters

As soon as an application pairs the kit with `gpui-shell` — the combination this crate's own docs recommend — the shell's HTTP and WebSocket clients bring in `ring`, so both providers are compiled in and rustls refuses to pick one:

| dependencies | `rustls` features |
| --- | --- |
| `gpui-shell` alone | `[ring, std, tls12]` |
| `gpui-shell` + `gpui-kit` | `[aws-lc-rs, aws_lc_rs, default, log, logging, prefer-post-quantum, ring, std, tls12]` |

The first `ClientConfig::builder()` a socket reaches then panics:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or
make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
```

In practice that lands in `tungstenite`'s TLS setup on a background thread, so the window comes up normally and the connection dies behind it — which makes the cause quite hard to see from the symptom.

## Why removing it is safe

Of the eighteen crates in this workspace that depend on `gpui-kit`, only two touch reqwest at all, and both already declare it themselves:

- `crates/story` — `reqwest_client.workspace = true`
- `examples/text_max_lines` — `reqwest_client.workspace = true`

`crates/base` declares it under `[dev-dependencies]`, which never reached a downstream build.

## Verification

Patched an application that depends on both `gpui-kit` and `gpui-shell` to this branch:

- `rustls` feature set becomes `[ring, std, tls12]`
- `cargo clean -p gpui-kit && cargo check -p gpui-kit` compiles
- the application's `cargo check --all-targets` passes

If the kit should offer an HTTP client, that seems worth doing deliberately — an optional feature plus a `pub use` — rather than through a dependency nothing can currently see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaPV68Vj5ibD9r4nyrMmzY