### PR TITLE
markdown: render hard line breaks instead of concatenating lines

### DIFF
--- a/crates/base/src/text/format/markdown.rs
+++ b/crates/base/src/text/format/markdown.rs
@@ -226,6 +226,13 @@ fn parse_paragraph(paragraph: &mut Paragraph, node: &mdast::Node, cx: &mut NodeC
                 ..Default::default()
             });
         }
+        Node::Break(_) => {
+            // Hard line break (trailing two spaces / backslash). Mirror the
+            // inline-HTML <br> path: emit a newline inline node so the break
+            // renders instead of silently concatenating adjacent lines.
+            text.push('\n');
+            paragraph.push(InlineNode::new("\n"));
+        }
         Node::InlineMath(raw) => {
             text = raw.value.clone();
             paragraph.push(

--- a/crates/base/src/text/format/markdown.rs
+++ b/crates/base/src/text/format/markdown.rs
@@ -600,6 +600,28 @@ mod tests {
         assert_eq!(image.height, None);
     }
 
+    /// A CommonMark hard break — two trailing spaces or a trailing backslash —
+    /// renders as a newline, instead of joining the two lines.
+    #[test]
+    fn test_hard_break_renders_newline() {
+        for source in [
+            "Owner: Jane  \nPersona: assistant",
+            "Owner: Jane\\\nPersona: assistant",
+        ] {
+            let mut cx = NodeContext::default();
+            let document = parse(source, &mut cx).unwrap();
+
+            let BlockNode::Paragraph(paragraph) = &document.blocks[0] else {
+                panic!("expected paragraph");
+            };
+
+            assert_eq!(paragraph.children.len(), 3, "source: {source:?}");
+            assert_eq!(paragraph.children[0].text.as_ref(), "Owner: Jane");
+            assert_eq!(paragraph.children[1].text.as_ref(), "\n");
+            assert_eq!(paragraph.children[2].text.as_ref(), "Persona: assistant");
+        }
+    }
+
     #[derive(Debug, Clone, PartialEq)]
     struct Ticker {
         symbol: String,


### PR DESCRIPTION
`parse_paragraph` has no arm for `Node::Break`, so a CommonMark hard break — two
trailing spaces or a backslash — is silently dropped and the adjacent lines are
joined.

## Reproduction

```markdown
Owner: Jane, ID: 338673110  
Persona: assistant
```

Renders as `…ID: 338673110Persona: assistant` on one line. Expected two lines.

Measured on a 3 874-note vault: hard breaks appear in the source of a meaningful
share of notes, and every one of them rendered wrong.

## Fix

Mirror the inline-HTML `<br>` path: emit a newline inline node for `Node::Break`.
Seven lines, `crates/base/src/text/format/markdown.rs` only.

Note this is a *hard* break fix. Soft breaks (a plain newline inside a `Text`
node) are a separate, opposite defect — they render as hard breaks — and are a
separate PR, since the two are distinguishable in `mdast` and should stay so.
