### PR TITLE
base: Stop auto scroll once the text selection gesture has ended

### DIFF
--- a/crates/base/src/text_selection.rs
+++ b/crates/base/src/text_selection.rs
@@ -1458,6 +1458,11 @@ impl WindowSelectionState {
         window: Option<&Window>,
         cx: &mut Context<Self>,
     ) {
+        // A finished gesture keeps its anchor for shift-click extension; only
+        // a live drag may scroll.
+        if !self.is_selecting {
+            return;
+        }
         let Some(anchor) = self.anchor.as_ref().filter(|anchor| anchor.inside) else {
             return;
         };
@@ -3138,6 +3143,29 @@ mod tests {
                     state.update_in_window(point(px(1.), px(50.)), window, cx);
                     assert!(!state.auto_scroll.is_active());
                     assert!(state.auto_scroll.last_drag_position.is_none());
+                });
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    fn pointer_moves_after_a_click_do_not_auto_scroll(cx: &mut TestAppContext) {
+        let window = cx.add_window(|_, cx| WindowSelectionView {
+            selection: TextSelectionHandle::new("unused", cx),
+        });
+        window
+            .update(cx, |_, window, cx| {
+                let state = cx.new(|_| WindowSelectionState::default());
+                let participant = FakeParticipant::new("participant", cx);
+                state.update(cx, |state, cx| {
+                    participant.register(state, 0., TextSelectionScopeId::default(), 0, cx);
+                    // A click on text keeps its anchor so shift-click can extend it.
+                    state.begin(point(px(1.), px(1.)), false, cx);
+                    state.end(cx);
+                    assert!(state.anchor.is_some());
+
+                    state.update_in_window(point(px(1.), px(50.)), window, cx);
+                    assert!(!state.auto_scroll.is_active());
                 });
             })
             .unwrap();


### PR DESCRIPTION
## Summary

- Fix markdown (and any other `TextView`) scrolling on its own after a single click: click on text, then move the pointer toward the top or bottom edge of the viewport, and the view starts auto scrolling and keeps going.
- Root cause: `WindowSelectionState::end()` keeps the anchor after mouse up so a shift-click can extend it, and only clears `is_selecting`. #2881 moved the auto scroll call out of `update_impl` (which has the `is_selecting` guard) into `update_in_window`, so `update_auto_scroll` ran on every pointer move with a live anchor. Once the pointer was in the edge zone it started the anchor auto scroll, and the synthesized `ScrollWheelEvent` re-entered the same path and kept it alive.
- Guard `update_auto_scroll` on `is_selecting`, restoring the pre-#2881 behavior: only a live drag may scroll.
- Add the regression test `pointer_moves_after_a_click_do_not_auto_scroll`: begin a gesture on text, end it, then drive `update_in_window` past the viewport edge and assert auto scroll stays idle.

The fix and the test were written with Claude Code.

## Test plan

- [x] `pointer_moves_after_a_click_do_not_auto_scroll` fails before the fix and passes after.
- [x] `cargo test -p gpui-base --lib text_selection` — all 49 tests pass.
- [x] `cargo test -p gpui-component --lib text::window_selection` — all 51 tests pass, including drag auto scroll in both directions.
- [x] `cargo clippy -p gpui-base --all-targets -- --deny warnings` and `cargo fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
