### PR TITLE
website: Refine App Stories layout and browsing

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - "website/**"
+      - ".github/workflows/test-docs.yml"
       - "crates/base/**"
       - "crates/story-web/**"
 
@@ -12,9 +13,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Checkout latest approved showcases
+        uses: actions/checkout@v4
+        with:
+          repository: longbridge/gpui-kit-showcases
+          ref: main
+          path: .showcases
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.6
+          bun-version: 1.4.0
+      - name: Install Showcase validation and rendering dependencies
+        working-directory: .showcases
+        run: bun install --frozen-lockfile
       - name: Install
         working-directory: website
         run: bun install
@@ -22,5 +33,8 @@ jobs:
         working-directory: website
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHOWCASES_DIR: ${{ github.workspace }}/.showcases
         run: |
+          bun run test:showcases
           bun run build
+          bun run test:seo

--- a/website/DESIGN.md
+++ b/website/DESIGN.md
@@ -241,16 +241,32 @@ apps through PRs in [longbridge/gpui-kit-showcases](https://github.com/longbridg
   to the Vue app; no duplicated hard-coded app list.
 - **Screenshots show the complete window.** Authors must preserve all four corners
   and edges in a clear, tidy capture. Images are archived unchanged and referenced
-  using raw GitHub URLs pinned to the checked-out commit. Cards use a shared 16:10
-  area with `object-fit: contain`, retaining the whole image. Do not wrap them in
+  using raw GitHub URLs pinned to the checked-out commit. Cards use a shared 16:9
+  area with `object-fit: cover` and top-center positioning, filling the card edge
+  to edge. The archived image remains unchanged; previews may crop the bottom
+  or sides. Do not wrap them in
   `.mac-window` or add a second title bar.
 - **Featured is editorial.** Maintainers list app IDs in the catalog's root
   `featured.json` using project history, implementation, completeness, and quality.
   The array defines both selection and display order; app manifests have no
-  `featured` field. Featured apps appear first. Other apps
-  appear in a separate group sortable by first inclusion time or GitHub Stars.
-  Search and category filters apply to both groups. Failed or unavailable star
+  `featured` field. Featured apps appear first, six per page, and keep their editorial order.
+  The heading shows the total selection count; pagination remains independent
+  of All apps filters.
+  All apps includes the entire catalog, including Featured, with nine apps per page.
+  Search, category, and sort changes return to page one. Its search, category
+  filters, and sorting controls live below the All apps heading and only affect
+  that section. Use the site’s neutral tokens and control radii for a compact,
+  thin-bordered search/filter panel, with counts at the trailing section edge.
+  The section and controls remain visible when no apps match. Failed or unavailable star
   counts remain unknown and sort after known counts, never as invented zeroes.
+- **Card hierarchy.** Use image, name and author, description, platform/date row,
+  then a shared footer. Development status belongs beside the identity. Platform
+  text is unboxed on the left; dates use `YYYY/MM/DD` on the right. In the footer,
+  Commercial precedes the Lucide Star and compact count on the left. Globe and
+  GitHub icon links sit on the right with accessible names and tooltips. Do not
+  add an Open source label, Stars suffix, or Read story row; the image opens
+  available story details. Keep footer centers and colors aligned, and absorb
+  unequal description length before metadata so cards align within each row.
 - **Metadata freshness.** `publishedAt` records first inclusion in App Stories,
   not the application's original release date, and remains unchanged for updates.
   GitHub Stars are refreshed in the Showcase repository after merges and weekly,
@@ -261,7 +277,8 @@ apps through PRs in [longbridge/gpui-kit-showcases](https://github.com/longbridg
   route. The catalog’s shared Bun validator and renderer enforce the 10 KB limit,
   official-link allowlist, local media and product-only content rules. The catalog
   checkout’s locked dependencies must be installed before building.
-- **Review before publication.** Explain before the list that every merged app PR is listed, Featured is not
+- **Review before publication.** Keep a labeled selection-policy disclosure before
+  the list explaining that every merged app PR is listed, Featured is not
   guaranteed, and maintainers adjust Featured as apps evolve.
   The submission CTA links to the repository's PR instructions.
 - **Automatic publishing.** On approved changes merged to Showcase `main`, its

--- a/website/package.json
+++ b/website/package.json
@@ -3,12 +3,12 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "bun --bun astro dev",
-    "build": "bun --bun astro build && bunx pagefind --site dist",
+    "dev": "bunx --bun astro dev",
+    "build": "bunx --bun astro build && bunx pagefind --site dist",
     "test:showcases": "bun test tests/showcases.test.ts tests/showcase-browser.test.ts",
     "test:seo": "bun test tests/seo.test.ts",
-    "preview": "bun --bun astro preview",
-    "astro": "bun --bun astro"
+    "preview": "bunx --bun astro preview",
+    "astro": "bunx --bun astro"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.3.0",

--- a/website/src/components/AppSortSelect.vue
+++ b/website/src/components/AppSortSelect.vue
@@ -1,0 +1,142 @@
+<template>
+    <div ref="root" class="app-sort" @focusout="onFocusOut">
+        <span :id="`${id}-label`" class="app-sort__label">{{ label }}</span>
+        <div class="app-sort__control">
+            <button
+                ref="trigger"
+                class="app-sort__trigger"
+                type="button"
+                aria-haspopup="listbox"
+                :aria-expanded="open"
+                :aria-controls="`${id}-options`"
+                :aria-labelledby="`${id}-label ${id}-value`"
+                @click="open ? close() : show()"
+                @keydown="onTriggerKey"
+            >
+                <span :id="`${id}-value`">{{ selectedLabel }}</span>
+                <ChevronDown aria-hidden="true" />
+            </button>
+            <div
+                v-if="open"
+                :id="`${id}-options`"
+                ref="listbox"
+                class="app-sort__options"
+                :data-side="opensAbove ? 'top' : 'bottom'"
+                role="listbox"
+                tabindex="-1"
+                :aria-labelledby="`${id}-label`"
+                :aria-activedescendant="`${id}-option-${activeIndex}`"
+                @keydown="onListKey"
+            >
+                <div
+                    v-for="(option, index) in options"
+                    :id="`${id}-option-${index}`"
+                    :key="option.value"
+                    class="app-sort__option"
+                    role="option"
+                    :aria-selected="option.value === modelValue"
+                    :data-active="index === activeIndex"
+                    @pointermove="activeIndex = index"
+                    @pointerdown.prevent
+                    @click="choose(index)"
+                >
+                    <Check :class="{ 'app-sort__check--hidden': option.value !== modelValue }" aria-hidden="true" />
+                    {{ option.label }}
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref } from "vue";
+import { Check, ChevronDown } from "lucide-vue-next";
+
+const props = defineProps<{
+    id: string;
+    label: string;
+    modelValue: string;
+    options: { value: string; label: string }[];
+}>();
+const emit = defineEmits<{ "update:modelValue": [value: string] }>();
+const root = ref<HTMLElement>();
+const trigger = ref<HTMLButtonElement>();
+const listbox = ref<HTMLElement>();
+const open = ref(false);
+const opensAbove = ref(false);
+const activeIndex = ref(0);
+const selectedLabel = computed(() => props.options.find(option => option.value === props.modelValue)?.label ?? "");
+
+async function show(index = props.options.findIndex(option => option.value === props.modelValue)) {
+    if (!props.options.length) return;
+    activeIndex.value = Math.max(0, index);
+    const bounds = trigger.value?.getBoundingClientRect();
+    // Match the relative row geometry when deciding which viewport edge has room.
+    const rem = parseFloat(getComputedStyle(document.documentElement).fontSize);
+    const menuHeight = (props.options.length * 2 + 0.75) * rem;
+    opensAbove.value = !!bounds && innerHeight - bounds.bottom < menuHeight && bounds.top > menuHeight;
+    open.value = true;
+    await nextTick();
+    if (open.value) listbox.value?.focus();
+}
+function close(restoreFocus = false) {
+    open.value = false;
+    if (restoreFocus) trigger.value?.focus();
+}
+function choose(index: number) {
+    const option = props.options[index];
+    if (!option) return;
+    emit("update:modelValue", option.value);
+    close(true);
+}
+function onTriggerKey(event: KeyboardEvent) {
+    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) return;
+    event.preventDefault();
+    show(event.key === "Home" ? 0 : event.key === "End" ? props.options.length - 1 : undefined);
+}
+function onListKey(event: KeyboardEvent) {
+    if (event.key === "Tab") { close(true); return; }
+    if (event.key === "Escape") { event.preventDefault(); event.stopPropagation(); close(true); return; }
+    if (["Enter", " "].includes(event.key)) { event.preventDefault(); choose(activeIndex.value); return; }
+    const count = props.options.length;
+    if (["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+        event.preventDefault();
+        activeIndex.value = event.key === "Home" ? 0 : event.key === "End" ? count - 1
+            : (activeIndex.value + (event.key === "ArrowDown" ? 1 : -1) + count) % count;
+    } else if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        const index = props.options.findIndex(option => option.label.toLocaleLowerCase().startsWith(event.key.toLocaleLowerCase()));
+        if (index !== -1) activeIndex.value = index;
+    }
+}
+function onOutsidePointer(event: PointerEvent) {
+    if (!root.value?.contains(event.target as Node)) close();
+}
+function onFocusOut(event: FocusEvent) {
+    if (!root.value?.contains(event.relatedTarget as Node | null)) close();
+}
+function onResize() { if (open.value) close(true); }
+onMounted(() => {
+    document.addEventListener("pointerdown", onOutsidePointer);
+    window.addEventListener("resize", onResize);
+});
+onUnmounted(() => {
+    document.removeEventListener("pointerdown", onOutsidePointer);
+    window.removeEventListener("resize", onResize);
+});
+</script>
+
+<style scoped>
+.app-sort { min-width: 0; }
+.app-sort__control { position: relative; }
+.app-sort__label { display: block; margin-bottom: 0.375rem; font-size: 0.75rem; font-weight: 550; line-height: 1; }
+.app-sort__trigger { display: flex; align-items: center; justify-content: space-between; gap: 0.5rem; width: 100%; min-height: 2rem; padding: 0.25rem 0.5rem; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--card); color: var(--foreground); text-align: start; font: inherit; font-size: 0.8125rem; line-height: 1.5; cursor: pointer; }
+.app-sort__trigger:hover, .app-sort__trigger[aria-expanded="true"] { border-color: var(--brand-line); background: var(--secondary); }
+.app-sort__trigger > svg { color: var(--muted-foreground); }
+.app-sort__trigger:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; }
+.app-sort__options { position: absolute; z-index: 30; inset-inline: 0; top: calc(100% + 0.25rem); padding: 0.25rem; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--popover); color: var(--popover-foreground); box-shadow: var(--shadow-panel); outline: none; }
+.app-sort__options[data-side="top"] { top: auto; bottom: calc(100% + 0.25rem); }
+.app-sort__option { display: flex; align-items: center; gap: 0.5rem; min-height: 2rem; padding: 0.25rem 0.5rem; border-radius: var(--radius-control); font-size: 0.8125rem; line-height: 1.5; cursor: pointer; }
+.app-sort__option[data-active="true"] { background: var(--secondary); color: var(--foreground); }
+.app-sort__check--hidden { visibility: hidden; }
+.app-sort svg { display: block; flex-shrink: 0; width: 0.875rem; height: 0.875rem; }
+</style>

