### PR TITLE
fps: Sustain frames by default, and stop grading the rate

### DIFF
--- a/crates/fps/src/monitor.rs
+++ b/crates/fps/src/monitor.rs
@@ -74,10 +74,6 @@ const UNIT_WIDTH: Pixels = px(22.);
 /// fast enough to feel live.
 const READOUT_INTERVAL: Duration = Duration::from_millis(500);
 
-/// Fraction of the target frame rate that still counts as meeting it. Vsync and
-/// the sampling window each cost a frame or so a second, so a 60Hz display that
-/// is keeping up perfectly reports 58 to 60, never a flat 60.
-
 /// A monospace family that ships with the platform, so the value column stays
 /// aligned without the application having to configure a font. The generic
 /// `monospace` alias is not resolvable by every platform's font backend, hence

--- a/crates/fps/src/monitor.rs
+++ b/crates/fps/src/monitor.rs
@@ -77,7 +77,6 @@ const READOUT_INTERVAL: Duration = Duration::from_millis(500);
 /// Fraction of the target frame rate that still counts as meeting it. Vsync and
 /// the sampling window each cost a frame or so a second, so a 60Hz display that
 /// is keeping up perfectly reports 58 to 60, never a flat 60.
-const FPS_TOLERANCE: f32 = 0.95;
 
 /// A monospace family that ships with the platform, so the value column stays
 /// aligned without the application having to configure a font. The generic
@@ -440,15 +439,14 @@ impl Render for FpsMonitor {
             dropped_percent: dropped,
             invalidations,
         } = self.readout;
-        // Continuous, the rate is the rate the window can sustain, and
-        // falling short of the target is the finding. Drawing on demand, the
-        // rate is how often something changed, and the platform's own overlay
-        // prints it plain -- so does this one.
-        let fps_color = if self.continuous {
-            fps_color(fps, budget, style)
-        } else {
-            style.foreground
-        };
+        // Printed plain, never graded. A rate falls for reasons that are not
+        // this application being slow: the window was occluded, or nothing
+        // changed, or the display asked for fewer frames. Colouring it turns
+        // every one of those into an alarm, and the alarm contradicts the rows
+        // underneath -- 25 in red above a FRAME of 10ms in green, which is a
+        // frame drawn in a third of its budget. What costs too much is a
+        // question about frames, and `FRAME`, `P95` and `DROP` answer it.
+        let fps_color = style.foreground;
         let resources = self.resources.filter(|_| self.show_resources);
         let compact = self.compact;
 
@@ -501,11 +499,11 @@ impl Render for FpsMonitor {
                         .child(reading(
                             "FRAME",
                             format!("{frame_millis:.1} ms"),
-                            // Graded against the budget, not against the frame
-                            // rate. An idle window draws a handful of frames a
-                            // second, so the headline goes red while every one
-                            // of those frames was in fact drawn well inside the
-                            // budget; this row is what says so.
+                            // Graded against the budget, and the first reading
+                            // in the HUD that is: the rate above says how often
+                            // frames happened, this says whether they were
+                            // affordable. It is the one to read when something
+                            // feels slow.
                             style.level_color(frame_millis / 1000., budget.as_secs_f32()),
                             style,
                         ))
@@ -583,29 +581,6 @@ impl Render for FpsMonitor {
                         })
                 }
             })
-    }
-}
-
-/// Grades the frame rate against the rate the budget implies.
-///
-/// This deliberately does not compare `1/fps` against the budget the way the
-/// per-frame trace does. Under vsync the measured rate lands just under the
-/// refresh rate essentially always — a 60Hz display reads 58 to 60, never
-/// exactly 60.00 — so an exact comparison would paint a perfectly healthy
-/// application as over budget. Anything within [`FPS_TOLERANCE`] of the target
-/// counts as meeting it.
-fn fps_color(fps: f32, budget: Duration, style: FpsStyle) -> Hsla {
-    if fps <= 0. {
-        return style.muted;
-    }
-
-    let target = 1. / budget.as_secs_f32();
-    if fps >= target * FPS_TOLERANCE {
-        style.good
-    } else if fps >= target * 0.5 {
-        style.warn
-    } else {
-        style.bad
     }
 }
 
@@ -696,25 +671,6 @@ mod tests {
             // the chart scaled for 60Hz frames.
             assert_eq!(monitor.axis_max, budget.as_secs_f32() * 2.);
         });
