### PR TITLE
editor: Reveal search match after manual scroll

### DIFF
--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -38,6 +38,12 @@ use crate::input::{
 };
 use crate::{AutoScroll, StepAction};
 
+/// Vertical clearance to retain when revealing a text position.
+pub(crate) enum ScrollPadding {
+    Minimal,
+    SurroundingLines,
+}
+
 #[derive(Action, Clone, PartialEq, Eq, Deserialize)]
 #[action(namespace = input, no_json)]
 pub struct Enter {
@@ -1874,7 +1880,12 @@ impl<M: InputModeKind> InputBaseState<M> {
         direction: Option<MoveDirection>,
         cx: &mut Context<Self>,
     ) {
-        self.scroll_to_with_padding(offset, direction, direction.is_some(), cx);
+        let padding = if direction.is_some() {
+            ScrollPadding::SurroundingLines
+        } else {
+            ScrollPadding::Minimal
+        };
+        self.scroll_to_with_padding(offset, direction, padding, cx);
     }
 
     /// Reveal an offset with independently chosen direction restriction and padding.
@@ -1883,7 +1894,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         &mut self,
         offset: usize,
         direction: Option<MoveDirection>,
-        use_surrounding_lines: bool,
+        padding: ScrollPadding,
         cx: &mut Context<Self>,
     ) {
         let Some(last_layout) = self.last_layout.as_ref() else {
@@ -1933,16 +1944,17 @@ impl<M: InputModeKind> InputBaseState<M> {
         // `TextElement::layout_cursor` so both scroll-into-view paths agree
         // (a mismatch flickered on `Down` at end-of-buffer with a small
         // `cursor_surrounding_lines` override).
-        let edge_height = if use_surrounding_lines && self.is_code_editor() {
-            super::element::cursor_surrounding_padding(
-                self.mode.is_auto_grow(),
-                self.cursor_surrounding_lines,
-                last_layout.visible_range.len(),
-                line_height,
-            )
-        } else {
-            line_height
-        };
+        let edge_height =
+            if matches!(padding, ScrollPadding::SurroundingLines) && self.is_code_editor() {
+                super::element::cursor_surrounding_padding(
+                    self.mode.is_auto_grow(),
+                    self.cursor_surrounding_lines,
+                    last_layout.visible_range.len(),
+                    line_height,
+                )
+            } else {
+                line_height
+            };
         if row_offset_y - edge_height + line_height < -scroll_offset.y {
             // Scroll up
             scroll_offset.y = -row_offset_y + edge_height - line_height;

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -1874,6 +1874,18 @@ impl<M: InputModeKind> InputBaseState<M> {
         direction: Option<MoveDirection>,
         cx: &mut Context<Self>,
     ) {
+        self.scroll_to_with_padding(offset, direction, direction.is_some(), cx);
+    }
+
+    /// Reveal an offset with independently chosen direction restriction and padding.
+    /// Search uses surrounding lines without restricting movement to match order.
+    pub(crate) fn scroll_to_with_padding(
+        &mut self,
+        offset: usize,
+        direction: Option<MoveDirection>,
+        use_surrounding_lines: bool,
+        cx: &mut Context<Self>,
+    ) {
         let Some(last_layout) = self.last_layout.as_ref() else {
             return;
         };
@@ -1921,7 +1933,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         // `TextElement::layout_cursor` so both scroll-into-view paths agree
         // (a mismatch flickered on `Down` at end-of-buffer with a small
         // `cursor_surrounding_lines` override).
-        let edge_height = if direction.is_some() && self.is_code_editor() {
+        let edge_height = if use_surrounding_lines && self.is_code_editor() {
             super::element::cursor_surrounding_padding(
                 self.mode.is_auto_grow(),
                 self.cursor_surrounding_lines,
@@ -3454,16 +3466,28 @@ mod tests {
         });
     }
 
-    /// Search navigation must reveal the selected match even when the user has
-    /// manually scrolled the viewport past it.
     #[gpui::test]
-    fn test_next_search_match_scrolls_back_to_match_after_manual_scroll(cx: &mut TestAppContext) {
+    fn test_next_search_match_reveals_with_padding_after_manual_scroll(cx: &mut TestAppContext) {
+        assert_search_reveals_with_padding_after_manual_scroll(false, cx);
+    }
+
+    #[gpui::test]
+    fn test_previous_search_match_reveals_with_padding_after_manual_scroll(
+        cx: &mut TestAppContext,
+    ) {
+        assert_search_reveals_with_padding_after_manual_scroll(true, cx);
+    }
+
+    fn assert_search_reveals_with_padding_after_manual_scroll(
+        previous: bool,
+        cx: &mut TestAppContext,
+    ) {
         let input_view = InputView::new(cx);
         let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
         let input = input_view.input;
-        let text = (0..80)
+        let text = (0..160)
             .map(|row| {
-                if matches!(row, 0 | 4 | 70) {
+                if matches!(row, 20 | 60 | 100) {
                     format!("match on row {row}")
                 } else {
                     format!("line {row}")
@@ -3471,45 +3495,58 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n");
-        let second_match_start = text.match_indices("match").nth(1).unwrap().0;
-        let second_match = second_match_start..second_match_start + "match".len();
-
+        let start = text.match_indices("match").nth(1).unwrap().0;
+        let expected_match = start..start + "match".len();
         cx.update(|window, cx| {
             input.update(cx, |state, cx| {
+                state.set_cursor_surrounding_lines(Some(3), window, cx);
                 state.set_value(text, window, cx);
                 state.set_search_query("match", true, cx);
+                if previous {
+                    state.search_session.matcher.next();
+                    state.search_session.matcher.next();
+                }
             });
         });
         cx.run_until_parked();
-
         cx.update(|_, cx| {
             input.update(cx, |state, cx| {
-                state.set_scroll_offset(point(px(0.), px(-1_000.)), cx);
+                let line_height = state.last_layout.as_ref().unwrap().line_height;
+                let y = if previous { px(0.) } else { -line_height * 80. };
+                state.set_scroll_offset(point(px(0.), y), cx);
             });
         });
         cx.run_until_parked();
         input.read_with(&cx, |state, _| {
-            assert!(
-                state
-                    .visible_row_range()
-                    .is_some_and(|visible| visible.start > 4),
-                "manual scroll should move the second match above the viewport"
-            );
+            let visible = state.visible_row_range().unwrap();
+            if previous {
+                assert!(visible.end <= 60, "target must be below the viewport");
+            } else {
+                assert!(visible.start > 60, "target must be above the viewport");
+            }
         });
-
         cx.update(|_, cx| {
             input.update(cx, |state, cx| {
-                assert_eq!(state.next_search_match(cx), Some(second_match));
+                let range = if previous {
+                    state.previous_search_match(cx)
+                } else {
+                    state.next_search_match(cx)
+                };
+                assert_eq!(range, Some(expected_match));
+                assert_eq!(state.search_session.matcher.label(), "2/3");
             });
         });
         cx.run_until_parked();
-
         input.read_with(&cx, |state, _| {
+            assert!(state.visible_row_range().unwrap().contains(&60));
+            let line_height = state.last_layout.as_ref().unwrap().line_height;
+            let target_y = line_height * 60. + state.scroll_handle.offset().y;
+            // Three lines of edge clearance include the matched line itself.
+            assert!(target_y >= line_height * 2. - px(0.1));
             assert!(
-                state
-                    .visible_row_range()
-                    .is_some_and(|visible| visible.contains(&4)),
-                "the newly active match should be visible after navigation"
+                target_y + line_height * 3.
+                    <= state.last_bounds.as_ref().unwrap().size.height + px(0.1),
+                "search must preserve the configured surrounding-line padding"
             );
         });
     }

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -3454,6 +3454,66 @@ mod tests {
         });
     }
 
+    /// Search navigation must reveal the selected match even when the user has
+    /// manually scrolled the viewport past it.
+    #[gpui::test]
+    fn test_next_search_match_scrolls_back_to_match_after_manual_scroll(cx: &mut TestAppContext) {
+        let input_view = InputView::new(cx);
+        let mut cx = VisualTestContext::from_window(input_view.window_handle.into(), cx);
+        let input = input_view.input;
+        let text = (0..80)
+            .map(|row| {
+                if matches!(row, 0 | 4 | 70) {
+                    format!("match on row {row}")
+                } else {
+                    format!("line {row}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let second_match_start = text.match_indices("match").nth(1).unwrap().0;
+        let second_match = second_match_start..second_match_start + "match".len();
+
+        cx.update(|window, cx| {
+            input.update(cx, |state, cx| {
+                state.set_value(text, window, cx);
+                state.set_search_query("match", true, cx);
+            });
+        });
+        cx.run_until_parked();
+
+        cx.update(|_, cx| {
+            input.update(cx, |state, cx| {
+                state.set_scroll_offset(point(px(0.), px(-1_000.)), cx);
+            });
+        });
+        cx.run_until_parked();
+        input.read_with(&cx, |state, _| {
+            assert!(
+                state
+                    .visible_row_range()
+                    .is_some_and(|visible| visible.start > 4),
+                "manual scroll should move the second match above the viewport"
+            );
+        });
+
+        cx.update(|_, cx| {
+            input.update(cx, |state, cx| {
+                assert_eq!(state.next_search_match(cx), Some(second_match));
+            });
+        });
+        cx.run_until_parked();
+
+        input.read_with(&cx, |state, _| {
+            assert!(
+                state
+                    .visible_row_range()
+                    .is_some_and(|visible| visible.contains(&4)),
+                "the newly active match should be visible after navigation"
+            );
+        });
+    }
+
     #[gpui::test]
     fn test_number_step(cx: &mut TestAppContext) {
         let input = InputView::build(cx, |state| state).input;

--- a/crates/base/src/input/editor/search.rs
+++ b/crates/base/src/input/editor/search.rs
@@ -142,7 +142,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         let range = self.search_session.matcher.next()?;
         // Match order does not describe viewport direction after a manual
         // scroll. Always allow search navigation to reveal the active match.
-        self.scroll_to(range.end, None, cx);
+        self.scroll_to_with_padding(range.end, None, true, cx);
         Some(range)
     }
 
@@ -150,7 +150,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         let range = self.search_session.matcher.next_back()?;
         // Match order does not describe viewport direction after a manual
         // scroll. Always allow search navigation to reveal the active match.
-        self.scroll_to(range.start, None, cx);
+        self.scroll_to_with_padding(range.start, None, true, cx);
         Some(range)
     }
 

--- a/crates/base/src/input/editor/search.rs
+++ b/crates/base/src/input/editor/search.rs
@@ -139,20 +139,18 @@ impl<M: InputModeKind> InputBaseState<M> {
     }
 
     pub fn next_search_match(&mut self, cx: &mut Context<Self>) -> Option<Range<usize>> {
-        let previous = self.search_session.matcher.current_match_index();
         let range = self.search_session.matcher.next()?;
-        let direction = (self.search_session.matcher.current_match_index() > previous)
-            .then_some(MoveDirection::Down);
-        self.scroll_to(range.end, direction, cx);
+        // Match order does not describe viewport direction after a manual
+        // scroll. Always allow search navigation to reveal the active match.
+        self.scroll_to(range.end, None, cx);
         Some(range)
     }
 
     pub fn previous_search_match(&mut self, cx: &mut Context<Self>) -> Option<Range<usize>> {
-        let previous = self.search_session.matcher.current_match_index();
         let range = self.search_session.matcher.next_back()?;
-        let direction = (self.search_session.matcher.current_match_index() < previous)
-            .then_some(MoveDirection::Up);
-        self.scroll_to(range.start, direction, cx);
+        // Match order does not describe viewport direction after a manual
+        // scroll. Always allow search navigation to reveal the active match.
+        self.scroll_to(range.start, None, cx);
         Some(range)
     }
 

--- a/crates/base/src/input/editor/search.rs
+++ b/crates/base/src/input/editor/search.rs
@@ -4,7 +4,9 @@ use gpui::{Context, Window};
 use ropey::Rope;
 use std::{ops::Range, rc::Rc};
 
-use super::{InputBaseState, Replace, RopeExt as _, Search, movement::MoveDirection};
+use super::{
+    InputBaseState, Replace, RopeExt as _, Search, movement::MoveDirection, state::ScrollPadding,
+};
 
 /// Stateful, presentation-independent search engine used by text inputs.
 #[derive(Debug, Clone)]
@@ -142,7 +144,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         let range = self.search_session.matcher.next()?;
         // Match order does not describe viewport direction after a manual
         // scroll. Always allow search navigation to reveal the active match.
-        self.scroll_to_with_padding(range.end, None, true, cx);
+        self.scroll_to_with_padding(range.end, None, ScrollPadding::SurroundingLines, cx);
         Some(range)
     }
 
@@ -150,7 +152,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         let range = self.search_session.matcher.next_back()?;
         // Match order does not describe viewport direction after a manual
         // scroll. Always allow search navigation to reveal the active match.
-        self.scroll_to_with_padding(range.start, None, true, cx);
+        self.scroll_to_with_padding(range.start, None, ScrollPadding::SurroundingLines, cx);
         Some(range)
     }
 


### PR DESCRIPTION
## Description

Fix Next/Previous advancing the search counter without revealing the match after manual scrolling. Search navigation now scrolls in either direction while preserving configured surrounding-line padding; cursor navigation keeps its existing direction restrictions.

## Screenshot

Before

https://github.com/user-attachments/assets/d71cc59a-5b62-4dd7-a837-5380b2ee2395

After

https://github.com/user-attachments/assets/2f43770a-edf7-4dbd-9188-e68b3a32efe9

## Validation

- Added regression tests for Next scrolling upward and Previous scrolling downward, including surrounding-line padding.
- `cargo test -p gpui-base input:: --lib --offline` — 152 tests passed locally.

AI assistance: Codex generated the implementation and regression tests.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [ ] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [x] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific) — Not applicable; the search navigation fix is platform-independent.