--- a/website/src/components/AppsApp.vue
+++ b/website/src/components/AppsApp.vue
@@ -4,8 +4,11 @@
             <span class="apps-kicker">{{ copy.kicker }}</span>
             <h1>{{ copy.title }}</h1>
             <p class="apps-lead">{{ copy.lead }}</p>
-            <p class="apps-policy">{{ copy.selectionPolicy }}</p>
-            <p class="apps-policy">{{ copy.rankingPolicy }}</p>
+            <details class="apps-policy">
+                <summary>{{ copy.selectionLabel }}</summary>
+                <p>{{ copy.selectionPolicy }}</p>
+                <p>{{ copy.rankingPolicy }}</p>
+            </details>
             <ul class="apps-signals">
                 <li><Boxes :size="15" /> {{ copy.signalCount }}</li>
                 <li><Monitor :size="15" /> macOS / Windows / Linux</li>
@@ -13,77 +16,98 @@
             </ul>
         </div>
 
-        <div class="apps-toolbar">
-            <label class="apps-search">
-                <span>{{ copy.searchLabel }}</span>
-                <input v-model="query" type="search" :placeholder="copy.searchPlaceholder" />
-            </label>
-            <label class="apps-sort">
-                <span>{{ copy.sortLabel }}</span>
-                <select v-model="sort">
-                    <option value="newest">{{ copy.newest }}</option>
-                    <option value="stars">{{ copy.mostStars }}</option>
-                </select>
-            </label>
-        </div>
-
-        <div class="apps-filter" role="group" :aria-label="copy.filterLabel">
-            <button
-                v-for="category in categories"
-                :key="category.id"
-                type="button"
-                class="apps-filter__chip"
-                :aria-pressed="String(category.id === active)"
-                @click="active = category.id"
-            >
-                {{ category.label }}
-                <span class="apps-filter__count">{{ category.count }}</span>
-            </button>
-        </div>
-
-        <p class="apps-results" aria-live="polite">{{ copy.results(groups.featured.length + groups.community.length) }}</p>
         <section v-for="section in sections" :key="section.id" class="apps-section" :aria-labelledby="`apps-${section.id}`">
-            <h2 :id="`apps-${section.id}`">{{ section.title }} <span>{{ section.apps.length }}</span></h2>
+            <h2 :id="`apps-${section.id}`">{{ section.title }} <span>{{ section.total }}</span></h2>
             <p class="apps-section__lead">{{ section.description }}</p>
