### PR TITLE
text: remeasure list items when a document is replaced with an equal block count

### DIFF
--- a/crates/base/src/text/state.rs
+++ b/crates/base/src/text/state.rs
@@ -162,6 +162,9 @@ impl TextViewState {
                                 state.parsed_content = content;
                                 state.parsed_error = None;
                                 state.compatible_layout_update = parsed_update.selection_compatible;
+                                if parsed_update.full_parse {
+                                    state.invalidate_measured_heights();
+                                }
                             }
                             Err(err) => {
                                 state.parsed_error = Some(err);
@@ -367,6 +370,28 @@ impl TextViewState {
         self.parsed_content.document.selected_text(format, blocks)
     }
 
+    /// Force a full re-measure of the block list after the document has been
+    /// replaced.
+    ///
+    /// `Document::render_root` only calls `ListState::reset` when the block
+    /// *count* changes, and the full-measure pass enabled by `measure_all` is
+    /// a one-shot latch that only `reset`, `remeasure_items`, or a width
+    /// change re-arms. Replacing a document with one that happens to have the
+    /// same number of blocks therefore leaves every cached height belonging to
+    /// the *previous* document. The list summary height stays wrong, and since
+    /// the wheel clamps against that summary, the blocks past the false bottom
+    /// can never scroll into view to be re-measured -- the clamp seals itself.
+    ///
+    /// `remeasure_items` re-arms the latch and marks the items unmeasured
+    /// while keeping their old sizes as hints, so the scrollbar does not
+    /// collapse in the frame before the next layout measures the real heights.
+    fn invalidate_measured_heights(&self) {
+        let count = self.list_state.item_count();
+        if count > 0 {
+            self.list_state.remeasure_items(0..count);
+        }
+    }
+
     fn increment_update(&mut self, text: &str, append: bool, cx: &mut Context<Self>) {
         self.revision += 1;
         if !append {
@@ -395,6 +420,7 @@ impl TextViewState {
                 Ok(content) => {
                     self.parsed_content = content;
                     self.parsed_error = None;
+                    self.invalidate_measured_heights();
                     if !self.is_selecting {
                         self.reset_selection_and_adapter(cx);
                     }

--- a/crates/base/src/text/text_view.rs
+++ b/crates/base/src/text/text_view.rs
@@ -751,6 +751,92 @@ mod tests {
         text_view: Entity<TextViewState>,
     }
 
+    /// A scrollable viewport, so the list has a bounded height to measure
+    /// against and `max_offset_for_scrollbar` reports a real scroll extent.
+    struct ScrollExtentTestRoot {
+        text_view: Entity<TextViewState>,
+    }
+
+    impl Render for ScrollExtentTestRoot {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .w(px(400.))
+                .h(px(200.))
+                .overflow_hidden()
+                .child(TextView::new(&self.text_view).scrollable(true))
+        }
+    }
+
+    /// `count` paragraphs, each `words` words long, so two documents can share
+    /// a block count while differing wildly in height.
+    fn document_of(count: usize, words: usize) -> String {
+        (1..=count)
+            .map(|i| format!("Block {i}: {}", "lorem ipsum dolor ".repeat(words)))
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
+
+    /// Replacing a document with one that happens to have the *same* block
+    /// count must still re-measure. `Document::render_root` only resets the
+    /// list when the count changes, so without an explicit re-measure every
+    /// cached height stays with the previous document and the scroll extent
+    /// keeps describing it.
+    #[gpui::test]
+    fn replacing_a_document_with_an_equal_block_count_remeasures(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+
+        const BLOCKS: usize = 24;
+        let short = document_of(BLOCKS, 1);
+        let tall = document_of(BLOCKS, 60);
+
+        let (root, cx) = cx.add_window_view(|_, cx| ScrollExtentTestRoot {
+            text_view: cx.new(|cx| TextViewState::markdown(&short, cx)),
+        });
+        let cx: &mut VisualTestContext = cx;
+
+        // The list is populated and measured during layout, so every
+        // assertion below has to follow a real frame.
+        let settle = |cx: &mut VisualTestContext| {
+            cx.run_until_parked();
+            cx.update(|window, cx| window.draw(cx).clear(cx));
+            cx.run_until_parked();
+        };
+        settle(cx);
+
+        let scroll_extent = |cx: &mut VisualTestContext| {
+            root.read_with(cx, |root, cx| {
+                root.text_view
+                    .read(cx)
+                    .list_state()
+                    .max_offset_for_scrollbar()
+                    .y
+            })
+        };
+
+        let short_extent = scroll_extent(cx);
+
+        root.update(cx, |root, cx| {
+            root.text_view
+                .update(cx, |state, cx| state.set_text(&tall, cx));
+        });
+        settle(cx);
+
+        root.read_with(cx, |root, cx| {
+            assert_eq!(
+                root.text_view.read(cx).list_state().item_count(),
+                BLOCKS,
+                "the replacement must keep the block count, or the list resets and the bug cannot occur"
+            );
+        });
+
+        let tall_extent = scroll_extent(cx);
+        assert!(
+            tall_extent > short_extent * 5.,
+            "a much taller document must grow the scroll extent, but it went from \
+             {short_extent:?} to {tall_extent:?}"
+        );
+    }
+
     struct StatelessMarkdownRoot {
         renders: Arc<AtomicUsize>,
     }


### PR DESCRIPTION
`Document::render_root` only calls `ListState::reset` when the block *count*
changes. The full-measure pass enabled by `measure_all` is a one-shot latch that
only `reset`, `remeasure_items`, or a width change re-arms. So replacing a
document with one that happens to have the same number of blocks leaves every
cached height belonging to the *previous* document.

The list summary height stays wrong, and since the wheel clamps against that
summary, the blocks past the false bottom can never scroll into view to be
re-measured. The clamp seals itself.

## Reproduction (deterministic)

1. Open a document with 96 short blocks (e.g. 96 one-line paragraphs).
   `max_off` ≈ 3 024 px.
2. Replace it with a document that also has 96 blocks but is 132 KB long.
3. `max_off` is now ≈ 3 503 px instead of the true ≈ 21 314 px. Wheel-scrolling
   stops at 16 % of the document. Resizing the window "fixes" it, because a
   width change re-arms the latch — which is why this is hard to notice
   interactively.

## Fix

Call `remeasure_items(0..count)` at the two places `parsed_content` is replaced
(sync and async full-parse paths). `remeasure_items` re-arms the latch and marks
items unmeasured while keeping the old sizes as hints, so the scrollbar does not
collapse for a frame.

Placement matters: hooking `increment_update` instead races on the async path —
a prepaint can land between the invalidation and the arrival of the new blocks
and re-latch against the old content. Both hooks sit at the exact instant
`parsed_content` is replaced; the async one is gated on `full_parse` so streaming
appends are unaffected.

Verified: the same repro after the fix ends at `max_off = 21 314`, the true
height, and a 500-tick wheel sweep reaches the final block. No gpui core change;
`crates/base/src/text/state.rs` only, +25 lines.
