### PR TITLE
icon: Support SVG bytes in component icon slots

### DIFF
--- a/crates/component/src/button/button_icon.rs
+++ b/crates/component/src/button/button_icon.rs
@@ -165,4 +165,38 @@ mod tests {
         assert!(!progress_variant.is_spinner());
         assert!(progress_variant.is_progress());
     }
+
+    #[test]
+    fn test_custom_data_icon_converts_through_component_slots() {
+        use crate::{icon::IconSource, menu::PopupMenuItem};
+
+        struct Search;
+        impl From<Search> for Icon {
+            fn from(_: Search) -> Self {
+                Icon::default().data(include_bytes!("../../../assets/assets/icons/search.svg"))
+            }
+        }
+
+        let button = ButtonIcon::from(Search)
+            .loading(true)
+            .loading_icon(Some(Search.into()));
+        let ButtonIconVariant::Icon(icon) = button.icon else {
+            panic!("custom data icons must use the standard icon variant");
+        };
+        assert!(matches!(icon.source_ref(), IconSource::Data(_)));
+        assert!(button.loading);
+        assert!(matches!(
+            button.loading_icon.unwrap().source_ref(),
+            IconSource::Data(_)
+        ));
+
+        let menu = PopupMenuItem::new("Search").icon(Search);
+        let PopupMenuItem::Item {
+            icon: Some(icon), ..
+        } = menu
+        else {
+            panic!("custom data icons must be accepted by menu slots");
+        };
+        assert!(matches!(icon.source_ref(), IconSource::Data(_)));
+    }
 }

--- a/crates/component/src/icon.rs
+++ b/crates/component/src/icon.rs
@@ -1,7 +1,9 @@
+use std::sync::Arc;
+
 use crate::{ActiveTheme, Sizable, Size};
 use gpui::{
-    AnyElement, App, AppContext, Context, Entity, Hsla, IntoElement, Radians, Render, RenderOnce,
-    SharedString, StyleRefinement, Styled, Svg, Transformation, Window,
+    AnyElement, App, AppContext, Context, Entity, Hsla, IntoElement, Pixels, Radians, Render,
+    RenderOnce, SharedString, StyleRefinement, Styled, Svg, Transformation, Window,
     prelude::FluentBuilder as _, svg,
 };
 use gpui_component_macros::icon_named;
@@ -47,37 +49,30 @@ impl RenderOnce for IconName {
     }
 }
 
-#[derive(IntoElement)]
+#[derive(Clone)]
+pub(crate) enum IconSource {
+    Path(SharedString),
+    Data(Arc<[u8]>),
+}
+
+#[derive(Clone, IntoElement)]
 pub struct Icon {
-    base: Svg,
     style: StyleRefinement,
-    path: SharedString,
+    source: IconSource,
     text_color: Option<Hsla>,
     size: Option<Size>,
-    rotation: Option<Radians>,
+    transformation: Option<Transformation>,
 }
 
 impl Default for Icon {
     fn default() -> Self {
         Self {
-            base: svg().flex_none().size_4(),
             style: StyleRefinement::default(),
-            path: "".into(),
+            source: IconSource::Path("".into()),
             text_color: None,
             size: None,
-            rotation: None,
+            transformation: None,
         }
-    }
-}
-
-impl Clone for Icon {
-    fn clone(&self) -> Self {
-        let mut this = Self::default().path(self.path.clone());
-        this.style = self.style.clone();
-        this.rotation = self.rotation;
-        this.size = self.size;
-        this.text_color = self.text_color;
-        this
     }
 }
 