-            <div class="apps-grid">
-            <article v-for="app in section.apps" :key="app.id" class="app-card">
-                <a
-                    class="app-card__shot"
-                    :href="app.hasReadme ? detailUrl(app.id) : (app.website ?? app.source)"
-                    :target="app.hasReadme ? undefined : '_blank'"
-                    rel="noopener noreferrer"
-                    :aria-label="app.name"
-                >
-                    <img :src="app.image" :alt="app.name" loading="lazy" decoding="async" />
-                </a>
-                <div class="app-card__body">
-                    <h3 class="app-card__name">{{ app.name }}</h3>
-                    <p class="app-card__author">{{ app.author }}</p>
-                    <p class="app-card__blurb">{{ app.description }}</p>
-                    <ul class="app-card__meta">
-                        <li>{{ app.platforms.join(" / ") }}</li>
-                        <li>{{ app.source ? copy.openSource : copy.commercial }}</li>
-                        <li v-if="app.stars !== null" :title="app.starsUpdatedAt ? `${copy.starsUpdated} ${app.starsUpdatedAt.slice(0, 10)}` : undefined">★ {{ app.stars.toLocaleString() }} GitHub Stars</li>
-                        <li v-if="app.publishedAt"><time :datetime="app.publishedAt">{{ copy.published }} {{ app.publishedAt.slice(0, 10) }}</time></li>
-                        <li v-if="app.building">{{ copy.building }}</li>
-                    </ul>
-                    <div class="app-card__links">
-                        <a v-if="app.hasReadme" :href="detailUrl(app.id)">{{ copy.details }} <ArrowRight :size="13" /></a>
-                        <a v-if="app.website" :href="app.website" target="_blank" rel="noopener noreferrer">
-                            {{ copy.visit }} <ArrowUpRight :size="13" />
-                        </a>
-                        <a v-if="app.source" :href="app.source" target="_blank" rel="noopener noreferrer">
-                            {{ copy.sourceLink }} <ArrowUpRight :size="13" />
-                        </a>
-                    </div>
+            <div v-if="section.id === 'all'" class="apps-browser">
+                <div class="apps-toolbar">
+                    <label class="apps-search">
+                        <span class="apps-field-label">{{ copy.searchLabel }}</span>
+                        <span class="apps-search__control">
+                            <Search aria-hidden="true" />
+                            <input v-model="query" type="search" :placeholder="copy.searchPlaceholder" />
+                        </span>
+                    </label>
+                    <AppSortSelect
+                        id="apps-sort"
+                        v-model="sort"
+                        class="apps-sort"
+                        :label="copy.sortLabel"
+                        :options="[{ value: 'newest', label: copy.newest }, { value: 'stars', label: copy.mostStars }]"
+                    />
                 </div>
-            </article>
+                <div class="apps-filter" role="group" :aria-label="copy.filterLabel">
+                    <button
+                        v-for="category in categories"
+                        :key="category.id"
+                        type="button"
+                        class="apps-filter__chip"
+                        :aria-pressed="String(category.id === active)"
+                        @click="active = category.id"
+                    >
+                        {{ category.label }}
+                        <span class="apps-filter__count">{{ category.count }}</span>
+                    </button>
+                    <button type="button" class="apps-reset" :disabled="!hasFilters" @click="clearFilters">{{ copy.clearFilters }}</button>
+                </div>
+                <p class="apps-results sr-only" role="status">{{ copy.results(filteredApps.length) }}</p>
+            </div>
+            <div class="apps-grid">
+                <article v-for="app in section.apps" :key="app.id" class="app-card">
+                    <a
+                        class="app-card__shot"
+                        :href="app.hasReadme ? detailUrl(app.id) : (app.website ?? app.source)"
+                        :target="app.hasReadme ? undefined : '_blank'"
+                        rel="noopener noreferrer"
+                        :aria-label="app.name"
+                    >
+                        <img :src="app.image" :alt="app.name" loading="lazy" decoding="async" />
+                    </a>
+                    <div class="app-card__body">
+                        <div class="app-card__header">
+                            <div class="app-card__identity">
+                                <h3 class="app-card__name">{{ app.name }}</h3>
+                                <p class="app-card__author">{{ app.author }}</p>
+                            </div>
+                            <span v-if="app.building" class="app-card__status">{{ copy.building }}</span>
+                        </div>
+                        <p class="app-card__blurb">{{ app.description }}</p>
+                        <div class="app-card__platform-row">
+                            <ul class="app-card__meta">
+                                <li>{{ app.platforms.join(" / ") }}</li>
+                            </ul>
+                            <time v-if="app.publishedAt" :datetime="app.publishedAt" :title="`${copy.published} ${formatDate(app.publishedAt)}`">{{ formatDate(app.publishedAt) }}</time>
+                        </div>
+                        <div class="app-card__footer">
+                            <div class="app-card__footer-start">
+                                <span v-if="!app.source" class="app-card__commercial">{{ copy.commercial }}</span>
+                                <span class="app-card__stats inline-flex items-center" role="img" v-if="app.stars !== null" :aria-label="`${app.stars.toLocaleString()} GitHub Stars`" :title="app.starsUpdatedAt ? `${copy.starsUpdated} ${app.starsUpdatedAt.slice(0, 10)}` : undefined"><Star aria-hidden="true" /><span>{{ formatStars(app.stars) }}</span></span>
+                            </div>
+                            <div class="app-card__links">
+                                <a v-if="app.website" class="app-card__icon-link" :href="app.website" :aria-label="`${app.name} — ${copy.visit}`" :title="copy.visit" target="_blank" rel="noopener noreferrer">
+                                    <Globe :size="16" aria-hidden="true" />
+                                </a>
+                                <a v-if="app.source" class="app-card__icon-link" :href="app.source" :aria-label="`${app.name} — ${copy.sourceLink}`" :title="copy.sourceLink" target="_blank" rel="noopener noreferrer">
+                                    <Github :size="16" aria-hidden="true" />
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+            </div>
+            <nav v-if="section.totalPages > 1" class="apps-pagination" :aria-label="section.id === 'featured' ? copy.featuredPagination : copy.allPagination">
+                <span class="apps-pagination__status" role="status">{{ copy.pageStatus(section.page, section.totalPages) }}</span>
+                <button type="button" :disabled="section.page === 1" :aria-label="copy.previousPage" :title="copy.previousPage" @click="setPage(section.id, section.page - 1)"><ChevronLeft aria-hidden="true" /></button>
+                <button v-for="page in section.totalPages" :key="page" type="button" :aria-label="copy.pageLabel(page)" :aria-current="section.page === page ? 'page' : undefined" @click="setPage(section.id, page)">{{ page }}</button>
+                <button type="button" :disabled="section.page === section.totalPages" :aria-label="copy.nextPage" :title="copy.nextPage" @click="setPage(section.id, section.page + 1)"><ChevronRight aria-hidden="true" /></button>
+            </nav>
+            <div v-if="section.id === 'all' && !filteredApps.length" class="apps-empty">
+                <SearchX aria-hidden="true" />
+                <h3>{{ copy.empty }}</h3>
+                <p>{{ copy.emptyHint }}</p>
+                <button type="button" @click="clearFilters">{{ copy.clearFilters }}</button>
             </div>
         </section>
-        <div v-if="!groups.featured.length && !groups.community.length" class="apps-empty">
-            <p>{{ copy.empty }}</p>
-            <button type="button" @click="query = ''; active = 'all'">{{ copy.clearFilters }}</button>
-        </div>
 
         <div class="apps-cta">
             <h2>{{ copy.ctaTitle }}</h2>
@@ -101,9 +125,10 @@
 </template>
 
 <script setup lang="ts">
-import { selectShowcases } from "../lib/showcase-browser.ts";
-import { computed, ref } from "vue";
-import { ArrowRight, ArrowUpRight, Boxes, Github, Monitor } from "lucide-vue-next";
+import AppSortSelect from "./AppSortSelect.vue";
+import { selectShowcases, paginateFeatured, paginateAll } from "../lib/showcase-browser.ts";
+import { computed, ref, watch } from "vue";
+import { ArrowRight, Boxes, ChevronLeft, ChevronRight, Github, Globe, Monitor, Search, SearchX, Star } from "lucide-vue-next";
 
 interface ShowcaseApp {
     id: string; name: string; author: string; hasReadme: boolean; category: string; platforms: string[];
@@ -114,6 +139,9 @@ interface ShowcaseApp {
 
 const props = defineProps<{ lang: 'en' | 'zh-CN'; apps: ShowcaseApp[] }>();
 const apps = props.apps;
+const starFormatter = new Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 });
+const formatDate = (date: string) => date.slice(0, 10).replaceAll("-", "/");
+const formatStars = (stars: number) => starFormatter.format(stars);
 const detailUrl = (id: string) => `${props.lang === "zh-CN" ? "/zh-CN" : ""}/apps/${id}`;
 
 const isZh = computed(() => props.lang === 'zh-CN');
