### PR TITLE
website: Fix Showcase lockfile installation in docs releases

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.6
+          bun-version: 1.4.0
 
       - name: Install Showcase validation and rendering dependencies
         working-directory: .showcases


### PR DESCRIPTION
The documentation release installs the Showcase catalog dependencies with a frozen lockfile. Bun 1.3.6 rejects its lockfile version 2, stopping publication before the website build.

Use Bun 1.4.0 to match the catalog workflow and lockfile generator. Frozen installation succeeds locally, and the matching runtime passed dependency installation in longbridge/gpui-kit-showcases#1.
