### PR TITLE
Require PNG images for App Stories previews

### DIFF
--- a/website/src/lib/showcases.ts
+++ b/website/src/lib/showcases.ts
@@ -37,12 +37,13 @@ export async function loadShowcases(root, revision) {
     if (manifest.building !== undefined && typeof manifest.building !== 'boolean') fail('building must be a boolean');
     if (!Array.isArray(manifest.previews) || !manifest.previews.length) fail('at least one preview is required');
     for (const name of manifest.previews) {
-      if (typeof name !== 'string' || !/^preview\d*\.(png|jpe?g|webp)$/i.test(name)) fail('invalid preview filename');
+      if (typeof name !== 'string' || !/^preview\d*\.(png|jpe?g|webp|avif)$/i.test(name)) fail('invalid preview filename');
       const path = await realpath(join(dir, name));
       if (!path.startsWith(await realpath(dir) + sep)) fail('preview must stay inside the app folder');
       const bytes = await readFile(path);
       const valid = /\.png$/i.test(name) ? bytes.subarray(0, 8).equals(Buffer.from('89504e470d0a1a0a', 'hex'))
         : /\.jpe?g$/i.test(name) ? bytes[0] === 255 && bytes[1] === 216
+        : /\.avif$/i.test(name) ? bytes.length >= 16 && bytes.readUInt32BE(0) >= 16 && bytes.readUInt32BE(0) <= bytes.length && bytes.toString('ascii', 4, 8) === 'ftyp' && ['avif', 'avis'].includes(bytes.toString('ascii', 8, 12))
         : bytes.toString('ascii', 0, 4) === 'RIFF' && bytes.toString('ascii', 8, 12) === 'WEBP';
       if (!valid) fail(`invalid image format: ${name}`);
     }

--- a/website/tests/showcases.test.ts
+++ b/website/tests/showcases.test.ts
@@ -41,6 +41,16 @@ test('rejects missing screenshots instead of publishing a broken page', async t 
   await app(root, 'broken', { previews: ['preview1.png'] });
   await assert.rejects(loadShowcases(root, revision), /preview1.png/);
 });
+test('loads AVIF previews while verifying their format', async t => {
+  const root = await fixture(t);
+  await app(root, 'avif-app', { previews: ['preview0.avif'] });
+  const path = join(root, 'apps/avif-app/preview0.avif');
+  await writeFile(path, Buffer.from('0000001c6674797061766966000000006d696631617669666d696166', 'hex'));
+  const [result] = await loadShowcases(root, revision);
+  assert(result.image.endsWith('/preview0.avif'));
+  await writeFile(path, Buffer.from('89504e470d0a1a0a', 'hex'));
+  await assert.rejects(loadShowcases(root, revision), /image format/);
+});
 
 test('rejects unsafe links, paths and missing descriptions', async t => {
   for (const extra of [{ website: 'javascript:alert(1)' }, { previews: ['../outside.png'] }, { description: '' }]) {


### PR DESCRIPTION
Require PNG filenames and PNG file signatures for App Stories previews, matching the catalog image policy. Reject other formats and mislabeled files. No image conversion code is included.

Merge longbridge/gpui-kit-showcases#5 first, which migrates existing images to PNG.

Validation: App Stories tests passed, including non-PNG rejection and signature checks.