@@ -130,6 +158,12 @@ const CATEGORY_LABELS: Record<string, { en: string; zh: string }> = {
 const active = ref("all");
 const query = ref("");
 const sort = ref("newest");
+const featuredPage = ref(1);
+const allPage = ref(1);
+watch([query, active, sort], () => { allPage.value = 1; });
+const featured = computed(() => paginateFeatured(apps, featuredPage.value));
+const hasFilters = computed(() => query.value.trim() !== "" || active.value !== "all");
+const clearFilters = () => { query.value = ""; active.value = "all"; };
 
 const categories = computed(() =>
     Object.entries(CATEGORY_LABELS).map(([id, label]) => ({
@@ -139,88 +173,137 @@ const categories = computed(() =>
     })),
 );
 
-const groups = computed(() => selectShowcases(apps, { query: query.value, category: active.value, sort: sort.value }));
+const filteredApps = computed(() => selectShowcases(
+    apps,
+    { query: query.value, category: active.value, sort: sort.value },
+).all);
+const all = computed(() => paginateAll(filteredApps.value, allPage.value));
 const sections = computed(() => [
-    { id: "featured", title: copy.value.featured, description: copy.value.featuredLead, apps: groups.value.featured },
-    { id: "community", title: copy.value.community, description: copy.value.communityLead, apps: groups.value.community },
-].filter(section => section.apps.length));
+    { id: "featured", title: copy.value.featured, description: copy.value.featuredLead, ...featured.value },
+    { id: "all", title: copy.value.community, description: copy.value.communityLead, ...all.value },
+].filter(section => section.id === "all" || section.apps.length));
+
+function setPage(section: string, page: number) {
+    if (section === "featured") featuredPage.value = page;
+    else allPage.value = page;
+}
 
 const copy = computed(() =>
     isZh.value
-        ? { details: "查看详情", starsUpdated: "Stars 更新于", featured: "Featured · 精选应用", featuredLead: "由维护者挑选，展示完整、优质的应用案例。", community: "更多应用", communityLead: "探索社区应用，找到适合你的工具。GitHub Stars 每周及案例 PR 合并后更新。", searchLabel: "搜索应用", searchPlaceholder: "搜索名称、简介、平台或作者…", sortLabel: "更多应用排序", newest: "最新发布", mostStars: "GitHub Stars 最多", published: "发布于", results: (count: number) => `找到 ${count} 个应用`, empty: "没有找到匹配的应用。", clearFilters: "清除筛选", kicker: "应用案例", title: "用 GPUI Kit 做出来的真实应用。", lead: "下面每一个都基于 GPUI Kit 构建，是人们真正下载并每天使用的桌面软件——从生产环境的交易终端，到数据库客户端、终端与系统工具。", selectionPolicy: "向 Showcase 仓库提交 PR，审核合并后，应用都会列在 App Stories 中，但不保证进入 Featured。", rankingPolicy: "Featured 由维护者结合项目历史、实现情况、完整度与品质挑选。我们会根据各应用后续更新和整体情况微调名单，尽量展示更完整、有代表性的应用。其他应用可按发布时间或 GitHub Stars 排序，也可搜索。", signalCount: `${apps.length} 个应用`, signalLicense: "开源与商业产品", filterLabel: "按类别筛选", openSource: "开源", commercial: "商业产品", building: "开发中", visit: "官网", sourceLink: "源码", ctaTitle: "你也用 GPUI Kit 做了应用？", ctaLead: "请在 Showcase 仓库提交 PR，包含应用清单和清晰、完整、整洁的窗口截图。审核合并后自动列在本页，Featured 由维护者另行挑选。", ctaAction: "提交你的应用" }
-        : { details: "View details", starsUpdated: "Stars updated", featured: "Featured", featuredLead: "Complete, carefully crafted apps selected by the maintainers.", community: "More apps", communityLead: "Explore apps from the community. GitHub Stars refresh weekly and after Showcase PRs merge.", searchLabel: "Search apps", searchPlaceholder: "Search names, descriptions, platforms or authors…", sortLabel: "Sort more apps", newest: "Newest published", mostStars: "Most GitHub Stars", published: "Published", results: (count: number) => `${count} apps found`, empty: "No apps match your search.", clearFilters: "Clear filters", kicker: "App Stories", title: "Real apps, shipped with GPUI Kit.", lead: "Every app below is built on GPUI Kit — desktop software people download and use every day, from a production trading terminal to database clients, terminals and system utilities.", selectionPolicy: "Every app accepted through a merged PR in the Showcase repository is listed in App Stories. A listing does not guarantee a place in Featured.", rankingPolicy: "Maintainers select Featured apps based on project history, implementation, completeness and quality, and revisit the selection as apps evolve to highlight complete, representative examples. Browse other apps by publication date or GitHub Stars, or search the collection.", signalCount: `${apps.length} apps`, signalLicense: "Open source and commercial", filterLabel: "Filter by category", openSource: "Open source", commercial: "Commercial", building: "In development", visit: "Website", sourceLink: "Source", ctaTitle: "Built something with GPUI Kit?", ctaLead: "Open a PR in the Showcase repository with your app manifest and clear, complete, tidy window screenshots. Every merged app PR is published here automatically; maintainers select Featured apps separately.", ctaAction: "Submit your app" },
+        ? { featuredPagination: "精选应用分页", allPagination: "全部应用分页", previousPage: "上一页", nextPage: "下一页", pageLabel: (page: number) => `第 ${page} 页`, pageStatus: (page: number, total: number) => `第 ${page} / ${total} 页`, selectionLabel: "应用收录与精选规则", emptyHint: "试试其他关键词或分类。", starsUpdated: "Stars 更新于", featured: "Featured · 精选应用", featuredLead: "由维护者挑选，展示完整、优质的应用案例。", community: "全部应用", communityLead: "探索社区应用，找到适合你的工具。GitHub Stars 每周及案例 PR 合并后更新。", searchLabel: "搜索应用", searchPlaceholder: "名称、作者、平台…", sortLabel: "应用排序", newest: "最新发布", mostStars: "GitHub Stars 最多", published: "发布于", results: (count: number) => `找到 ${count} 个应用`, empty: "没有找到匹配的应用。", clearFilters: "清除筛选", kicker: "应用案例", title: "用 GPUI Kit 做出来的真实应用。", lead: "探索基于 GPUI Kit 构建的桌面应用，从交易终端、开发工具到日常效率软件。", selectionPolicy: "向 Showcase 仓库提交 PR，审核合并后，应用都会列在 App Stories 中，但不保证进入 Featured。", rankingPolicy: "Featured 由维护者结合项目历史、实现情况、完整度与品质挑选。我们会根据各应用后续更新和整体情况微调名单，尽量展示更完整、有代表性的应用。全部应用可按发布时间或 GitHub Stars 排序，也可搜索。", signalCount: `${apps.length} 个应用`, signalLicense: "开源与商业产品", filterLabel: "按类别筛选", commercial: "商业产品", building: "开发中", visit: "官网", sourceLink: "源码", ctaTitle: "你也用 GPUI Kit 做了应用？", ctaLead: "请在 Showcase 仓库提交 PR，包含应用清单和清晰、完整、整洁的窗口截图。审核合并后自动列在本页，Featured 由维护者另行挑选。", ctaAction: "提交你的应用" }
+        : { featuredPagination: "Featured apps pagination", allPagination: "All apps pagination", previousPage: "Previous page", nextPage: "Next page", pageLabel: (page: number) => `Page ${page}`, pageStatus: (page: number, total: number) => `Page ${page} of ${total}`, selectionLabel: "How apps are selected", emptyHint: "Try another keyword or category.", starsUpdated: "Stars updated", featured: "Featured", featuredLead: "Complete, carefully crafted apps selected by the maintainers.", community: "All apps", communityLead: "Explore apps from the community. GitHub Stars refresh weekly and after Showcase PRs merge.", searchLabel: "Search apps", searchPlaceholder: "Name, author, platform…", sortLabel: "Sort apps", newest: "Newest published", mostStars: "Most GitHub Stars", published: "Published", results: (count: number) => `${count} ${count === 1 ? "app" : "apps"} found`, empty: "No apps match your search.", clearFilters: "Clear filters", kicker: "App Stories", title: "Real apps, shipped with GPUI Kit.", lead: "Explore desktop apps built with GPUI Kit, from trading terminals and developer tools to everyday productivity software.", selectionPolicy: "Every app accepted through a merged PR in the Showcase repository is listed in App Stories. A listing does not guarantee a place in Featured.", rankingPolicy: "Maintainers select Featured apps based on project history, implementation, completeness and quality, and revisit the selection as apps evolve to highlight complete, representative examples. Browse all apps by publication date or GitHub Stars, or search the collection.", signalCount: `${apps.length} apps`, signalLicense: "Open source and commercial", filterLabel: "Filter by category", commercial: "Commercial", building: "In development", visit: "Website", sourceLink: "Source", ctaTitle: "Built something with GPUI Kit?", ctaLead: "Open a PR in the Showcase repository with your app manifest and clear, complete, tidy window screenshots. Every merged app PR is published here automatically; maintainers select Featured apps separately.", ctaAction: "Submit your app" },
 );
 </script>
 
