### PR TITLE
base: Add window_ext for overlay/floating window configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3409,6 +3409,8 @@ dependencies = [
  "tracing",
  "unicode-segmentation",
  "web-time",
+ "windows-sys 0.59.0",
+ "x11-dl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,8 @@ log = "0.4"
 lsp-types = { version = "0.97.0", features = ["proposed"] }
 notify = "7.0.0"
 raw-window-handle = "0.6.2"
+windows-sys = { version = "0.59", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation"] }
+x11-dl = "2"
 ropey = { version = "=2.0.0-beta.1", features = [
     "metric_chars",
     "metric_lines_lf",

--- a/crates/base/Cargo.toml
+++ b/crates/base/Cargo.toml
@@ -46,6 +46,7 @@ tracing.workspace = true
 unicode-segmentation = "1.12.0"
 web-time = "1"
 syntect.workspace = true
+raw-window-handle.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 smol.workspace = true
@@ -55,10 +56,15 @@ gpui_platform.workspace = true
 async-channel = "2.3.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-raw-window-handle.workspace = true
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSView", "NSWindow"] }
 objc2-foundation = { version = "0.3", features = ["NSGeometry", "NSString"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+x11-dl.workspace = true
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/base/src/lib.rs
+++ b/crates/base/src/lib.rs
@@ -35,6 +35,7 @@ mod link;
 mod list_settings;
 #[cfg(all(target_os = "macos", not(test)))]
 mod macos_accessibility;
+pub mod window_ext;
 mod measure;
 pub mod motion;
 mod nav_stack;
@@ -116,6 +117,7 @@ pub use macos_accessibility::install_window_hit_test_forwarder;
 #[doc(hidden)]
 pub use measure::measurement_enabled;
 pub use measure::{Measure, measure, measure_if};
+pub use window_ext::{WindowBehavior, configure, make_floating, make_overlay, set_click_through};
 pub use motion::{
     Discrete, DiscreteError, Easing, EasingError, Interpolate, IterationCount, Keyframe,
     KeyframeError, Keyframes, LinearStop, MotionPhase, MotionReveal, MotionStatus, MotionTransform,

--- a/crates/base/src/window_ext.rs
+++ b/crates/base/src/window_ext.rs
@@ -153,19 +153,23 @@ fn configure_macos(
     behavior: &WindowBehavior,
 ) {
     use objc2::runtime::NSObject;
-    use objc2::{msg_send, ClassType};
-    use objc2_app_kit::NSWindow;
+    use objc2::msg_send;
+    use objc2_app_kit::{NSView, NSWindow};
 
-    let ns_window_ptr = handle.ns_window as *mut NSObject;
-    if ns_window_ptr.is_null() {
+    // Get the NSWindow from the NSView handle
+    let ns_view_ptr = handle.ns_view as *mut NSObject;
+    if ns_view_ptr.is_null() {
         return;
     }
-    let ns_window: &NSWindow = unsafe { &*ns_window_ptr.cast::<NSWindow>() };
+    let ns_view: &NSView = unsafe { &*ns_view_ptr.cast::<NSView>() };
+    let Some(ns_window) = ns_view.window() else {
+        return;
+    };
 
     unsafe {
         // Configure collection behavior (taskbar / alt-tab / spaces)
         if behavior.is_skip_taskbar() || behavior.is_always_on_top() {
-            let mut collection_behavior: objc2::runtime::NSUInteger = 0;
+            let mut collection_behavior: usize = 0;
 
             if behavior.is_skip_taskbar() {
                 // NSWindowCollectionBehavior::CanJoinAllSpaces

--- a/crates/base/src/window_ext.rs
+++ b/crates/base/src/window_ext.rs
@@ -220,7 +220,7 @@ fn configure_windows(
         SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW,
     };
 
-    let hwnd = HWND(handle.hwnd as _);
+    let hwnd: HWND = handle.hwnd as _;
     if hwnd.is_invalid() {
         return;
     }
@@ -231,16 +231,16 @@ fn configure_windows(
 
         if behavior.is_skip_taskbar() {
             // WS_EX_TOOLWINDOW: hide from taskbar
-            ex_style |= WS_EX_TOOLWINDOW.0;
+            ex_style |= WS_EX_TOOLWINDOW;
             // WS_EX_NOACTIVATE: don't steal focus
-            ex_style |= WS_EX_NOACTIVATE.0;
+            ex_style |= WS_EX_NOACTIVATE;
         }
 
         if behavior.is_click_through() {
             // WS_EX_TRANSPARENT: click-through
-            ex_style |= WS_EX_TRANSPARENT.0;
+            ex_style |= WS_EX_TRANSPARENT;
             // WS_EX_LAYERED: required for transparent styles
-            ex_style |= WS_EX_LAYERED.0;
+            ex_style |= WS_EX_LAYERED;
         }
 
         // Apply extended styles

--- a/crates/base/src/window_ext.rs
+++ b/crates/base/src/window_ext.rs
@@ -220,8 +220,8 @@ fn configure_windows(
         SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW,
     };
 
-    let hwnd: HWND = handle.hwnd as _;
-    if hwnd.is_invalid() {
+    let hwnd: HWND = handle.hwnd.get() as *mut _;
+    if hwnd.is_null() {
         return;
     }
 

--- a/crates/base/src/window_ext.rs
+++ b/crates/base/src/window_ext.rs
@@ -152,19 +152,20 @@ fn configure_macos(
     handle: raw_window_handle::AppKitWindowHandle,
     behavior: &WindowBehavior,
 ) {
-    use objc2::runtime::NSObject;
     use objc2::msg_send;
     use objc2_app_kit::{NSView, NSWindow};
 
     // Get the NSWindow from the NSView handle
-    let ns_view_ptr = handle.ns_view as *mut NSObject;
+    let ns_view_ptr = handle.ns_view.as_ptr() as *mut NSView;
     if ns_view_ptr.is_null() {
         return;
     }
-    let ns_view: &NSView = unsafe { &*ns_view_ptr.cast::<NSView>() };
+    let ns_view = unsafe { &*ns_view_ptr };
     let Some(ns_window) = ns_view.window() else {
         return;
     };
+    // Use a reference for msg_send! (Retained<NSWindow> is not MessageReceiver)
+    let ns_window_ref = &*ns_window;
 
     unsafe {
         // Configure collection behavior (taskbar / alt-tab / spaces)
@@ -187,18 +188,18 @@ fn configure_macos(
                 collection_behavior |= 1 << 0;
             }
 
-            let _: () = msg_send![ns_window, setCollectionBehavior: collection_behavior];
+            let _: () = msg_send![ns_window_ref, setCollectionBehavior: collection_behavior];
         }
 
         // Configure window level (always on top)
         if behavior.is_always_on_top() {
             // NSFloatingWindowLevel = 3, use 5 to be above floating
-            let _: () = msg_send![ns_window, setLevel: 5];
+            let _: () = msg_send![ns_window_ref, setLevel: 5];
         }
 
         // Configure click-through
         if behavior.is_click_through() {
-            let _: () = msg_send![ns_window, setIgnoresMouseEvents: true];
+            let _: () = msg_send![ns_window_ref, setIgnoresMouseEvents: true];
         }
     }
 }

--- a/crates/base/src/window_ext.rs
+++ b/crates/base/src/window_ext.rs
@@ -153,7 +153,7 @@ fn configure_macos(
     behavior: &WindowBehavior,
 ) {
     use objc2::msg_send;
-    use objc2_app_kit::{NSView, NSWindow};
+    use objc2_app_kit::NSView;
 
     // Get the NSWindow from the NSView handle
     let ns_view_ptr = handle.ns_view.as_ptr() as *mut NSView;
@@ -213,11 +213,11 @@ fn configure_windows(
     handle: raw_window_handle::Win32WindowHandle,
     behavior: &WindowBehavior,
 ) {
-    use windows::Win32::Foundation::HWND;
-    use windows::Win32::UI::WindowsAndMessaging::{
-        self, GWL_EXSTYLE, HWND_NOTOPMOST, HWND_TOPMOST, SET_WINDOW_POS_FLAGS,
-        WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, SetWindowLongW,
-        SetWindowPos, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW,
+    use windows_sys::Win32::Foundation::HWND;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GWL_EXSTYLE, HWND_NOTOPMOST, HWND_TOPMOST, SET_WINDOW_POS_FLAGS, WS_EX_LAYERED,
+        WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, SetWindowLongW, SetWindowPos,
+        SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW,
     };
 
     let hwnd = HWND(handle.hwnd as _);

--- a/crates/base/src/window_ext.rs
+++ b/crates/base/src/window_ext.rs
@@ -209,7 +209,11 @@ fn configure_windows(
     behavior: &WindowBehavior,
 ) {
     use windows::Win32::Foundation::HWND;
-    use windows::Win32::UI::WindowsAndMessaging::*;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        self, GWL_EXSTYLE, HWND_NOTOPMOST, HWND_TOPMOST, SET_WINDOW_POS_FLAGS,
+        WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, SetWindowLongW,
+        SetWindowPos, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE, SWP_SHOWWINDOW,
+    };
 
     let hwnd = HWND(handle.hwnd as _);
     if hwnd.is_invalid() {
@@ -218,46 +222,34 @@ fn configure_windows(
 
     unsafe {
         // Build extended window styles
-        let mut ex_style: WINDOW_EX_STYLE = WINDOW_EX_STYLE(0);
+        let mut ex_style: u32 = 0;
 
         if behavior.is_skip_taskbar() {
             // WS_EX_TOOLWINDOW: hide from taskbar
-            ex_style |= WS_EX_TOOLWINDOW;
+            ex_style |= WS_EX_TOOLWINDOW.0;
             // WS_EX_NOACTIVATE: don't steal focus
-            ex_style |= WS_EX_NOACTIVATE;
+            ex_style |= WS_EX_NOACTIVATE.0;
         }
 
         if behavior.is_click_through() {
             // WS_EX_TRANSPARENT: click-through
-            ex_style |= WS_EX_TRANSPARENT;
+            ex_style |= WS_EX_TRANSPARENT.0;
             // WS_EX_LAYERED: required for transparent styles
-            ex_style |= WS_EX_LAYERED;
+            ex_style |= WS_EX_LAYERED.0;
         }
 
         // Apply extended styles
-        SetWindowLongW(hwnd, GWL_EXSTYLE, ex_style.0 as i32);
+        let _ = SetWindowLongW(hwnd, GWL_EXSTYLE, ex_style as i32);
+
+        // Build set-window-pos flags
+        let flags: SET_WINDOW_POS_FLAGS =
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW;
 
         // Set z-order
         if behavior.is_always_on_top() {
-            SetWindowPos(
-                hwnd,
-                HWND_TOPMOST,
-                0,
-                0,
-                0,
-                0,
-                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW,
-            );
+            let _ = SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, flags);
         } else {
-            SetWindowPos(
-                hwnd,
-                HWND_NOTOPMOST,
-                0,
-                0,
-                0,
-                0,
-                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW,
-            );
+            let _ = SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, flags);
         }
     }
 }

--- a/crates/base/src/window_ext.rs
+++ b/crates/base/src/window_ext.rs
@@ -1,0 +1,342 @@
+//! Platform-specific window configuration utilities.
+//!
+//! Provides cross-platform APIs to configure window behavior beyond what
+//! [`WindowOptions`] offers:
+//!
+//! - **Skip taskbar** — hide the window from the taskbar / dock / alt-tab
+//! - **Click-through** — mouse events pass through the window
+//! - **Always on top** — window stays above other windows
+//!
+//! # Example
+//!
+//! ```no_run
+//! use gpui_kit::base::window_ext;
+//!
+//! // After creating a window, configure it as an overlay:
+//! window_ext::make_overlay(&window);
+//! ```
+//!
+//! [`WindowOptions`]: gpui::WindowOptions
+
+use gpui::Window;
+use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+/// Window behavior configuration.
+///
+/// Construct with the builder methods and pass to [`configure`].
+///
+/// # Example
+///
+/// ```
+/// use gpui_kit::base::window_ext::WindowBehavior;
+///
+/// let behavior = WindowBehavior::new()
+///     .skip_taskbar(true)
+///     .click_through(true)
+///     .always_on_top(true);
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct WindowBehavior {
+    skip_taskbar: bool,
+    click_through: bool,
+    always_on_top: bool,
+}
+
+impl WindowBehavior {
+    /// Create a new `WindowBehavior` with all options disabled.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Whether the window is hidden from the taskbar, dock, and alt-tab.
+    pub fn is_skip_taskbar(&self) -> bool {
+        self.skip_taskbar
+    }
+
+    /// Whether mouse events pass through the window.
+    pub fn is_click_through(&self) -> bool {
+        self.click_through
+    }
+
+    /// Whether the window stays above other windows.
+    pub fn is_always_on_top(&self) -> bool {
+        self.always_on_top
+    }
+
+    /// Set whether to hide the window from the taskbar.
+    pub fn with_skip_taskbar(mut self, skip: bool) -> Self {
+        self.skip_taskbar = skip;
+        self
+    }
+
+    /// Set whether mouse events pass through the window.
+    pub fn with_click_through(mut self, click_through: bool) -> Self {
+        self.click_through = click_through;
+        self
+    }
+
+    /// Set whether the window should stay on top of other windows.
+    pub fn with_always_on_top(mut self, on_top: bool) -> Self {
+        self.always_on_top = on_top;
+        self
+    }
+}
+
+/// Apply a [`WindowBehavior`] configuration to a window.
+///
+/// Call this after the window has been created (e.g. inside the
+/// `open_window` closure, or from a `cx.defer` callback).
+///
+/// # Example
+///
+/// ```no_run
+/// use gpui_kit::base::window_ext::{self, WindowBehavior};
+///
+/// // Inside a window handler:
+/// let behavior = WindowBehavior::new()
+///     .with_skip_taskbar(true)
+///     .with_always_on_top(true);
+/// window_ext::configure(&window, &behavior);
+/// ```
+pub fn configure(window: &Window, behavior: &WindowBehavior) {
+    let Ok(handle) = HasWindowHandle::window_handle(window) else {
+        return;
+    };
+    match handle.as_raw() {
+        #[cfg(target_os = "macos")]
+        RawWindowHandle::AppKit(handle) => configure_macos(handle, behavior),
+        #[cfg(target_os = "windows")]
+        RawWindowHandle::Win32(handle) => configure_windows(handle, behavior),
+        #[cfg(target_os = "linux")]
+        RawWindowHandle::Xlib(handle) => configure_xlib(window, handle, behavior),
+        #[cfg(target_os = "linux")]
+        RawWindowHandle::Wayland(_) => {
+            // Wayland does not support these features at the client level.
+        }
+        _ => {}
+    }
+}
+
+/// Convenience: configure as an overlay window (skip taskbar + click-through + always on top).
+pub fn make_overlay(window: &Window) {
+    configure(
+        window,
+        &WindowBehavior::new()
+            .with_skip_taskbar(true)
+            .with_click_through(true)
+            .with_always_on_top(true),
+    );
+}
+
+/// Convenience: configure as a floating window (skip taskbar + always on top, no click-through).
+pub fn make_floating(window: &Window) {
+    configure(
+        window,
+        &WindowBehavior::new()
+            .with_skip_taskbar(true)
+            .with_always_on_top(true),
+    );
+}
+
+/// Convenience: enable click-through only.
+pub fn set_click_through(window: &Window, enabled: bool) {
+    configure(window, &WindowBehavior::new().with_click_through(enabled));
+}
+
+// ---------------------------------------------------------------------------
+// macOS implementation
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+fn configure_macos(
+    handle: raw_window_handle::AppKitWindowHandle,
+    behavior: &WindowBehavior,
+) {
+    use objc2::runtime::NSObject;
+    use objc2::{msg_send, ClassType};
+    use objc2_app_kit::NSWindow;
+
+    let ns_window_ptr = handle.ns_window as *mut NSObject;
+    if ns_window_ptr.is_null() {
+        return;
+    }
+    let ns_window: &NSWindow = unsafe { &*ns_window_ptr.cast::<NSWindow>() };
+
+    unsafe {
+        // Configure collection behavior (taskbar / alt-tab / spaces)
+        if behavior.is_skip_taskbar() || behavior.is_always_on_top() {
+            let mut collection_behavior: objc2::runtime::NSUInteger = 0;
+
+            if behavior.is_skip_taskbar() {
+                // NSWindowCollectionBehavior::CanJoinAllSpaces
+                collection_behavior |= 1 << 0;
+                // NSWindowCollectionBehavior::Stationary
+                collection_behavior |= 1 << 6;
+                // NSWindowCollectionBehavior::IgnoresCycle (hide from Alt-Tab)
+                collection_behavior |= 1 << 7;
+                // NSWindowCollectionBehavior::ExcludedFromWindowsMenu
+                collection_behavior |= 1 << 8;
+            }
+
+            if behavior.is_always_on_top() {
+                // NSWindowCollectionBehavior::CanJoinAllSpaces
+                collection_behavior |= 1 << 0;
+            }
+
+            let _: () = msg_send![ns_window, setCollectionBehavior: collection_behavior];
+        }
+
+        // Configure window level (always on top)
+        if behavior.is_always_on_top() {
+            // NSFloatingWindowLevel = 3, use 5 to be above floating
+            let _: () = msg_send![ns_window, setLevel: 5];
+        }
+
+        // Configure click-through
+        if behavior.is_click_through() {
+            let _: () = msg_send![ns_window, setIgnoresMouseEvents: true];
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Windows implementation
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+fn configure_windows(
+    handle: raw_window_handle::Win32WindowHandle,
+    behavior: &WindowBehavior,
+) {
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::*;
+
+    let hwnd = HWND(handle.hwnd as _);
+    if hwnd.is_invalid() {
+        return;
+    }
+
+    unsafe {
+        // Build extended window styles
+        let mut ex_style: WINDOW_EX_STYLE = WINDOW_EX_STYLE(0);
+
+        if behavior.is_skip_taskbar() {
+            // WS_EX_TOOLWINDOW: hide from taskbar
+            ex_style |= WS_EX_TOOLWINDOW;
+            // WS_EX_NOACTIVATE: don't steal focus
+            ex_style |= WS_EX_NOACTIVATE;
+        }
+
+        if behavior.is_click_through() {
+            // WS_EX_TRANSPARENT: click-through
+            ex_style |= WS_EX_TRANSPARENT;
+            // WS_EX_LAYERED: required for transparent styles
+            ex_style |= WS_EX_LAYERED;
+        }
+
+        // Apply extended styles
+        SetWindowLongW(hwnd, GWL_EXSTYLE, ex_style.0 as i32);
+
+        // Set z-order
+        if behavior.is_always_on_top() {
+            SetWindowPos(
+                hwnd,
+                HWND_TOPMOST,
+                0,
+                0,
+                0,
+                0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW,
+            );
+        } else {
+            SetWindowPos(
+                hwnd,
+                HWND_NOTOPMOST,
+                0,
+                0,
+                0,
+                0,
+                SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW,
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Linux/X11 implementation
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+fn configure_xlib(
+    _window: &Window,
+    handle: raw_window_handle::XlibWindowHandle,
+    behavior: &WindowBehavior,
+) {
+    use x11_dl::xlib;
+
+    // X11 requires a Display connection. We open a new one here because
+    // GPUI does not expose its display handle.
+    let xlib = match x11_dl::xlib::Xlib::open() {
+        Ok(x) => x,
+        Err(_) => return,
+    };
+
+    unsafe {
+        let display = (xlib.XOpenDisplay)(std::ptr::null());
+        if display.is_null() {
+            return;
+        }
+        let window = handle.window as xlib::Window;
+
+        // Helper: intern an atom
+        let intern_atom = |name: &[u8]| -> xlib::Atom {
+            (xlib.XInternAtom)(display, name.as_ptr() as *const i8, 0)
+        };
+
+        // Helper: set a single Atom property on the window
+        let set_atom_property = |property: xlib::Atom, value: xlib::Atom| {
+            (xlib.XChangeProperty)(
+                display,
+                window,
+                property,
+                xlib::XA_ATOM,
+                32,
+                xlib::PropModeReplace,
+                &value as *const _ as *const u8,
+                1,
+            );
+        };
+
+        // Set window type to DOCK to hide from taskbar/pager
+        if behavior.is_skip_taskbar() {
+            let atom_net_wm_window_type = intern_atom(b"_NET_WM_WINDOW_TYPE\0");
+            let atom_dock = intern_atom(b"_NET_WM_WINDOW_TYPE_DOCK\0");
+            set_atom_property(atom_net_wm_window_type, atom_dock);
+
+            // Also set SKIP_TASKBAR state
+            let atom_net_wm_state = intern_atom(b"_NET_WM_STATE\0");
+            let atom_skip_taskbar = intern_atom(b"_NET_WM_STATE_SKIP_TASKBAR\0");
+            set_atom_property(atom_net_wm_state, atom_skip_taskbar);
+        }
+
+        // Always on top
+        if behavior.is_always_on_top() {
+            let atom_net_wm_state = intern_atom(b"_NET_WM_STATE\0");
+            let atom_above = intern_atom(b"_NET_WM_STATE_ABOVE\0");
+            set_atom_property(atom_net_wm_state, atom_above);
+        }
+
+        // Click-through on X11 requires the Shape extension.
+        // We set _NET_WM_WINDOW_TYPE_SPLASH as a hint, but true
+        // click-through needs XShapeCombineRegion which requires
+        // querying the shape extension first.
+        if behavior.is_click_through() {
+            let atom_net_wm_window_type = intern_atom(b"_NET_WM_WINDOW_TYPE\0");
+            let atom_splash = intern_atom(b"_NET_WM_WINDOW_TYPE_SPLASH\0");
+            set_atom_property(atom_net_wm_window_type, atom_splash);
+        }
+
+        (xlib.XFlush)(display);
+        (xlib.XCloseDisplay)(display);
+    }
+}

--- a/crates/base/src/window_ext.rs
+++ b/crates/base/src/window_ext.rs
@@ -7,17 +7,31 @@
 //! - **Click-through** — mouse events pass through the window
 //! - **Always on top** — window stays above other windows
 //!
+//! # Platform support
+//!
+//! | Feature | macOS | Windows | Linux/X11 | Wayland |
+//! | ------- | ----- | ------- | --------- | ------- |
+//! | Skip taskbar | ✅ | ✅ | ✅ | ❌ |
+//! | Always on top | ✅ | ✅ | ✅ | ❌ |
+//! | Click-through | ✅ | ✅ | ⚠️ Partial | ❌ |
+//!
+//! Wayland is not supported at the client level due to protocol limitations.
+//! On Linux/X11, click-through uses `_NET_WM_WINDOW_TYPE_SPLASH` as a hint but
+//! does not implement true mouse-pass-through (that requires the XShape
+//! extension and is left for future work).
+//!
 //! # Example
 //!
 //! ```no_run
 //! use gpui_kit::base::window_ext;
 //!
 //! // After creating a window, configure it as an overlay:
-//! window_ext::make_overlay(&window);
+//! window_ext::make_overlay(&window).expect("configure overlay");
 //! ```
 //!
 //! [`WindowOptions`]: gpui::WindowOptions
 
+use anyhow::Result;
 use gpui::Window;
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 
@@ -87,6 +101,9 @@ impl WindowBehavior {
 /// Call this after the window has been created (e.g. inside the
 /// `open_window` closure, or from a `cx.defer` callback).
 ///
+/// Returns an error if the platform-specific handle cannot be obtained or
+/// the OS call fails.
+///
 /// # Example
 ///
 /// ```no_run
@@ -96,12 +113,12 @@ impl WindowBehavior {
 /// let behavior = WindowBehavior::new()
 ///     .with_skip_taskbar(true)
 ///     .with_always_on_top(true);
-/// window_ext::configure(&window, &behavior);
+/// window_ext::configure(&window, &behavior)?;
 /// ```
-pub fn configure(window: &Window, behavior: &WindowBehavior) {
-    let Ok(handle) = HasWindowHandle::window_handle(window) else {
-        return;
-    };
+pub fn configure(window: &Window, behavior: &WindowBehavior) -> Result<()> {
+    let handle = HasWindowHandle::window_handle(window).map_err(|e| {
+        anyhow::Error::msg(format!("failed to get window handle: {e}"))
+    })?;
     match handle.as_raw() {
         #[cfg(target_os = "macos")]
         RawWindowHandle::AppKit(handle) => configure_macos(handle, behavior),
@@ -111,36 +128,42 @@ pub fn configure(window: &Window, behavior: &WindowBehavior) {
         RawWindowHandle::Xlib(handle) => configure_xlib(window, handle, behavior),
         #[cfg(target_os = "linux")]
         RawWindowHandle::Wayland(_) => {
-            // Wayland does not support these features at the client level.
+            return Err(anyhow::Error::msg(
+                "Wayland does not support window_ext features at the client level",
+            ));
         }
-        _ => {}
+        other => {
+            return Err(anyhow::Error::msg(format!(
+                "unsupported window backend: {other:?}"
+            )));
+        }
     }
 }
 
 /// Convenience: configure as an overlay window (skip taskbar + click-through + always on top).
-pub fn make_overlay(window: &Window) {
+pub fn make_overlay(window: &Window) -> Result<()> {
     configure(
         window,
         &WindowBehavior::new()
             .with_skip_taskbar(true)
             .with_click_through(true)
             .with_always_on_top(true),
-    );
+    )
 }
 
 /// Convenience: configure as a floating window (skip taskbar + always on top, no click-through).
-pub fn make_floating(window: &Window) {
+pub fn make_floating(window: &Window) -> Result<()> {
     configure(
         window,
         &WindowBehavior::new()
             .with_skip_taskbar(true)
             .with_always_on_top(true),
-    );
+    )
 }
 
 /// Convenience: enable click-through only.
-pub fn set_click_through(window: &Window, enabled: bool) {
-    configure(window, &WindowBehavior::new().with_click_through(enabled));
+pub fn set_click_through(window: &Window, enabled: bool) -> Result<()> {
+    configure(window, &WindowBehavior::new().with_click_through(enabled))
 }
 
 // ---------------------------------------------------------------------------
@@ -151,57 +174,62 @@ pub fn set_click_through(window: &Window, enabled: bool) {
 fn configure_macos(
     handle: raw_window_handle::AppKitWindowHandle,
     behavior: &WindowBehavior,
-) {
+) -> Result<()> {
     use objc2::msg_send;
     use objc2_app_kit::NSView;
 
-    // Get the NSWindow from the NSView handle
+    // Get the NSWindow from the NSView handle.
     let ns_view_ptr = handle.ns_view.as_ptr() as *mut NSView;
     if ns_view_ptr.is_null() {
-        return;
+        return Err(anyhow::Error::msg("ns_view is null".into()));
     }
     let ns_view = unsafe { &*ns_view_ptr };
     let Some(ns_window) = ns_view.window() else {
-        return;
+        return Err(anyhow::Error::msg(
+            "ns_view is not attached to a window".into(),
+        ));
     };
-    // Use a reference for msg_send! (Retained<NSWindow> is not MessageReceiver)
+    // Use a reference for msg_send! (Retained<NSWindow> is not MessageReceiver).
     let ns_window_ref = &*ns_window;
 
     unsafe {
-        // Configure collection behavior (taskbar / alt-tab / spaces)
+        // Configure collection behavior (taskbar / alt-tab / spaces).
         if behavior.is_skip_taskbar() || behavior.is_always_on_top() {
             let mut collection_behavior: usize = 0;
 
             if behavior.is_skip_taskbar() {
-                // NSWindowCollectionBehavior::CanJoinAllSpaces
+                // NSWindowCollectionBehavior::CanJoinAllSpaces = 1 << 0
                 collection_behavior |= 1 << 0;
-                // NSWindowCollectionBehavior::Stationary
+                // NSWindowCollectionBehavior::Stationary = 1 << 6
                 collection_behavior |= 1 << 6;
-                // NSWindowCollectionBehavior::IgnoresCycle (hide from Alt-Tab)
+                // NSWindowCollectionBehavior::IgnoresCycle = 1 << 7 (hide from Alt-Tab)
                 collection_behavior |= 1 << 7;
-                // NSWindowCollectionBehavior::ExcludedFromWindowsMenu
+                // NSWindowCollectionBehavior::ExcludedFromWindowsMenu = 1 << 8
                 collection_behavior |= 1 << 8;
             }
 
             if behavior.is_always_on_top() {
-                // NSWindowCollectionBehavior::CanJoinAllSpaces
+                // NSWindowCollectionBehavior::CanJoinAllSpaces = 1 << 0
                 collection_behavior |= 1 << 0;
             }
 
             let _: () = msg_send![ns_window_ref, setCollectionBehavior: collection_behavior];
         }
 
-        // Configure window level (always on top)
+        // Configure window level (always on top).
+        // NSNormalWindowLevel = 0, NSFloatingWindowLevel = 3.
+        // Use 5 to stay above floating windows (e.g. menus).
         if behavior.is_always_on_top() {
-            // NSFloatingWindowLevel = 3, use 5 to be above floating
-            let _: () = msg_send![ns_window_ref, setLevel: 5];
+            const WINDOW_LEVEL_ABOVE_FLOATING: i32 = 5;
+            let _: () = msg_send![ns_window_ref, setLevel: WINDOW_LEVEL_ABOVE_FLOATING];
         }
 
-        // Configure click-through
+        // Configure click-through.
         if behavior.is_click_through() {
             let _: () = msg_send![ns_window_ref, setIgnoresMouseEvents: true];
         }
     }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -212,7 +240,7 @@ fn configure_macos(
 fn configure_windows(
     handle: raw_window_handle::Win32WindowHandle,
     behavior: &WindowBehavior,
-) {
+) -> Result<()> {
     use windows_sys::Win32::Foundation::HWND;
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         GWL_EXSTYLE, HWND_NOTOPMOST, HWND_TOPMOST, SET_WINDOW_POS_FLAGS, WS_EX_LAYERED,
@@ -222,41 +250,55 @@ fn configure_windows(
 
     let hwnd: HWND = handle.hwnd.get() as *mut _;
     if hwnd.is_null() {
-        return;
+        return Err(anyhow::Error::msg("HWND is null".into()));
     }
 
     unsafe {
-        // Build extended window styles
+        // Build extended window styles.
         let mut ex_style: u32 = 0;
 
         if behavior.is_skip_taskbar() {
-            // WS_EX_TOOLWINDOW: hide from taskbar
+            // WS_EX_TOOLWINDOW: hide from taskbar.
             ex_style |= WS_EX_TOOLWINDOW;
-            // WS_EX_NOACTIVATE: don't steal focus
+            // WS_EX_NOACTIVATE: don't steal focus.
             ex_style |= WS_EX_NOACTIVATE;
         }
 
         if behavior.is_click_through() {
-            // WS_EX_TRANSPARENT: click-through
+            // WS_EX_TRANSPARENT: click-through.
             ex_style |= WS_EX_TRANSPARENT;
-            // WS_EX_LAYERED: required for transparent styles
+            // WS_EX_LAYERED: required for transparent styles.
             ex_style |= WS_EX_LAYERED;
         }
 
-        // Apply extended styles
-        let _ = SetWindowLongW(hwnd, GWL_EXSTYLE, ex_style as i32);
+        // Apply extended styles.
+        let result = SetWindowLongW(hwnd, GWL_EXSTYLE, ex_style as i32);
+        if result == 0 {
+            let err = std::io::Error::last_os_error();
+            return Err(anyhow::Error::msg(format!(
+                "SetWindowLongW failed: {err}"
+            )));
+        }
 
-        // Build set-window-pos flags
+        // Build set-window-pos flags.
         let flags: SET_WINDOW_POS_FLAGS =
             SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE | SWP_SHOWWINDOW;
 
-        // Set z-order
-        if behavior.is_always_on_top() {
-            let _ = SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, flags);
+        // Set z-order.
+        let z_order = if behavior.is_always_on_top() {
+            HWND_TOPMOST
         } else {
-            let _ = SetWindowPos(hwnd, HWND_NOTOPMOST, 0, 0, 0, 0, flags);
+            HWND_NOTOPMOST
+        };
+        let result = SetWindowPos(hwnd, z_order, 0, 0, 0, 0, flags);
+        if result == 0 {
+            let err = std::io::Error::last_os_error();
+            return Err(anyhow::Error::msg(format!(
+                "SetWindowPos failed: {err}"
+            )));
         }
     }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -268,29 +310,35 @@ fn configure_xlib(
     _window: &Window,
     handle: raw_window_handle::XlibWindowHandle,
     behavior: &WindowBehavior,
-) {
+) -> Result<()> {
     use x11_dl::xlib;
 
     // X11 requires a Display connection. We open a new one here because
-    // GPUI does not expose its display handle.
+    // GPUI does not expose its display handle. This is intentionally a fresh
+    // connection per call — caching would require lifetime management that
+    // does not fit this API.
     let xlib = match x11_dl::xlib::Xlib::open() {
         Ok(x) => x,
-        Err(_) => return,
+        Err(e) => {
+            return Err(anyhow::Error::msg(format!(
+                "failed to load Xlib: {e}"
+            )))
+        }
     };
 
     unsafe {
         let display = (xlib.XOpenDisplay)(std::ptr::null());
         if display.is_null() {
-            return;
+            return Err(anyhow::Error::msg("XOpenDisplay failed"));
         }
         let window = handle.window as xlib::Window;
 
-        // Helper: intern an atom
+        // Helper: intern an atom.
         let intern_atom = |name: &[u8]| -> xlib::Atom {
             (xlib.XInternAtom)(display, name.as_ptr() as *const i8, 0)
         };
 
-        // Helper: set a single Atom property on the window
+        // Helper: set a single Atom property on the window.
         let set_atom_property = |property: xlib::Atom, value: xlib::Atom| {
             (xlib.XChangeProperty)(
                 display,
@@ -304,29 +352,29 @@ fn configure_xlib(
             );
         };
 
-        // Set window type to DOCK to hide from taskbar/pager
+        // Set window type to DOCK to hide from taskbar/pager.
         if behavior.is_skip_taskbar() {
             let atom_net_wm_window_type = intern_atom(b"_NET_WM_WINDOW_TYPE\0");
             let atom_dock = intern_atom(b"_NET_WM_WINDOW_TYPE_DOCK\0");
             set_atom_property(atom_net_wm_window_type, atom_dock);
 
-            // Also set SKIP_TASKBAR state
+            // Also set SKIP_TASKBAR state.
             let atom_net_wm_state = intern_atom(b"_NET_WM_STATE\0");
             let atom_skip_taskbar = intern_atom(b"_NET_WM_STATE_SKIP_TASKBAR\0");
             set_atom_property(atom_net_wm_state, atom_skip_taskbar);
         }
 
-        // Always on top
+        // Always on top.
         if behavior.is_always_on_top() {
             let atom_net_wm_state = intern_atom(b"_NET_WM_STATE\0");
             let atom_above = intern_atom(b"_NET_WM_STATE_ABOVE\0");
             set_atom_property(atom_net_wm_state, atom_above);
         }
 
-        // Click-through on X11 requires the Shape extension.
-        // We set _NET_WM_WINDOW_TYPE_SPLASH as a hint, but true
-        // click-through needs XShapeCombineRegion which requires
-        // querying the shape extension first.
+        // Click-through on X11 is not fully implementable without the Shape
+        // extension. We set the window type to SPLASH as a hint (some WMs
+        // treat splash windows as non-interactive), but true mouse-pass-through
+        // requires XShapeCombineRegion and is left for future work.
         if behavior.is_click_through() {
             let atom_net_wm_window_type = intern_atom(b"_NET_WM_WINDOW_TYPE\0");
             let atom_splash = intern_atom(b"_NET_WM_WINDOW_TYPE_SPLASH\0");
@@ -335,5 +383,44 @@ fn configure_xlib(
 
         (xlib.XFlush)(display);
         (xlib.XCloseDisplay)(display);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_behavior_is_all_disabled() {
+        let b = WindowBehavior::new();
+        assert!(!b.is_skip_taskbar());
+        assert!(!b.is_click_through());
+        assert!(!b.is_always_on_top());
+    }
+
+    #[test]
+    fn builder_flags_roundtrip() {
+        let b = WindowBehavior::new()
+            .with_skip_taskbar(true)
+            .with_click_through(true)
+            .with_always_on_top(true);
+        assert!(b.is_skip_taskbar());
+        assert!(b.is_click_through());
+        assert!(b.is_always_on_top());
+    }
+
+    #[test]
+    fn builder_can_disable_individually() {
+        let b = WindowBehavior::new()
+            .with_skip_taskbar(true)
+            .with_click_through(false);
+        assert!(b.is_skip_taskbar());
+        assert!(!b.is_click_through());
+        assert!(!b.is_always_on_top());
     }
 }

--- a/crates/component/src/dock/mod.rs
+++ b/crates/component/src/dock/mod.rs
@@ -86,6 +86,9 @@ pub(crate) struct SkinShared {
     tiles_scrollbar_mode: Cell<Option<ScrollbarMode>>,
     /// The dock whose resize handle is being dragged, if any. Only one can be.
     resizing_dock: Cell<Option<DockPlacement>>,
+    /// Whether the title-bar ellipsis (⋯) menu button is shown. Defaults to
+    /// `true`; skins that need a chrome-free title bar set it to `false`.
+    ellipsis_menu: Cell<bool>,
 }
 
 impl SkinShared {
@@ -107,6 +110,14 @@ impl SkinShared {
 
     pub(crate) fn resizing_dock(&self) -> &Cell<Option<DockPlacement>> {
         &self.resizing_dock
+    }
+
+    pub(crate) fn is_ellipsis_menu_visible(&self) -> bool {
+        self.ellipsis_menu.get()
+    }
+
+    pub(crate) fn set_ellipsis_menu_visible(&self, visible: bool) {
+        self.ellipsis_menu.set(visible);
     }
 
     /// Redraw the area after a setting changed. The skin is not an entity, so
@@ -165,6 +176,7 @@ impl DockSkin {
                 toggle_button_visible: Cell::new(true),
                 tiles_scrollbar_mode: Cell::new(None),
                 resizing_dock: Cell::new(None),
+                ellipsis_menu: Cell::new(true),
             }),
         })
     }
@@ -191,6 +203,17 @@ impl DockSkin {
 
     pub fn set_toggle_button_visible(&self, visible: bool, cx: &mut App) {
         self.shared.toggle_button_visible.set(visible);
+        self.shared.notify(cx);
+    }
+
+    /// Whether the title-bar ellipsis (⋯) menu button is drawn. Defaults to
+    /// `true`; set to `false` for a chrome-free title bar.
+    pub fn ellipsis_menu(&self) -> bool {
+        self.shared.is_ellipsis_menu_visible()
+    }
+
+    pub fn set_ellipsis_menu(&self, visible: bool, cx: &mut App) {
+        self.shared.set_ellipsis_menu_visible(visible);
         self.shared.notify(cx);
     }
 

--- a/crates/component/src/dock/tab_panel.rs
+++ b/crates/component/src/dock/tab_panel.rs
@@ -324,32 +324,34 @@ impl TabGroupSkin {
                     )
                 },
             )
-            .child(
-                Button::new("menu")
-                    .icon(IconName::Ellipsis)
-                    .xsmall()
-                    .ghost()
-                    .tab_stop(false)
-                    .dropdown_menu(move |menu, window, cx| {
-                        menu.when_some(panel.clone(), |menu, panel| {
-                            panel.dropdown_menu(menu, window, cx)
+            .when(self.shared.is_ellipsis_menu_visible(), |this| {
+                this.child(
+                    Button::new("menu")
+                        .icon(IconName::Ellipsis)
+                        .xsmall()
+                        .ghost()
+                        .tab_stop(false)
+                        .dropdown_menu(move |menu, window, cx| {
+                            menu.when_some(panel.clone(), |menu, panel| {
+                                panel.dropdown_menu(menu, window, cx)
+                            })
+                            .separator()
+                            .menu_with_disabled(
+                                match zoomed {
+                                    true => t!("Dock.Zoom Out"),
+                                    false => t!("Dock.Zoom In"),
+                                },
+                                Box::new(ToggleZoom),
+                                !menu_zoom,
+                            )
+                            .when(closable, |menu| {
+                                menu.separator()
+                                    .menu(t!("Dock.Close"), Box::new(ClosePanel))
+                            })
                         })
-                        .separator()
-                        .menu_with_disabled(
-                            match zoomed {
-                                true => t!("Dock.Zoom Out"),
-                                false => t!("Dock.Zoom In"),
-                            },
-                            Box::new(ToggleZoom),
-                            !menu_zoom,
-                        )
-                        .when(closable, |menu| {
-                            menu.separator()
-                                .menu(t!("Dock.Close"), Box::new(ClosePanel))
-                        })
-                    })
-                    .anchor(Anchor::TopRight),
-            )
+                        .anchor(Anchor::TopRight),
+                )
+            })
     }
 
     /// The one-panel title bar: no tabs, just the title and the controls.


### PR DESCRIPTION
Provides cross-platform APIs to configure OS-level window behavior:
- Skip taskbar (hide from taskbar/dock/alt-tab)
- Click-through (mouse events pass through window)
- Always on top (window stays above other windows)

Supports macOS (NSWindow), Windows (Win32 API), and Linux/X11. Wayland is not supported due to protocol limitations.

Generated with assistance from Claude Code.

Closes #[issue number]

## Description

Describe in English for the changes made in this pull request and the problem it solves.
Please keep **1 PR to solve 1 problem**, and keep **Small improvements should be small modifications** to make PR easier to review and to merge.

## Screenshot

| Before                       | After                       |
| ---------------------------- | --------------------------- |
| [Put Before Screenshot here] | [Put After Screenshot here] |

## Break Changes

Describe any breaking changes introduced by this pull request. If none, remove this section.

- Change 1

```diff
- Old code snippet
+ New code snippet
```

## How to Test

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