@@ -93,14 +88,34 @@ impl Icon {
     /// Set the icon path of the Assets bundle
     ///
     /// For example: `icons/foo.svg`
+    /// Replaces any previously set path or SVG data.
     pub fn path(mut self, path: impl Into<SharedString>) -> Self {
-        self.path = path.into();
+        self.source = IconSource::Path(path.into());
+        self
+    }
+
+    /// Set raw SVG bytes without registering an asset path.
+    ///
+    /// Copies the bytes into shared storage; the input need not be static.
+    /// Cloning the icon shares those bytes. Replaces any previously set path or data.
+    /// Parsing and rendering follow GPUI's SVG behavior.
+    ///
+    /// ```
+    /// use gpui_component::Icon;
+    ///
+    /// let bytes = br#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    ///     <path d="M4 12h16" stroke="currentColor"/>
+    /// </svg>"#;
+    /// let icon = Icon::default().data(bytes);
+    /// ```
+    pub fn data(mut self, data: &[u8]) -> Self {
+        self.source = IconSource::Data(Arc::from(data));
         self
     }
 
     #[cfg(any(target_os = "macos", target_os = "windows", test))]
-    pub(crate) fn path_ref(&self) -> &SharedString {
-        &self.path
+    pub(crate) fn source_ref(&self) -> &IconSource {
+        &self.source
     }
 
     /// Create a new view for the icon
@@ -108,8 +123,9 @@ impl Icon {
         cx.new(|_| self)
     }
 
+    /// Set the SVG transformation, replacing any previous transformation or rotation.
     pub fn transform(mut self, transformation: gpui::Transformation) -> Self {
-        self.base = self.base.with_transformation(transformation);
+        self.transformation = Some(transformation);
         self
     }
 
@@ -118,11 +134,39 @@ impl Icon {
     }
 
     /// Rotate the icon by the given angle
+    ///
+    /// Replaces any previous transformation or rotation.
     pub fn rotate(mut self, radians: impl Into<Radians>) -> Self {
-        self.base = self
-            .base
-            .with_transformation(Transformation::rotate(radians));
+        self.transformation = Some(Transformation::rotate(radians));
         self
+    }
+
+    fn into_svg(self, text_size: Pixels, fallback_color: Hsla) -> Svg {
+        let text_color = self.text_color.unwrap_or(fallback_color);
+        let has_base_size = self.style.size.width.is_some() || self.style.size.height.is_some();
+
+        svg()
+            .map(|mut this| {
+                *this.style() = self.style;
+                this
+            })
+            .flex_shrink_0()
+            .text_color(text_color)
+            .when(!has_base_size, |this| this.size(text_size))
+            .when_some(self.size, |this, size| match size {
+                Size::Size(px) => this.size(px),
+                Size::XSmall => this.size_3(),
+                Size::Small => this.size_3p5(),
+                Size::Medium => this.size_4(),
+                Size::Large => this.size_6(),
+            })
+            .map(|this| match self.source {
+                IconSource::Path(path) => this.path(path),
+                IconSource::Data(data) => this.data(&data),
+            })
+            .when_some(self.transformation, |this, transformation| {
+                this.with_transformation(transformation)
+            })
     }
 }
 
@@ -146,24 +190,8 @@ impl Sizable for Icon {
 
 impl RenderOnce for Icon {
     fn render(self, window: &mut Window, _cx: &mut App) -> impl IntoElement {
-        let text_color = self.text_color.unwrap_or_else(|| window.text_style().color);
         let text_size = window.text_style().font_size.to_pixels(window.rem_size());
-        let has_base_size = self.style.size.width.is_some() || self.style.size.height.is_some();
-
-        let mut base = self.base;
-        *base.style() = self.style;
-
-        base.flex_shrink_0()
-            .text_color(text_color)
-            .when(!has_base_size, |this| this.size(text_size))
-            .when_some(self.size, |this, size| match size {
-                Size::Size(px) => this.size(px),
-                Size::XSmall => this.size_3(),
-                Size::Small => this.size_3p5(),
-                Size::Medium => this.size_4(),
-                Size::Large => this.size_6(),
-            })
-            .path(self.path)
+        self.into_svg(text_size, window.text_style().color)
     }
 }
 
@@ -175,26 +203,68 @@ impl From<Icon> for AnyElement {
 
 impl Render for Icon {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let text_color = self.text_color.unwrap_or_else(|| cx.theme().foreground);
         let text_size = window.text_style().font_size.to_pixels(window.rem_size());
-        let has_base_size = self.style.size.width.is_some() || self.style.size.height.is_some();
+        self.clone().into_svg(text_size, cx.theme().foreground)
+    }
+}
 
-        let mut base = svg().flex_none();
-        *base.style() = self.style.clone();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{px, size};
 
-        base.flex_shrink_0()
-            .text_color(text_color)
-            .when(!has_base_size, |this| this.size(text_size))
-            .when_some(self.size, |this, size| match size {
-                Size::Size(px) => this.size(px),
-                Size::XSmall => this.size_3(),
-                Size::Small => this.size_3p5(),
-                Size::Medium => this.size_4(),
-                Size::Large => this.size_6(),
-            })
-            .path(self.path.clone())
-            .when_some(self.rotation, |this, rotation| {
-                this.with_transformation(Transformation::rotate(rotation))
-            })
+    const SVG: &[u8] = include_bytes!("../../assets/assets/icons/arrow-up.svg");
+
+    #[test]
+    fn test_icon_builder_preserves_owned_data_and_transform_on_clone() {
+        let transformation = Transformation::scale(size(0.5, 0.5))
+            .with_rotation(gpui::radians(std::f32::consts::FRAC_PI_2));
+        let icon = {
+            let bytes = SVG.to_vec();
+            Icon::default()
+                .data(&bytes)
+                .large()
+                .text_color(gpui::red())
+                .transform(transformation)
+        };
+        let cloned = icon.clone();
+        let (IconSource::Data(original), IconSource::Data(copy)) = (&icon.source, &cloned.source)
+        else {
+            panic!("cloning must preserve the data source");
+        };
+        assert_eq!(copy.as_ref(), SVG);
+        assert!(Arc::ptr_eq(original, copy));
+        assert_eq!(cloned.transformation, Some(transformation));
+        assert_eq!(cloned.size, icon.size);
+        assert_eq!(cloned.text_color, icon.text_color);
+
+        let mut svg = cloned.into_svg(px(12.), gpui::blue());
+        assert_eq!(svg.style().text.color, Some(gpui::red()));
+        assert_eq!(svg.style().size.width, Some(gpui::rems(1.5).into()));
+
+        let rotated = icon.rotate(gpui::radians(std::f32::consts::PI)).clone();
+        assert_eq!(
+            rotated.transformation,
+            Some(Transformation::rotate(gpui::radians(std::f32::consts::PI)))
+        );
+    }
+
+    #[test]
+    fn test_icon_source_builders_replace_previous_source() {
+        let icon = Icon::new(IconName::Search).data(SVG);
+        assert!(matches!(icon.source_ref(), IconSource::Data(bytes) if bytes.as_ref() == SVG));
+
+        let icon = icon.path("icons/replacement.svg");
+        assert!(
+            matches!(icon.source_ref(), IconSource::Path(path) if path == "icons/replacement.svg")
+        );
+
+        let icon = icon.data(SVG).data(b"replacement");
+        assert!(
+            matches!(icon.source_ref(), IconSource::Data(bytes) if bytes.as_ref() == b"replacement")
+        );
+
+        let icon = icon.path("");
+        assert!(matches!(icon.source_ref(), IconSource::Path(path) if path.is_empty()));
     }
 }

--- a/crates/component/src/native_menu/macos.rs
+++ b/crates/component/src/native_menu/macos.rs
@@ -2,7 +2,7 @@
 
 use std::{cell::Cell, sync::Arc};
 
-use gpui::{Action, App, AssetSource, Pixels, Point, SharedString, Window};
+use gpui::{Action, App, AssetSource, Pixels, Point, Window};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, NSObject};
 use objc2::{AnyThread, DefinedClass, MainThreadMarker, define_class, msg_send, sel};