-<style>
-.apps-page { color: var(--foreground); }
-
-.apps-hero { max-width: 46rem; margin-bottom: clamp(2.5rem, 5vw, 3.5rem); }
-
-.apps-kicker {
-    display: block; margin-bottom: 0.9rem;
-    color: var(--muted-foreground);
-    font: 600 0.68rem/1 var(--font-mono);
-    letter-spacing: 0.14em; text-transform: uppercase;
+<style scoped>
+.apps-page {
+    --apps-space-1: 0.25rem;
+    --apps-space-2: 0.5rem;
+    --apps-space-3: 0.75rem;
+    --apps-space-4: 1rem;
+    --apps-space-6: 1.5rem;
+    --apps-space-8: 2rem;
+    --apps-meta-size: 0.8125rem;
+    color: var(--foreground);
 }
 
-html[lang^="zh"] .apps-kicker { letter-spacing: 0.06em; }
+.apps-hero { max-width: 46rem; margin-bottom: 2.5rem; }
+.apps-kicker { display: block; margin-bottom: var(--apps-space-4); color: var(--muted-foreground); font: 600 0.6875rem/1 var(--font-mono); letter-spacing: 0.14em; text-transform: uppercase; }
+.apps-hero h1 { margin: 0; padding: 0; border: 0; font-size: clamp(2rem, 3.6vw, 3rem); font-weight: 660; letter-spacing: -0.045em; line-height: 1.15; text-wrap: balance; }
+.apps-lead { margin: var(--apps-space-4) 0 0; color: var(--muted-foreground); font-size: 1rem; line-height: 1.65; }
+.apps-policy { margin: var(--apps-space-4) 0 0; color: var(--muted-foreground); font-size: 0.875rem; }
+.apps-policy summary { width: fit-content; cursor: pointer; border-radius: var(--radius-control); }
+.apps-policy summary:hover { color: var(--foreground); }
+.apps-policy p { margin: var(--apps-space-3) 0 0; line-height: 1.6; }
+.apps-signals { display: flex; flex-wrap: wrap; gap: var(--apps-space-2) var(--apps-space-6); margin: var(--apps-space-4) 0 0; padding: 0; list-style: none; color: var(--muted-foreground); font-size: var(--apps-meta-size); font-variant-numeric: tabular-nums; }
+.apps-signals li { display: inline-flex; align-items: center; gap: var(--apps-space-2); margin: 0; line-height: 1.5; }
+.apps-signals svg { flex-shrink: 0; width: 1rem; height: 1rem; }
 
-.apps-hero h1 { margin: 0; border: 0; padding: 0; font-size: clamp(2rem, 3.6vw, 3rem); font-weight: 660; letter-spacing: -0.045em; line-height: 1.1; }
-html[lang^="zh"] .apps-hero h1 { letter-spacing: normal; }
-.apps-lead { margin: 1.1rem 0 0; color: var(--muted-foreground); font-size: 1.05rem; line-height: 1.7; }
+.apps-section + .apps-section { margin-top: 3rem; border-top: 1px solid var(--border); padding-top: var(--apps-space-8); }
+.apps-section h2 { display: flex; align-items: baseline; justify-content: space-between; gap: var(--apps-space-4); margin: 0; padding: 0; border: 0; font-size: 1.5rem; font-weight: 620; line-height: 1.3; }
+.apps-section h2 span { flex-shrink: 0; color: var(--muted-foreground); font-size: 0.875rem; font-weight: 400; font-variant-numeric: tabular-nums; }
+.apps-section__lead { margin: var(--apps-space-2) 0 var(--apps-space-6); color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.5; }
+.apps-browser { margin-bottom: var(--apps-space-6); border: 1px solid var(--border); border-radius: var(--radius-card); }
+.apps-toolbar { display: flex; flex-wrap: wrap; align-items: end; gap: var(--apps-space-2); padding: var(--apps-space-2); border-bottom: 1px solid var(--border); }
+.apps-search { flex: 0 1 20rem; min-width: 0; }
+.apps-sort { flex: 0 1 12rem; min-width: 0; }
+.apps-field-label { display: block; margin-bottom: 0.375rem; font-size: 0.75rem; font-weight: 550; line-height: 1; }
+.apps-search__control { display: block; position: relative; }
+.apps-toolbar input { width: 100%; height: 2rem; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--card); color: var(--foreground); padding: var(--apps-space-1) var(--apps-space-2); font: inherit; font-size: var(--apps-meta-size); line-height: 1.5; }
+.apps-search__control input { padding-left: 2rem; }
+.apps-search__control > svg { position: absolute; top: 50%; transform: translateY(-50%); width: 0.875rem; height: 0.875rem; color: var(--muted-foreground); pointer-events: none; }
+.apps-search__control > svg { left: 0.625rem; }
+.apps-toolbar input:hover { border-color: var(--brand-line); }
+.apps-filter { display: flex; flex-wrap: wrap; align-items: center; gap: var(--apps-space-1); padding: var(--apps-space-2); }
+.apps-filter__chip { display: inline-flex; align-items: center; gap: var(--apps-space-2); min-height: 1.75rem; border: 1px solid var(--border); border-radius: var(--radius-control); padding: 0.125rem var(--apps-space-2); color: var(--muted-foreground); font-size: var(--apps-meta-size); line-height: 1.5; cursor: pointer; }
+.apps-filter__chip:hover { background: var(--secondary); color: var(--foreground); }
+.apps-filter__chip[aria-pressed="true"] { border-color: var(--brand-line); background: var(--secondary); color: var(--foreground); }
+.apps-filter__count { font-size: 0.75rem; font-variant-numeric: tabular-nums; }
+.apps-results { margin: 0; color: var(--muted-foreground); font-size: var(--apps-meta-size); line-height: 1.5; }
+.apps-reset { margin-left: auto; min-height: 1.75rem; border-radius: var(--radius-control); padding: var(--apps-space-1) var(--apps-space-2); color: var(--muted-foreground); font-size: var(--apps-meta-size); cursor: pointer; }
+.apps-reset:disabled { opacity: 0.4; cursor: default; }
+.apps-reset:hover:not(:disabled) { color: var(--foreground); background: var(--secondary); }
+.apps-empty { display: flex; flex-direction: column; align-items: center; gap: var(--apps-space-3); padding: 3rem var(--apps-space-4); border: 1px dashed var(--border); border-radius: var(--radius-card); text-align: center; }
+.apps-empty > svg { width: 1.5rem; height: 1.5rem; color: var(--muted-foreground); }
+.apps-empty h3 { margin: 0; font-size: 1rem; font-weight: 550; line-height: 1.5; }
+.apps-empty p { margin: 0; color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.5; }
+.apps-empty button { margin-top: var(--apps-space-1); min-height: 2.25rem; padding: var(--apps-space-2) var(--apps-space-3); border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--card); font-size: 0.875rem; cursor: pointer; }
+.apps-empty button:hover { background: var(--secondary); }
 
