### PR TITLE
chore: Forward platform test support and profiling

### DIFF
--- a/crates/kit/Cargo.toml
+++ b/crates/kit/Cargo.toml
@@ -21,8 +21,10 @@ default = ["component", "assets"]
 component = ["dep:gpui-component"]
 # The default icon set for `gpui-component`, `gpui_kit::assets`.
 assets = ["dep:gpui-kit-assets"]
-# GPUI's test harness: `#[gpui_kit::test]`, `TestAppContext`, `VisualTestContext`.
-test-support = ["gpui/test-support"]
+# GPUI's test harness and native-platform rendering support.
+test-support = ["gpui/test-support", "gpui_platform/test-support"]
+# Frame-event instrumentation remains opt-in for performance builds.
+profiler = ["gpui/profiler"]
 inspector = ["gpui/inspector", "gpui-base/inspector", "gpui-component?/inspector"]
 decimal = ["component", "gpui-component/decimal"]
 tree-sitter = ["component", "gpui-component/tree-sitter"]

--- a/crates/kit/README.md
+++ b/crates/kit/README.md
@@ -53,5 +53,7 @@ fn main() {
 The `gpui-component` features (`inspector`, `decimal`, `tree-sitter`,
 `tree-sitter-languages`, and each `tree-sitter-<language>`) are available on
 `gpui-kit` under the same names. `test-support` turns on GPUI's test harness
-for `#[gpui_kit::test]`, `TestAppContext` and `VisualTestContext`; enable it
-under `[dev-dependencies]`. See <https://gpui-kit.com> for the guides.
+for `#[gpui_kit::test]`, `TestAppContext`, `VisualTestContext`, and native-platform
+rendering support; enable it under `[dev-dependencies]`. The independent `profiler`
+feature enables GPUI frame-event instrumentation and is off by default.
+See <https://gpui-kit.com> for the guides.

--- a/crates/kit/tests/exports.rs
+++ b/crates/kit/tests/exports.rs
@@ -102,3 +102,7 @@ mod component {
 mod assets {
     type Assets = gpui_kit::assets::Assets;
 }
+
+/// The opt-in facade feature enables GPUI's feature-gated profiler API.
+#[cfg(feature = "profiler")]
+type WindowProfiler = gpui_kit::profiler::WindowProfiler;

--- a/crates/kit/tests/exports.rs
+++ b/crates/kit/tests/exports.rs
@@ -105,4 +105,4 @@ mod assets {
 
 /// The opt-in facade feature enables GPUI's feature-gated profiler API.
 #[cfg(feature = "profiler")]
-type WindowProfiler = gpui_kit::profiler::WindowProfiler;
+use gpui_kit::profiler::WindowProfiler;


### PR DESCRIPTION
I use GPUI Kit in NearWord (app based on gpui-kit now). These changes come from my fork, that I made during testing/

`test-support` enables GPUI's test harness but leaves out the native platform implementation. On macOS, screenshot capture can fail with `render_to_image not implemented for this platform`. This patch also enables `gpui_platform/test-support`.

It adds `profiler = ["gpui/profiler"]` so applications can enable profiling through `gpui-kit`, without adding a direct GPUI dependency. Profiling stays opt-in. The patch includes feature documentation and a compile-time `WindowProfiler` export check.

Default features, dependency versions, and the lockfile are unchanged.

## How to Test

Passed on macOS:

- Build checks with default features, no default features, and `test-support` and `profiler` separately and together.
- Kit tests, doctests, formatting, and Clippy with warnings denied.
- Isolated consumer checks for platform test support and opt-in profiling.
- Native Metal capture, with the center pixel matching `[51, 102, 153, 255]`.

<details>
<summary>Build and test commands</summary>

Run from the repository root. All commands should pass. The export check runs at compile time.

```sh
cargo check -p gpui-kit --locked
cargo check -p gpui-kit --no-default-features --locked
cargo check -p gpui-kit --features test-support --locked
cargo check -p gpui-kit --features profiler --locked
cargo check -p gpui-kit --features test-support,profiler --locked
cargo test -p gpui-kit --features test-support,profiler --locked
cargo clippy -p gpui-kit --all-targets --features test-support,profiler --locked -- -D warnings
```

</details>

<details>
<summary>Reproduce native screenshot capture on macOS</summary>

On macOS with Metal, save this as `crates/kit/examples/native_render.rs`; create the directory if needed. This temporary probe is not part of the committed tests.

```rust
use gpui_kit::{AppContext as _, Context, IntoElement, Render, Styled, VisualTestAppContext, div, px, size};

struct Swatch;

impl Render for Swatch {
    fn render(&mut self, _: &mut gpui_kit::Window, _: &mut Context<Self>) -> impl IntoElement {
        div().size_full().bg(gpui_kit::rgb(0x336699))
    }
}

fn main() {
    let mut cx = VisualTestAppContext::new(gpui_kit::platform::current_platform(false));
    let window = cx.open_offscreen_window(size(px(64.), px(48.)), |_, cx| cx.new(|_| Swatch))
        .expect("open native offscreen window");
    cx.run_until_parked();
    let image = cx.capture_screenshot(window.into()).expect("native render_to_image");
    let pixel = image.get_pixel(image.width()/2, image.height()/2);
    assert_eq!(pixel.0, [0x33, 0x66, 0x99, 0xff]);
    println!("native rendering passed: {}x{}, center={:?}", image.width(), image.height(), pixel.0);
}
```

From the repository root, run:

```sh
cargo run -p gpui-kit --example native_render --features test-support --locked
```

Capture and the pixel assertion should succeed. Observed output:

```text
native rendering passed: 128x96, center=[51, 102, 153, 255]
```

Image dimensions depend on the display scale; the center pixel must match. Remove the temporary example after testing:

```sh
rm crates/kit/examples/native_render.rs
```

</details>

Story was not used for this feature-flag change; the native probe checks screenshot capture directly. Windows and Linux runtime checks were not run.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/longbridge/gpui-kit/blob/main/CONTRIBUTING.md).
- [x] Reviewed the patch, including AI-assisted changes.
- [x] Manually tested the patch.
- [ ] Windows and Linux runtime validation.

## AI assistance

OpenAI’s `gpt-6-astra` extracted these changes from my GPUI Kit fork used in NearWord and prepared this PR. I reviewed the patch and made edits before submitting it.