@@ -145,7 +145,7 @@ fn build_menu<'a>(
                     ns_item.setTitle(&NSString::from_str(label));
                     ns_item.setEnabled(!*disabled);
                     if let Some(icon) = icon {
-                        if let Some(ns_image) = ns_image_for_icon(icon.path_ref(), asset_source) {
+                        if let Some(ns_image) = ns_image_for_icon(icon, asset_source) {
                             ns_image.setSize(NSSize::new(MENU_IMAGE_SIZE, MENU_IMAGE_SIZE));
                             ns_image.setTemplate(true);
                             ns_item.setImage(Some(&ns_image));
@@ -186,10 +186,10 @@ fn build_menu<'a>(
 }
 
 fn ns_image_for_icon(
-    path: &SharedString,
+    icon: &crate::Icon,
     asset_source: &dyn AssetSource,
 ) -> Option<Retained<NSImage>> {
-    let image = resolve_icon_image(path, asset_source)?;
+    let image = resolve_icon_image(icon, asset_source)?;
     if image.bytes.is_empty() {
         return None;
     }

--- a/crates/component/src/native_menu/mod.rs
+++ b/crates/component/src/native_menu/mod.rs
@@ -25,6 +25,8 @@
 #[cfg(target_os = "windows")]
 use crate::ActiveTheme as _;
 use crate::Icon;
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
+use crate::icon::IconSource;
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use gpui::AssetSource;
@@ -106,6 +108,7 @@ impl NativeMenu {
     ///
     /// Native platform menus load absolute paths ([`Path::is_absolute`]) from the filesystem,
     /// and every other path through the application [`gpui::AssetSource`].
+    /// Icons created with [`Icon::data`] use their SVG bytes directly, without an asset lookup.
     /// [`crate::IconName`] resolves as an asset and works across all backends.
     /// - **macOS**: loaded into an `NSImage` as a template image, so it tints with the item
     /// text and assigned to the item ([`NSMenuItem::image`]).
@@ -222,9 +225,18 @@ impl NativeMenu {
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 pub(super) fn resolve_icon_image(
-    path: &SharedString,
+    icon: &Icon,
     asset_source: &dyn AssetSource,
 ) -> Option<Arc<Image>> {
+    let path = match icon.source_ref() {
+        IconSource::Path(path) => path,
+        IconSource::Data(bytes) => {
+            return Some(Arc::new(Image::from_bytes(
+                ImageFormat::Svg,
+                bytes.to_vec(),
+            )));
+        }
+    };
     if path.is_empty() {
         return None;
     }
@@ -372,7 +384,7 @@ mod tests {
         assert_eq!(label, "Github");
         assert!(!disabled);
         assert!(!checked);
-        assert_eq!(icon.path_ref().as_ref(), "icons/github.svg");
+        assert!(matches!(icon.source_ref(), IconSource::Path(path) if path == "icons/github.svg"));
     }
 
     #[test]
@@ -399,7 +411,7 @@ mod tests {
         assert_eq!(label, "Inbox");
         assert!(disabled);
         assert!(!checked);
-        assert!(icon.path_ref().ends_with("inbox.svg"));
+        assert!(matches!(icon.source_ref(), IconSource::Path(path) if path.ends_with("inbox.svg")));
     }
 
     /// Icon resolution is only compiled for the platforms with an OS-native menu.
@@ -452,7 +464,7 @@ mod tests {
         #[test]
         fn test_native_menu_icon_asset_resolves_to_bytes() {
             let icon = Icon::new(IconName::Github);
-            let image = resolve_icon_image(icon.path_ref(), &gpui_kit_assets::Assets)
+            let image = resolve_icon_image(&icon, &gpui_kit_assets::Assets)
                 .expect("icon asset should resolve");
 
             assert_eq!(image.format, ImageFormat::Svg);
@@ -464,11 +476,12 @@ mod tests {
             let path: SharedString = "native-menu-relative-shadow-test.svg".into();
             let _file = TestIconFile::create(path.as_ref(), FILE_SVG);
 
-            let image = resolve_icon_image(&path, &TestAssetSource(Some(ASSET_SVG)))
+            let icon = Icon::default().path(path);
+            let image = resolve_icon_image(&icon, &TestAssetSource(Some(ASSET_SVG)))
                 .expect("relative icon should resolve from the asset source");
             assert_eq!(image.bytes, ASSET_SVG);
 
-            assert!(resolve_icon_image(&path, &TestAssetSource(None)).is_none());
+            assert!(resolve_icon_image(&icon, &TestAssetSource(None)).is_none());
         }
 
         #[test]
@@ -479,9 +492,26 @@ mod tests {
             let _file = TestIconFile::create(&path, FILE_SVG);
             let path: SharedString = path.to_string_lossy().into_owned().into();
 
-            let image = resolve_icon_image(&path, &TestAssetSource(Some(ASSET_SVG)))
-                .expect("absolute icon should resolve from the filesystem");
+            let image = resolve_icon_image(
+                &Icon::default().path(path),
+                &TestAssetSource(Some(ASSET_SVG)),
+            )
+            .expect("absolute icon should resolve from the filesystem");
             assert_eq!(image.bytes, FILE_SVG);
+        }
+
+        #[test]
+        fn test_native_menu_icon_data_replaces_path_and_survives_clone() {
+            let icon = Icon::default().path("icons/previous.png").data(FILE_SVG);
+            let image = resolve_icon_image(&icon.clone(), &TestAssetSource(None))
+                .expect("SVG data should resolve without an asset source");
+            assert_eq!(image.format, ImageFormat::Svg);
+            assert_eq!(image.bytes, FILE_SVG);
+
+            let icon = icon.path("icons/replacement.svg");
+            let image = resolve_icon_image(&icon, &TestAssetSource(Some(ASSET_SVG)))
+                .expect("a later path should replace the data source");
+            assert_eq!(image.bytes, ASSET_SVG);
         }
     }
 }

--- a/crates/component/src/native_menu/windows.rs
+++ b/crates/component/src/native_menu/windows.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use gpui::{Action, App, AssetSource, ImageFormat, Pixels, Point, SharedString, Window};
+use gpui::{Action, App, AssetSource, ImageFormat, Pixels, Point, Window};
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
 use windows::Win32::Foundation::{BOOL, GlobalFree, HANDLE, HWND, POINT};
 use windows::Win32::Graphics::Gdi::{
@@ -228,9 +228,7 @@ unsafe fn build_menu<'a>(
                 };
                 let _ = unsafe { AppendMenuW(menu, flags, id, PCWSTR(wide.as_ptr())) };
                 if let Some(icon) = icon {
-                    if let Some(bitmap) =
-                        unsafe { load_hbitmap(icon.path_ref(), asset_source, image_px) }
-                    {
+                    if let Some(bitmap) = unsafe { load_hbitmap(icon, asset_source, image_px) } {
                         let info = MENUITEMINFOW {
                             cbSize: std::mem::size_of::<MENUITEMINFOW>() as u32,
                             fMask: MIIM_BITMAP,
@@ -316,11 +314,11 @@ impl Drop for GdiplusSession {
 /// # Safety
 /// Calls GDI+ /GDI flat APIs; the returned handle is owned by the caller.
 unsafe fn load_hbitmap(
-    path: &SharedString,
+    icon: &crate::Icon,
     asset_source: &dyn AssetSource,
     image_px: u32,
 ) -> Option<HBITMAP> {
-    let image = resolve_icon_image(path, asset_source)?;
+    let image = resolve_icon_image(icon, asset_source)?;
     if image.bytes.is_empty() {
         return None;
     }

--- a/crates/story/src/stories/icon_story.rs
+++ b/crates/story/src/stories/icon_story.rs
@@ -2,23 +2,47 @@ use gpui_kit::component::{
     ActiveTheme as _, Icon, IconName, Sizable,
     button::{Button, ButtonVariant, ButtonVariants},
     dock::PanelControl,
-    h_flex, neutral_500, v_flex,
+    h_flex,
+    menu::{DropdownMenu as _, PopupMenuItem},
+    neutral_500, v_flex,
 };
 use gpui_kit::{
     App, AppContext, Context, Entity, FocusHandle, Focusable, IntoElement, ParentElement, Render,
-    Styled, Window, px,
+    Styled, Window, px, radians,
 };
 
 use crate::section;
 
+const SEARCH_SVG: &[u8] = include_bytes!("../../../assets/assets/icons/search.svg");
+const ARROW_SVG: &[u8] = include_bytes!("../../../assets/assets/icons/arrow-up.svg");
+const LOADER_SVG: &[u8] = include_bytes!("../../../assets/assets/icons/loader-circle.svg");
+
+struct Search;
+
+impl From<Search> for Icon {
+    fn from(_: Search) -> Self {
+        Icon::default().data(SEARCH_SVG)
+    }
+}
+
 pub struct IconStory {
     focus_handle: gpui_kit::FocusHandle,
+    arrow: Icon,
+    arrow_view: Entity<Icon>,
+    message: &'static str,
 }
 
 impl IconStory {
     fn new(_: &mut Window, cx: &mut Context<Self>) -> Self {
+        let arrow = Icon::default()
+            .data(ARROW_SVG)
+            .rotate(radians(std::f32::consts::FRAC_PI_2))
+            .large();
         Self {
             focus_handle: cx.focus_handle(),
+            arrow_view: arrow.clone().view(cx),
+            arrow,
+            message: "Choose a button or menu item to try the icon slots.",
         }
     }
 
@@ -53,9 +77,84 @@ impl Focusable for IconStory {
 
 impl Render for IconStory {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let view = cx.entity();
         v_flex()
             .items_center()
             .gap_6()
+            .child(
+                section("SVG bytes")
+                    .description(
+                        "Embedded icons share the same sizing, colors, and loading behavior.",
+                    )
+                    .w(gpui_kit::rems(30.))
+                    .child(
+                        v_flex()
+                            .gap_3()
+                            .child(
+                                h_flex()
+                                    .gap_4()
+                                    .child(Icon::default().data(SEARCH_SVG).small())
+                                    .child(
+                                        Icon::default()
+                                            .data(SEARCH_SVG)
+                                            .large()
+                                            .text_color(cx.theme().primary),
+                                    )
+                                    .child(
+                                        Button::new("embedded-search")
+                                            .icon(Search)
+                                            .label("Search")
+                                            .on_click(cx.listener(|this, _, _, cx| {
+                                                this.message = "Search selected from the button.";
+                                                cx.notify();
+                                            })),
+                                    )
+                                    .child(
+                                        Button::new("embedded-loading")
+                                            .icon(Search)
+                                            .loading_icon(Icon::default().data(LOADER_SVG))
+                                            .loading(true)
+                                            .label("Searching"),
+                                    )
+                                    .child(
+                                        Button::new("embedded-menu")
+                                            .label("Actions")
+                                            .dropdown_menu(move |menu, window, _| {
+                                                menu.item(
+                                                    PopupMenuItem::new("Search")
+                                                        .icon(Search)
+                                                        .on_click(window.listener_for(
+                                                        &view,
+                                                        |this, _, _, cx| {
+                                                            this.message =
+                                                                "Search selected from the menu.";
+                                                            cx.notify();
+                                                        },
+                                                    )),
+                                                )
+                                            }),
+                                    ),
+                            )
+                            .child(
+                                gpui_kit::div()
+                                    .text_sm()
+                                    .text_color(cx.theme().muted_foreground)
+                                    .child(self.message),
+                            ),
+                    ),
+            )
+            .child(
+                section("Cloning and views")
+                    .description("Both arrows retain their SVG bytes and 90° rotation.")
+                    .w(gpui_kit::rems(30.))
+                    .child(h_flex().gap_4().child("Clone").child(self.arrow.clone()))
+                    .child(
+                        h_flex()
+                            .gap_4()
+                            .child("Entity")
+                            .child(self.arrow_view.clone()),
+                    ),
+            )
             .child(
                 section("Icons")
                     .description("Common interface symbols from the bundled icon set.")

--- a/crates/story/src/stories/native_menu_story.rs
+++ b/crates/story/src/stories/native_menu_story.rs
@@ -2,7 +2,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use gpui_kit::component::{
-    ActiveTheme as _, ElementExt, IconName, button::Button, native_menu::NativeMenu, v_flex,
+    ActiveTheme as _, ElementExt, Icon, IconName, button::Button, native_menu::NativeMenu, v_flex,
 };
 use gpui_kit::*;
 use serde::Deserialize;
@@ -35,6 +35,11 @@ fn demo_menu(word_wrap: bool) -> NativeMenu {
         .separator()
         .menu_with_icon("Github", IconName::Github, Box::new(OpenGitHub))
         .menu_with_icon("Inbox", IconName::Inbox, click("Inbox"))
+        .menu_with_icon(
+            "Search (SVG bytes)",
+            Icon::default().data(include_bytes!("../../../assets/assets/icons/search.svg")),
+            click("Search"),
+        )
         .separator()
         .menu_with_disabled("Disabled item", true, click("Disabled"))
         .menu_with_check("Word Wrap", word_wrap, click("Word Wrap"))

--- a/website/docs/assets.md
+++ b/website/docs/assets.md
@@ -128,6 +128,23 @@ impl Render for Example {
 }
 ```
 
+## Embed individual SVG icons
+
+For custom icons, `Icon::data` accepts SVG bytes directly without an asset-path registry:
+
+```rust
+use gpui_kit::component::{Icon, button::Button};
+
+Button::new("search")
+    .icon(Icon::default().data(include_bytes!("search.svg")))
+    .label("Search")
+```
+
+This only removes the asset lookup for that icon. Built-in `IconName` values and
+other path-based component icons still need an asset source. See
+[SVG Bytes](./components/icon.md#svg-bytes) for ownership, source replacement,
+loading icons, and custom icon types.
+
 ## Resources
 
 - [Lucide Icons](https://lucide.dev/) - The icon set used in GPUI Component is based on the open-source Lucide Icons library, which provides a wide range of customizable SVG icons.

--- a/website/docs/components/icon.md
+++ b/website/docs/components/icon.md
@@ -5,7 +5,7 @@ description: Display SVG icons with various sizes, colors, and transformations.
 
 # Icon
 
-A flexible icon component that renders SVG icons from the built-in icon library. Icons are based on Lucide.dev and support customization of size, color, and rotation. The component requires SVG files to be provided by the user in the assets bundle.
+A flexible icon component that renders SVG icons from asset paths or in-memory bytes, with customizable size, color, and transformations. The built-in Lucide icons use the assets bundle; custom SVG bytes can be supplied directly with `Icon::data`.
 
 Before you start, please make sure you have read: [Icons & Assets](../assets.md) to understand how use SVG in GPUI & GPUI Component application.
 
@@ -55,15 +55,15 @@ Icon::new(IconName::Star)
 ### Rotated Icons
 
 ```rust
-use gpui_kit::Radians;
+use gpui_kit::{Transformation, radians};
 
 // Rotate by radians
 Icon::new(IconName::ArrowUp)
-    .rotate(Radians::from_degrees(90.))
+    .rotate(radians(std::f32::consts::FRAC_PI_2))
 
 // Transform with custom transformation
 Icon::new(IconName::ChevronRight)
-    .transform(Transformation::rotate(Radians::PI))
+    .transform(Transformation::rotate(radians(std::f32::consts::PI)))
 ```
 
 ### Custom SVG Path
@@ -73,6 +73,70 @@ Icon::new(IconName::ChevronRight)
 Icon::new(Icon::empty())
     .path("icons/my-custom-icon.svg")
 ```
+
+### SVG Bytes
+
+Use `data(&[u8])` to supply SVG bytes without registering an `AssetSource` path:
+
+```rust
+use gpui_kit::component::{Icon, button::Button, menu::PopupMenuItem};
+
+let icon = Icon::default().data(include_bytes!("search.svg"));
+
+Button::new("search").icon(icon.clone()).label("Search");
+PopupMenuItem::new("Search").icon(icon);
+```
+
+`data` copies its input into shared storage, so the input need not be `'static`.
+Cloning an `Icon` shares those bytes and preserves its style and transformation.
+Both direct rendering and `Icon::view(cx)` retain the data source. GPUI's renderer
+may copy the bytes again; this API does not promise zero-copy rendering.
+
+The last source builder wins, including when the new source is empty:
+
+```rust
+let bytes = include_bytes!("search.svg");
+Icon::default().path("icons/old.svg").data(bytes); // Uses SVG bytes
+Icon::default().data(bytes).path("icons/search.svg"); // Uses the asset path
+```
+
+Bytes go through the same SVG renderer as path-based icons. They retain component
+sizing, foreground colors, and button loading behavior. Use `loading_icon` to
+choose a custom loading symbol:
+
+```rust
+Button::new("search")
+    .icon(Icon::default().data(include_bytes!("search.svg")))
+    .loading_icon(Icon::default().data(include_bytes!("loader.svg")))
+    .loading(true)
+    .label("Searching")
+```
+
+`NativeMenu::menu_with_icon` also accepts data-backed icons. Native menus keep
+their existing platform sizing and tinting rules. Other path-based icons used
+by your application or components still need an asset source.
+
+### Custom Icon Types with SVG Bytes
+
+An icon crate can export individual types that implement `From<T> for Icon`:
+
+```rust
+use gpui_kit::component::{Icon, button::Button};
+
+pub struct Search;
+
+impl From<Search> for Icon {
+    fn from(_: Search) -> Self {
+        Icon::default().data(include_bytes!("search.svg"))
+    }
+}
+
+Button::new("search").icon(Search);
+```
+
+Existing `IconNamed` implementations continue to provide asset paths. A
+data-backed type uses the conversion above without also implementing `IconNamed`.
+Binary-size savings depend on which resources are referenced and on build settings.
 
 ## Available Icons
 

--- a/website/zh-CN/docs/assets.md
+++ b/website/zh-CN/docs/assets.md
@@ -131,6 +131,22 @@ impl Render for Example {
 }
 ```
 
+## 单独嵌入 SVG 图标
+
+自定义图标可以通过 `Icon::data` 直接传入 SVG 字节，无须维护资源路径注册表：
+
+```rust
+use gpui_kit::component::{Icon, button::Button};
+
+Button::new("search")
+    .icon(Icon::default().data(include_bytes!("search.svg")))
+    .label("Search")
+```
+
+这样可以省去该图标的资源查找。内置 `IconName` 和组件中使用的其他路径图标仍需要资源源。
+数据所有权、来源替换、加载图标与自定义图标类型的说明见
+[SVG 字节](./components/icon.md#svg-字节)。
+
 ## 参考资源
 
 - [Lucide Icons](https://lucide.dev/) - GPUI Component 的图标集主要基于 Lucide 开源图标库

--- a/website/zh-CN/docs/components/icon.md
+++ b/website/zh-CN/docs/components/icon.md
@@ -5,7 +5,7 @@ description: 以不同尺寸、颜色和变换方式显示 SVG 图标。
 
 # Icon
 
-Icon 是一个灵活的图标组件，用于渲染内置图标库中的 SVG 图标。图标基于 Lucide.dev，并支持尺寸、颜色与旋转等定制。组件依赖你在资源包中提供对应的 SVG 文件。
+Icon 支持通过资源路径或内存中的字节渲染 SVG 图标，并可定制尺寸、颜色与变换。内置的 Lucide 图标使用资源包；自定义 SVG 字节可以通过 `Icon::data` 直接传入。
 
 在开始之前，建议先阅读 [Icons & Assets](../assets.md)，了解如何在 GPUI 与 GPUI Component 应用中使用 SVG。
 
@@ -49,13 +49,13 @@ Icon::new(IconName::Star)
 ### 旋转图标
 
 ```rust
-use gpui_kit::Radians;
+use gpui_kit::{Transformation, radians};
 
 Icon::new(IconName::ArrowUp)
-    .rotate(Radians::from_degrees(90.))
+    .rotate(radians(std::f32::consts::FRAC_PI_2))
 
 Icon::new(IconName::ChevronRight)
-    .transform(Transformation::rotate(Radians::PI))
+    .transform(Transformation::rotate(radians(std::f32::consts::PI)))
 ```
 
 ### 自定义 SVG 路径
@@ -64,6 +64,67 @@ Icon::new(IconName::ChevronRight)
 Icon::new(Icon::empty())
     .path("icons/my-custom-icon.svg")
 ```
+
+### SVG 字节
+
+通过 `data(&[u8])` 传入 SVG 字节，无须为该图标注册 `AssetSource` 路径：
+
+```rust
+use gpui_kit::component::{Icon, button::Button, menu::PopupMenuItem};
+
+let icon = Icon::default().data(include_bytes!("search.svg"));
+
+Button::new("search").icon(icon.clone()).label("Search");
+PopupMenuItem::new("Search").icon(icon);
+```
+
+`data` 会将输入复制到共享存储中，因此输入无须具有 `'static` 生命周期。
+克隆 `Icon` 时会共享这些字节，并保留样式和变换。直接渲染与通过
+`Icon::view(cx)` 创建实体视图都会保留数据源。GPUI 渲染器可能再次复制字节，
+因此此 API 不承诺渲染过程零复制。
+
+最后一次设置的数据源生效，即使新来源为空也会替换旧来源：
+
+```rust
+let bytes = include_bytes!("search.svg");
+Icon::default().path("icons/old.svg").data(bytes); // 使用 SVG 字节
+Icon::default().data(bytes).path("icons/search.svg"); // 使用资源路径
+```
+
+字节图标与路径图标使用相同的 SVG 渲染器，保留组件尺寸、前景色与按钮加载行为。
+可以通过 `loading_icon` 指定自定义加载图标：
+
+```rust
+Button::new("search")
+    .icon(Icon::default().data(include_bytes!("search.svg")))
+    .loading_icon(Icon::default().data(include_bytes!("loader.svg")))
+    .loading(true)
+    .label("Searching")
+```
+
+`NativeMenu::menu_with_icon` 也支持字节图标，尺寸与着色继续遵循现有原生菜单规则。
+应用或组件中使用的其他路径图标仍需要资源源。
+
+### 使用 SVG 字节的自定义图标类型
+
+图标 crate 可以导出独立类型，并实现 `From<T> for Icon`：
+
+```rust
+use gpui_kit::component::{Icon, button::Button};
+
+pub struct Search;
+
+impl From<Search> for Icon {
+    fn from(_: Search) -> Self {
+        Icon::default().data(include_bytes!("search.svg"))
+    }
+}
+
+Button::new("search").icon(Search);
+```
+
+现有 `IconNamed` 实现继续提供资源路径。使用字节的类型实现上述转换即可，
+无须同时实现 `IconNamed`。二进制体积能否缩小取决于实际引用的资源和构建配置。
 
 ## 可用图标
 


### PR DESCRIPTION
Closes #2961

## Description

Custom SVG bytes can now be passed to existing component icon slots with `Icon::data(&[u8])`, without registering an asset path. The last `.path()` or `.data()` call selects the source, and existing `IconNamed` implementations and component conversion APIs remain compatible.

Icon sources and transformations are stored as cloneable configuration shared by both render paths. Native menus on macOS and Windows also resolve byte-backed icons. The change includes focused regression tests, Icon and NativeMenu Story examples, and English/Chinese documentation.

## Screenshot

No screenshots attached. The macOS Icon Story was checked in a real window: byte-backed icons, rotated clones and entity views, custom loading icons, and button/dropdown-menu feedback. The new native-menu item was opened and selected; its OS popup image was not captured by the screenshot tool.

## Breaking Changes

None. This is an additive API; existing path-based usage remains supported. Applications may opt into embedded bytes:

```diff
-Button::new("search").icon(Icon::default().path("icons/search.svg"))
+Button::new("search").icon(Icon::default().data(include_bytes!("search.svg")))
```

`data` copies its input into shared storage, and cloning an `Icon` shares those bytes. GPUI may copy the data again during rendering; this does not promise zero-copy rendering or binary-size savings.

## How to Test

Passed locally on macOS:

- `cargo test --locked --workspace --exclude gpui-shell --features gpui-component-story/test-support`
- `cargo test --locked -p gpui-component --doc` (3 passed, 30 ignored)
- `cargo test --locked -p gpui-component --lib icon` (18 passed)
- Clippy for the changed component and Story targets with warnings denied; targeted rustfmt, typos, and `git diff --check`.
- Markdown parsing, local-link validation, and matching new English/Chinese code examples.

To inspect the examples, run `cargo run --locked -p gpui-component-story -- Icon`, then open NativeMenu and select `Search (SVG bytes)`.

Windows/Linux runtime checks and the full website build have not been run locally and remain for CI/maintainer validation.

## AI Assistance

Codex assisted with the implementation, regression tests, Story examples, documentation, and this PR description. Automated checks and agent-driven UI checks are reported above; human review and testing remain for the contributor/maintainers.

## Checklist

- [x] Read the CONTRIBUTING document and repository design/coding guides.
- [ ] Human review and testing of the AI-assisted changes completed.
- [x] Passed `cargo run` for the related Story examples on macOS.
- [ ] Tested macOS, Windows and Linux platform performance.