-.apps-policy { margin: 0.8rem 0 0; color: var(--muted-foreground); font-size: 0.9rem; line-height: 1.7; }
+.apps-pagination { display: flex; flex-wrap: wrap; align-items: center; justify-content: end; gap: var(--apps-space-1); margin-top: var(--apps-space-4); }
+.apps-pagination__status { margin-right: auto; color: var(--muted-foreground); font-size: var(--apps-meta-size); font-variant-numeric: tabular-nums; }
+.apps-pagination button { display: inline-flex; align-items: center; justify-content: center; min-width: 2rem; height: 2rem; border: 1px solid transparent; border-radius: var(--radius-control); font-size: var(--apps-meta-size); cursor: pointer; }
+.apps-pagination button:hover:not(:disabled) { background: var(--secondary); }
+.apps-pagination button[aria-current="page"] { border-color: var(--border); background: var(--secondary); }
+.apps-pagination button:disabled { opacity: 0.4; cursor: default; }
+.apps-pagination svg { width: 1rem; height: 1rem; }
 
-.apps-signals { display: flex; flex-wrap: wrap; gap: 0.5rem 1.5rem; margin: 1.6rem 0 0; padding: 0; list-style: none; color: var(--muted-foreground); font-size: 0.85rem; font-variant-numeric: tabular-nums; }
-.apps-signals li { display: inline-flex; align-items: center; gap: 0.45rem; margin: 0; }
+.apps-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(20rem, 100%), 1fr)); gap: var(--apps-space-4); }
+.app-card { display: flex; flex-direction: column; min-width: 0; overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-card); background: var(--card); }
+.app-card:hover { border-color: var(--brand-line); }
+.app-card__shot { display: block; flex-shrink: 0; border-bottom: 1px solid var(--border); background: var(--secondary); }
+.app-card__shot:focus-visible { outline-offset: -2px; }
+.app-card__shot img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; object-position: top center; }
+.app-card__body { display: flex; flex: 1; flex-direction: column; min-width: 0; padding: var(--apps-space-4) var(--apps-space-4) var(--apps-space-2); overflow-wrap: anywhere; }
+.app-card__header { display: flex; align-items: start; justify-content: space-between; gap: var(--apps-space-3); }
+.app-card__identity { min-width: 0; }
+.app-card__name { margin: 0; border: 0; padding: 0; font-size: 1.0625rem; font-weight: 620; letter-spacing: -0.015em; line-height: 1.3; }
+.app-card__author { margin: var(--apps-space-1) 0 0; color: var(--muted-foreground); font-size: var(--apps-meta-size); line-height: 1.5; }
+.app-card__status { flex-shrink: 0; margin-top: 0; border: 1px solid var(--border); border-radius: var(--radius-control); padding: 0 var(--apps-space-2); color: var(--muted-foreground); font-size: 0.75rem; line-height: 1.75; }
+.app-card__blurb { margin: var(--apps-space-3) 0 auto; padding-bottom: var(--apps-space-4); color: var(--foreground); font-size: 0.875rem; line-height: 1.5; }
+.app-card__platform-row { display: flex; align-items: baseline; justify-content: space-between; gap: var(--apps-space-2); margin-bottom: var(--apps-space-3); color: var(--muted-foreground); font-size: var(--apps-meta-size); line-height: 1.5; }
+.app-card__platform-row > time { flex-shrink: 0; font-variant-numeric: tabular-nums; }
+.app-card__meta { min-width: 0; display: flex; flex-wrap: wrap; gap: var(--apps-space-2); margin: 0; padding: 0; list-style: none; }
+.app-card__meta li { margin: 0; padding: 0; line-height: inherit; }
+.app-card__footer { display: flex; align-items: center; justify-content: space-between; gap: var(--apps-space-2); border-top: 1px solid var(--border); padding-top: var(--apps-space-2); color: var(--muted-foreground); font-size: var(--apps-meta-size); line-height: 1; min-height: 2.5rem; }
+.app-card__footer-start { display: flex; flex-wrap: wrap; align-items: center; gap: var(--apps-space-3); min-width: 0; }
+.app-card__commercial, .app-card__stats { display: inline-flex; align-items: center; gap: var(--apps-space-1); min-height: 2rem; }
+.app-card__stats { font-variant-numeric: tabular-nums; }
+/* Numeral ink sits above its line-box center; align it optically with the star. */
+.app-card__stats > span { display: inline-flex; align-items: center; height: 1rem; line-height: 1; transform: translateY(0.03125rem); }
+.app-card__links { display: flex; flex-shrink: 0; align-items: center; gap: var(--apps-space-1); }
+.app-card__icon-link { display: inline-flex; align-items: center; justify-content: center; width: 2rem; height: 2rem; border-radius: var(--radius-control); color: inherit; text-decoration: none; }
+.app-card__icon-link:hover { color: var(--foreground); background: var(--secondary); }
+.app-card__stats svg, .app-card__links svg { display: block; flex-shrink: 0; width: 1rem; height: 1rem; }
 