-    }
-
-    #[test]
-    fn a_display_keeping_up_is_never_graded_as_falling_behind() {
-        let style = FpsStyle::dark();
-        let budget = DEFAULT_FRAME_BUDGET;
-
-        // What a healthy 60Hz display actually reports.
-        for rate in [58., 59., 59.7, 60., 61.] {
-            assert_eq!(
-                fps_color(rate, budget, style),
-                style.good,
-                "{rate} fps should read as healthy on a 60Hz display"
-            );
-        }
-
-        assert_eq!(fps_color(45., budget, style), style.warn);
-        assert_eq!(fps_color(20., budget, style), style.bad);
-        assert_eq!(fps_color(0., budget, style), style.muted);
     }
 
     #[test]

--- a/crates/shell/src/materialize/components/fps.rs
+++ b/crates/shell/src/materialize/components/fps.rs
@@ -19,7 +19,9 @@ pub(in crate::materialize) fn fps_monitor(
 
     gpui_fps::fps_monitor(window, cx)
         .when_some(behavior.anchor, |monitor, anchor| monitor.anchor(anchor))
-        .continuous(behavior.continuous.unwrap_or(false))
+        .when_some(behavior.continuous, |monitor, continuous| {
+            monitor.continuous(continuous)
+        })
         .when_some(behavior.frame_budget, |monitor, budget| {
             monitor.frame_budget(budget)
         })

--- a/crates/shell/src/root.rs
+++ b/crates/shell/src/root.rs
@@ -159,9 +159,16 @@ pub struct ShellRoot {
 /// Where the performance HUD sits over the window and how it behaves.
 ///
 /// What a script's `show_fps_monitor(options)` names, with the same defaults
-/// `gpui_fps` gives an overlay a Rust host places by hand -- except
-/// `continuous`, which is off: a HUD a script switches on is there to watch
-/// the application's own frames, not to drive a redraw loop of its own.
+/// `gpui_fps` gives an overlay a Rust host places by hand.
+///
+/// Including `continuous`. A HUD that only observes counts how often the
+/// window had a reason to redraw, and in a retained-mode application that is
+/// demand rather than speed: it reads far below the platform's own overlay --
+/// 26-58 against Metal's 113-120 on the same window -- and the conclusion a
+/// reader draws is that the framework cannot hold a frame rate. Sustaining the
+/// frames is what makes the number mean "can hold", and the display's refresh
+/// rate bounds it for free. A script that wants the observing behaviour asks
+/// for `continuous: false`.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct FpsHudRequest {
     /// Corner or edge of the window.
@@ -177,7 +184,7 @@ impl Default for FpsHudRequest {
     fn default() -> Self {
         Self {
             anchor: Anchor::TopRight,
-            continuous: false,
+            continuous: true,
             frame_budget: None,
         }
     }

--- a/crates/shell/src/tests/snapshot.rs
+++ b/crates/shell/src/tests/snapshot.rs
@@ -255,27 +255,8 @@ fn shell_root_reuses_a_clean_views_materialized_subtree(cx: &mut TestAppContext)
 }
 
 #[gpui::test]
-fn shell_fps_monitor_does_not_drive_the_window_unless_requested(cx: &mut TestAppContext) {
+fn shell_fps_monitor_drives_the_window_by_default(cx: &mut TestAppContext) {
     let (_runtime, mut context, view) = script_view(cx, FPS_MONITOR);
-    context.update(|window, cx| {
-        window.replace_root(cx, |window, cx| {
-            crate::root::ShellRoot::new(view.clone().into(), window, cx)
-        })
-    });
-
-    context.update(|window, cx| window.draw(cx).clear(cx));
-    let requested = context.update(|window, cx| window.simulate_next_frame(cx));
-
-    assert_eq!(
-        requested, 0,
-        "the diagnostic HUD must observe application frames rather than create a redraw loop"
-    );
-}
-
-#[gpui::test]
-fn shell_fps_monitor_can_explicitly_drive_a_sustained_frame_test(cx: &mut TestAppContext) {
-    let source = FPS_MONITOR.replace("fps_monitor()", "fps_monitor().continuous(true)");
-    let (_runtime, mut context, view) = script_view(cx, &source);
     context.update(|window, cx| {
         window.replace_root(cx, |window, cx| {
             crate::root::ShellRoot::new(view.clone().into(), window, cx)
@@ -287,7 +268,26 @@ fn shell_fps_monitor_can_explicitly_drive_a_sustained_frame_test(cx: &mut TestAp
 
     assert!(
         requested > 0,
-        "continuous(true) must remain an explicit sustained-frame diagnostic mode"
+        "the HUD must sustain frames by default, so its rate is the one the window can hold"
+    );
+}
+
+#[gpui::test]
+fn shell_fps_monitor_can_be_asked_to_only_observe(cx: &mut TestAppContext) {
+    let source = FPS_MONITOR.replace("fps_monitor()", "fps_monitor().continuous(false)");
+    let (_runtime, mut context, view) = script_view(cx, &source);
+    context.update(|window, cx| {
+        window.replace_root(cx, |window, cx| {
+            crate::root::ShellRoot::new(view.clone().into(), window, cx)
+        })
+    });
+
+    context.update(|window, cx| window.draw(cx).clear(cx));
+    let requested = context.update(|window, cx| window.simulate_next_frame(cx));
+
+    assert_eq!(
+        requested, 0,
+        "continuous(false) must remain a way to watch the application's own frames"
     );
 }
 

--- a/crates/shell/src/typings.rs
+++ b/crates/shell/src/typings.rs
@@ -1814,7 +1814,10 @@ const ELEMENT_METHODS: &str = r#"    /**
      * edge is a preference rather than a promise.
      */
     anchor(value: Anchor): Element;
-    /** Whether an fps_monitor requests continuous whole-window redraws. Default false. */
+    /** Whether an fps_monitor requests continuous whole-window redraws, which is
+     * what makes its rate mean the one the window can hold rather than the one it
+     * happened to need. Default true; pass false to watch the application's own
+     * frames instead. */
     continuous(value: boolean): Element;
     /** Frame budget, in milliseconds, used by an fps_monitor's FRAME grading. */
     frame_budget(milliseconds: number): Element;


### PR DESCRIPTION
The HUD read **26–58** while Metal's overlay, on the same window at the same moment, read **113–120** — and then printed its own number in **red**. Read together those say a gpui-shell application cannot hold a frame rate. Neither was true.

## The rate

`gpui-fps` defaults `continuous` to `true` — the mode its own docs describe as making the readout "behave like an in-game FPS counter". The shell overrode that in two places:

- `FpsHudRequest::default()` (the `show_fps_monitor(options)` path)
- `behavior.continuous.unwrap_or(false)` in `materialize/components/fps.rs` — the `fps_monitor()` element path, which is the one scripts actually use

So the HUD went up over a window that still drew only when a quote arrived or a pointer moved. It was counting redraw *demand*, and demand is not speed. The element now leaves the default to `gpui-fps`, the way it already did for `anchor` and `frame_budget`.

Measured on a 60Hz panel, nothing else changed:

| | Metal HUD | this HUD |
| --- | --- | --- |
| FPS | 60.00 | 60 |
| frame interval | 16.67 ms | 16.6 ms |

The same figure from both — and it is the panel's refresh rate, not a ceiling this application struggled up to: 7.7 ms of work inside a 16.67 ms frame, `DROP 0.0%`. On the 120Hz panel it reads 120. Scripts that want the observing behaviour pass `continuous: false`.

## The colour

The rate is no longer graded; it prints in the foreground colour.

A rate falls for reasons that are not this application being slow — the window was occluded, nothing changed, the display asked for fewer frames. Colouring it turns every one of those into an alarm, and the alarm contradicts the rows underneath:

> `FPS 25` in red, above `FRAME 10.0 ms` and `P95 12.1 ms` and `DROP 0.0%` in green — a frame drawn in a third of its budget.

The code already knew this. `FRAME` carried a comment explaining that "the headline goes red while every one of those frames was in fact drawn well inside the budget; this row is what says so." Better not to make the claim than to explain it away: what costs too much is a question about frames, and `FRAME`, `P95` and `DROP` answer it in colour already.

`fps_color` and `FPS_TOLERANCE` go with it, along with the test that pinned the grading thresholds.

## Tests

`cargo test -p gpui-fps` — 23 pass. `cargo test -p gpui-shell fps` — 3 pass, with the two paired snapshot tests inverted to match the new default: the HUD sustains frames unless a script asks it not to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaPV68Vj5ibD9r4nyrMmzY