### PR TITLE
fps: Stop claiming the rate matches the platform overlay

### DIFF
--- a/crates/fps/src/lib.rs
+++ b/crates/fps/src/lib.rs
@@ -3,10 +3,19 @@
 //!
 //! Frame data comes from GPUI's own frame trace
 //! ([`gpui::FrameTimingCollector`]). The rate and the interval count frames
-//! *presented*, stamped with their own present time, so they agree with the
-//! platform's overlay (Metal's HUD counts the same drawables); the frame cost
-//! is what the framework actually spent in `Window::draw`, rather than an
+//! *presented*, stamped with their own present time; the frame cost is what
+//! the framework actually spent in `Window::draw`, rather than an
 //! approximation measured from the outside.
+//!
+//! Expect a lower rate here than the platform's overlay reports, and read it
+//! as a different measurement rather than a disagreement. GPUI presents only
+//! a frame it has drawn, so this is the rate the application produced. Metal's
+//! HUD, on a composited window, reports the rate that window reaches the
+//! display at -- on a 120 Hz panel a flat 120.00 at 8.33 ms, held there while
+//! the application hands it 58 new frames a second, and held there still while
+//! an idle retained-mode window hands it none. A rate below the display's is
+//! therefore not a dropped frame in itself; `FRAME` and `DROP` are what say
+//! whether the frames that were produced arrived on time.
 //!
 //! Render it wherever it should appear, guarded by your own flag:
 //!

--- a/crates/fps/src/sampler.rs
+++ b/crates/fps/src/sampler.rs
@@ -80,10 +80,16 @@ impl FrameSampler {
     /// Frames presented per second, over the frames still inside
     /// [`FPS_WINDOW`].
     ///
-    /// Presented, not drawn: it is the same count the platform's own overlay
-    /// keeps -- Metal's HUD counts drawables handed to the display -- so the
-    /// two agree on the figure. A drawn frame that was never presented did not
+    /// Presented, not drawn: a drawn frame that was never presented did not
     /// reach the screen and is not a frame the reader saw.
+    ///
+    /// This is not the figure the platform's own overlay shows, and it is not
+    /// meant to be. GPUI presents a frame only when it has drawn one, so this
+    /// counts what the application produced. Metal's HUD, on a composited
+    /// window, reports the rate the window reaches the display at, which is
+    /// the display's own: a 120 Hz panel reads a flat 120.00 at 8.33 ms while
+    /// the application hands it 58 new frames a second. Both are honest about
+    /// different things.
     ///
     /// `n` frames span `n - 1` intervals, so the rate is derived from the
     /// elapsed span rather than from the raw count; that keeps the readout


### PR DESCRIPTION
The module docs and `FrameSampler::fps` both said this readout is the same figure Metal's HUD keeps — "so the two agree on the figure". They do not agree, and someone who checks finds a number less than half the HUD's and reasonably concludes the HUD in this crate is broken. That is exactly what happened to a Longbridge Lite user, which is where this came from.

## What the numbers actually are

Measured side by side on a 120 Hz panel, with `MTL_HUD_ENABLED=1` and the application's own profiler counting `FrameEvent::Present` as an independent third opinion, all at the same instant:

| source | reading |
| --- | --- |
| Metal HUD | 120.00 fps, frame interval 8.33 ms |
| gpui-fps overlay | 58 fps, interval 17.2 ms |
| `FrameEvent::Present` count | 54 / 62 / **58** per second |

So this crate reports exactly what GPUI recorded — the sampler is correct. Feeding it a synthetic 8.61 ms cadence returns 116.13, matching a HUD reading from the same machine to the second decimal, so the arithmetic is right too.

The HUD's figure is the rate the *composited* window reaches the display at, which is the display's own: a flat 120.00 at exactly 8.33 ms (1/120), held there whether the application hands it 58 new frames a second or — with an idle retained-mode window — none at all. On a ProMotion panel that adapts, the same reading appears as 116.13 at 8.61 ms.

## What changed

Only the claim. The sampler already counts presents rather than draws, filters by window, stamps each frame with its own present time, and derives the rate from the span the frames cover rather than the raw count — all of which stays.

The docs now say which measurement this is, why it sits below the platform's, and that a rate below the display's refresh is not by itself a dropped frame — `FRAME` and `DROP` are what answer that.

`cargo test -p gpui-fps` — 24 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaPV68Vj5ibD9r4nyrMmzY