-.apps-toolbar { display: flex; flex-wrap: wrap; align-items: end; gap: 1rem; margin-bottom: 1.25rem; }
-.apps-search { flex: 1 1 18rem; }
-.apps-sort { flex: 0 1 15rem; }
-.apps-toolbar label > span { display: block; margin-bottom: 0.4rem; font-size: 0.85rem; font-weight: 550; }
-.apps-toolbar input, .apps-toolbar select { width: 100%; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--card); color: var(--foreground); padding: 0.65rem 0.8rem; font: inherit; }
-.apps-toolbar input:focus-visible, .apps-toolbar select:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; }
-.apps-results, .apps-section__lead { color: var(--muted-foreground); font-size: 0.9rem; }
-.apps-section { margin-top: 2rem; }
-.apps-section + .apps-section { margin-top: 3.5rem; border-top: 1px solid var(--border); padding-top: 2rem; }
-.apps-section h2 { margin: 0; padding: 0; border: 0; font-size: 1.5rem; }
-.apps-section h2 span { margin-left: 0.4rem; color: var(--muted-foreground); font-size: 0.9rem; font-weight: 400; }
-.apps-section__lead { margin: 0.5rem 0 1.5rem; }
-.apps-empty { padding: 3rem 1rem; text-align: center; }
-.apps-empty button { color: var(--brand); text-decoration: underline; cursor: pointer; }
-
-.apps-filter { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1.75rem; border-top: 1px solid var(--border); padding-top: 1.75rem; }
-
-.apps-filter__chip { display: inline-flex; align-items: center; gap: 0.45rem; border: 1px solid var(--border); border-radius: 999px; padding: 0.35rem 0.85rem; color: var(--foreground); font-size: 0.85rem; line-height: 1.4; cursor: pointer; transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease; }
-.apps-filter__chip:hover { background: var(--secondary); }
-.apps-filter__chip[aria-pressed="true"] { border-color: var(--brand); background: var(--brand); color: var(--brand-contrast); }
-.apps-filter__count { color: var(--muted-foreground); font-size: 0.75rem; font-variant-numeric: tabular-nums; }
-.apps-filter__chip[aria-pressed="true"] .apps-filter__count { color: var(--brand-contrast); opacity: 0.65; }
-
-.apps-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(20rem, 100%), 1fr)); gap: 1.5rem; }
-
-.app-card { display: flex; flex-direction: column; overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-card); background: var(--card); transition: border-color 0.18s ease, box-shadow 0.18s ease; }
-.app-card:hover { border-color: var(--brand-line); box-shadow: var(--shadow-raise); }
-.app-card__shot { display: block; border-bottom: 1px solid var(--border); background: var(--secondary); }
-.app-card__shot img { display: block; width: 100%; aspect-ratio: 16 / 10; object-fit: contain; object-position: center; }
-.app-card__body { display: flex; flex: 1; flex-direction: column; padding: 1.15rem 1.25rem 1.25rem; }
-.app-card__name { margin: 0; border: 0; padding: 0; font-size: 1.05rem; font-weight: 620; letter-spacing: -0.015em; line-height: 1.3; }
-html[lang^="zh"] .app-card__name { letter-spacing: normal; }
-.app-card__author { margin: 0.35rem 0 0; color: var(--muted-foreground); font-size: 0.8rem; }
-.app-card__blurb { margin: 0.55rem 0 auto; padding-bottom: 1rem; color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.65; }
-.app-card__meta { display: flex; flex-wrap: wrap; gap: 0.4rem; margin: 0 0 0.9rem; padding: 0; list-style: none; }
-.app-card__meta li { margin: 0; border: 1px solid var(--border); border-radius: var(--radius-control); padding: 0.15rem 0.45rem; color: var(--muted-foreground); font-size: 0.72rem; line-height: 1.5; white-space: nowrap; }
-.app-card__links { display: flex; flex-wrap: wrap; gap: 1rem; border-top: 1px solid var(--border); padding-top: 0.9rem; }
-.app-card__links a { display: inline-flex; align-items: center; gap: 0.2rem; color: var(--foreground); font-size: 0.85rem; font-weight: 500; text-decoration: none; transition: opacity 0.15s ease; }
-.app-card__links a:hover { opacity: 0.66; }
-
-.apps-cta { margin-top: clamp(3rem, 6vw, 4.5rem); border-top: 1px solid var(--border); padding-top: clamp(2rem, 4vw, 3rem); }
-.apps-cta h2 { margin: 0; border: 0; padding: 0; font-size: 1.4rem; font-weight: 640; letter-spacing: -0.02em; line-height: 1.3; }
-html[lang^="zh"] .apps-cta h2 { letter-spacing: normal; }
-.apps-cta p { margin: 0.6rem 0 1.3rem; color: var(--muted-foreground); font-size: 0.95rem; line-height: 1.7; }
-.apps-cta__action { display: inline-flex; align-items: center; gap: 0.4rem; border-radius: var(--radius-control); background: var(--brand); padding: 0.55rem 1.1rem; color: var(--brand-contrast); font-size: 0.9rem; font-weight: 500; text-decoration: none; transition: background-color 0.15s ease; }
-.apps-cta__action:hover { background: var(--brand-hover); }
-
-@media (max-width: 640px) { .apps-grid { gap: 1.15rem; } }
+.apps-cta { display: flex; flex-direction: column; align-items: start; gap: var(--apps-space-3); margin-top: 3rem; padding-top: var(--apps-space-8); border-top: 1px solid var(--border); }
+.apps-cta h2 { margin: 0; padding: 0; border: 0; font-size: 1.375rem; font-weight: 620; letter-spacing: -0.02em; line-height: 1.3; }
+.apps-cta p { margin: 0; max-width: 46rem; color: var(--muted-foreground); font-size: 0.875rem; line-height: 1.6; }
+.apps-cta__action { display: inline-flex; align-items: center; gap: var(--apps-space-2); margin-top: var(--apps-space-1); min-height: 2.5rem; border: 1px solid var(--border); border-radius: var(--radius-control); padding: var(--apps-space-2) var(--apps-space-4); color: var(--foreground); background: var(--card); font-size: 0.875rem; font-weight: 500; text-decoration: none; }
+.apps-cta__action:hover { background: var(--secondary); }
+.apps-cta__action svg { width: 1rem; height: 1rem; }
+.apps-page :is(a, button, input, select, summary):focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; }
+.apps-page .app-card__shot:focus-visible { outline-offset: -2px; }
+.apps-page button:active, .app-card__icon-link:active { background: var(--secondary); color: var(--foreground); }
+:global(html[lang^="zh"]) :is(.apps-hero h1, .app-card__name, .apps-cta h2) { letter-spacing: normal; }
+:global(html[lang^="zh"]) .apps-kicker { letter-spacing: 0.06em; }
+@media (prefers-reduced-motion: no-preference) {
+    .app-card { transition: border-color 150ms ease; }
+    .app-card__icon-link, .apps-filter__chip, .apps-reset, .apps-cta__action { transition: background-color 150ms ease, color 150ms ease; }
+}
+@media (max-width: 640px) {
+    .apps-search { flex: 1 1 15rem; }
+    .apps-sort { flex: 1 1 11rem; }
+    .apps-section + .apps-section { margin-top: var(--apps-space-8); }
+}
 </style>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -134,7 +134,7 @@ const resourcesLabel = isZh ? '资源' : 'Resources';
 
       <!-- Language switch -->
       <a href={langSwitchHref} class="site-nav__lang-btn site-nav__link">
-        {langLabel}
+        <span>{langLabel}</span>
       </a>
 
       <!-- Theme toggle -->
@@ -257,14 +257,25 @@ const resourcesLabel = isZh ? '资源' : 'Resources';
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.76rem;
+  font-size: 0.8125rem;
   font-variant-numeric: tabular-nums;
 }
 
 .site-nav__lang-btn {
-  font-size: 0.78rem;
+  font-size: 0.8125rem;
   font-weight: 560;
 }
+
+/* Give toolbar labels the same centered line box as their icons. */
+.site-nav__actions .site-nav__link { height: 2rem; padding-block: 0; }
+.github-star-btn__label,
+.site-nav__lang-btn > span {
+  display: inline-flex;
+  align-items: center;
+  height: 1rem;
+  line-height: 1rem;
+}
+.site-nav__actions svg { display: block; flex-shrink: 0; }
 
 .site-nav__burger {
   display: none;

--- a/website/src/lib/showcase-browser.ts
+++ b/website/src/lib/showcase-browser.ts
@@ -7,9 +7,26 @@ export function selectShowcases(apps, { query = '', category = 'all', sort = 'ne
   });
   const featured = matches.filter(app => app.featured);
   const community = matches.filter(app => !app.featured);
-  community.sort((a, b) => {
+  const compare = (a, b) => {
     if (sort === 'stars' && a.stars !== b.stars) return (b.stars ?? -1) - (a.stars ?? -1);
     return (Date.parse(b.publishedAt) || 0) - (Date.parse(a.publishedAt) || 0) || a.name.localeCompare(b.name);
-  });
-  return { featured, community };
+  };
+  community.sort(compare);
+  return { featured, community, all: [...matches].sort(compare) };
+}
+
+/** Six editorial selections per page; browsing never changes catalog order. */
+export function paginateFeatured<T extends { featured: boolean }>(apps: T[], requestedPage = 1) {
+  return paginate(apps.filter(app => app.featured), requestedPage, 6);
+}
+
+/** Nine filtered and sorted catalog entries per page. */
+export function paginateAll<T>(apps: T[], requestedPage = 1) {
+  return paginate(apps, requestedPage, 9);
+}
+
+function paginate<T>(apps: T[], requestedPage: number, pageSize: number) {
+  const totalPages = Math.ceil(apps.length / pageSize);
+  const page = Math.max(1, Math.min(requestedPage, totalPages));
+  return { apps: apps.slice((page - 1) * pageSize, page * pageSize), page, totalPages, total: apps.length };
 }

--- a/website/tests/showcase-browser.test.ts
+++ b/website/tests/showcase-browser.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { selectShowcases } from '../src/lib/showcase-browser.ts';
+import { selectShowcases, paginateFeatured } from '../src/lib/showcase-browser.ts';
 const apps = [
   { id: 'picked', name: 'Picked', featured: true, category: 'dev', description: 'A database', author: 'Database Team', platforms: ['Linux'], stars: 1, publishedAt: '2026-01-01' },
   { id: 'older', name: 'Older', featured: false, category: 'dev', description: 'A terminal', platforms: ['Linux'], stars: 100, publishedAt: '2026-01-01' },
@@ -20,4 +20,35 @@ test('search matches descriptions and authors and combines with categories', () 
   assert.equal(selectShowcases(apps, { query: 'Database Team' }).featured.length, 1);
   assert.equal(selectShowcases(apps, { query: '  TERMINAL ', category: 'dev' }).community[0].id, 'older');
   assert.equal(selectShowcases(apps, { query: 'notes', category: 'dev' }).community.length, 0);
+});
+test('all apps includes Featured in the requested order without changing editorial data', () => {
+  const before = structuredClone(apps);
+  assert.deepEqual(selectShowcases(apps, { sort: 'stars' }).all.map(a => a.id), ['older', 'picked', 'newer']);
+  assert.deepEqual(selectShowcases(apps).all.map(a => a.id), ['newer', 'older', 'picked']);
+  assert.deepEqual(selectShowcases(apps, { query: 'Database Team', category: 'dev' }).all.map(a => a.id), ['picked']);
+  assert.deepEqual(apps, before);
+});
+test('Featured pagination shows six apps per page in editorial order', () => {
+  const featuredApps = Array.from({ length: 16 }, (_, id) => ({ id, featured: true }));
+  const catalog = [...featuredApps, { id: 99, featured: false }];
+  assert.deepEqual(paginateFeatured(catalog, 1), { apps: featuredApps.slice(0, 6), page: 1, totalPages: 3, total: 16 });
+  assert.deepEqual(paginateFeatured(catalog, 2).apps.map(a => a.id), [6, 7, 8, 9, 10, 11]);
+  assert.deepEqual(paginateFeatured(catalog, 3).apps.map(a => a.id), [12, 13, 14, 15]);
+  assert.equal(paginateFeatured(catalog, 9).page, 3);
+  assert.equal(paginateFeatured(catalog, 0).page, 1);
+  assert.deepEqual(paginateFeatured([], 1), { apps: [], page: 1, totalPages: 0, total: 0 });
+  assert.equal(catalog.length, 17);
+});
+
+
+test('All apps pagination keeps sorted results in pages of nine and clamps boundaries', async () => {
+  const { paginateAll } = await import('../src/lib/showcase-browser.ts');
+  const apps = Array.from({ length: 23 }, (_, id) => ({ id }));
+  const pages = [1, 2, 3].map(page => paginateAll(apps, page));
+  assert.deepEqual(pages.map(page => page.apps.length), [9, 9, 5]);
+  assert.deepEqual(pages.flatMap(page => page.apps), apps);
+  assert.equal(paginateAll(apps, 99).page, 3);
+  assert.equal(paginateAll(apps, 0).page, 1);
+  assert.deepEqual(paginateAll([], 3), { apps: [], page: 1, totalPages: 0, total: 0 });
+  assert.equal(paginateAll(apps.slice(0, 2), 3).page, 1);
 });


### PR DESCRIPTION
## Description

App Stories cards inherited prose list markers and spacing, making the catalog tall and difficult to scan. Scope the page styles and use the GPUI Kit website's typography, neutral theme tokens, compact controls, and consistent card spacing. Screenshot previews fill a shared 16:9 area, with author, platform/date, and icon-only links organized into aligned rows.

Featured now displays six apps per page in editorial order. All apps displays nine entries per page from the complete catalog, defaults to newest publication first, and owns its search, category filters, and star sorting. Search, category, and sort changes reset All apps to page one. Empty results keep the controls available. Star counts use compact notation, accessible names, and an optical alignment correction; Commercial precedes the count, and the separate Read story row is removed.

Replace the native sort menu with a theme-aware keyboard-operable listbox and use 32px search/sort controls. Normalize navigation action label sizing and centered line boxes. Update the website design rules and test both pagination sizes and boundaries. Implementation and tests were AI-assisted, with iterative visual feedback and independent code review.

Use `bunx` to invoke Astro binaries directly in the package scripts. The previous `bun --bun astro` invocation resolved the identically named package script recursively in CI and failed with E2BIG. Verified the standard `bun run build` command after this fix.

Align Test Docs with the release workflow by checking out the approved Showcase catalog, installing its locked dependencies with Bun 1.4.0, and passing `SHOWCASES_DIR`. Run catalog and SEO tests in the website check.

## Visual verification

Checked English and Chinese, light and dark themes, and widths from 360 to 1440 pixels in Chromium. Verified aligned card metadata and icon rows, edge-to-edge previews, keyboard focus, selection, empty-state recovery, reduced motion, and Featured's 6/6/4 pagination and All apps' 9/9/9/9/3 pagination, with no duplicate entries.

The App Stories content also fits at 200% root font size. The existing shared site navigation overflows in that text-only scaling case; this pre-existing text-scaling overflow remains outside the toolbar alignment fix.

## How to Test

From `website/`:

```sh
bun run test:showcases
bun run build
bun run test:seo
```

Open `/apps` and `/zh-CN/apps`. Change Featured pages, search and clear an unmatched query, combine search with a category, and switch between publication and star sorting. Featured selection and order should remain independent of All apps filters.

## Checklist

- [x] Read and followed the contributing guidelines.
- [x] Reviewed the changes and ran the website tests and build.
- [ ] Maintainer review of AI-assisted changes.

Rust Story and platform performance tests are not applicable to this website-only change.
