### PR TITLE
input: preserve CRLF cursor boundaries and document shortcuts

### DIFF
--- a/crates/base/src/input/base/movement.rs
+++ b/crates/base/src/input/base/movement.rs
@@ -1,5 +1,6 @@
 use crate::input::InputModeKind;
 use gpui::{Context, Pixels, Point, Window};
+use sum_tree::Bias;
 
 use crate::input::{
     InputBaseState, MoveDown, MoveEnd, MoveHome, MoveLeft, MovePageDown, MovePageUp, MoveRight,
@@ -83,7 +84,7 @@ impl<M: InputModeKind> InputBaseState<M> {
     ) {
         self.undo_manager.break_transaction_coalescing();
         self.selections.remove_all_but_active();
-        let offset = offset.clamp(0, self.text.len());
+        let offset = self.cursor_boundary(offset, Bias::Left);
         self.cursor_line_end_affinity = line_end_affinity;
         self.set_cursor_to(offset);
         self.scroll_to(offset, direction, cx);
@@ -184,7 +185,6 @@ impl<M: InputModeKind> InputBaseState<M> {
         cx: &mut Context<Self>,
     ) {
         self.undo_manager.break_transaction_coalescing();
-        let len = self.text.len();
         let mut active_affinity = false;
         let new_selections: Vec<CursorSelection> = self
             .selections
@@ -195,7 +195,7 @@ impl<M: InputModeKind> InputBaseState<M> {
                     active_affinity = line_end_affinity;
                 }
                 let mut new_sel = *sel;
-                new_sel.place_at(offset.clamp(0, len), anchor);
+                new_sel.place_at(self.cursor_boundary(offset, Bias::Left), anchor);
                 new_sel
             })
             .collect();

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -212,6 +212,14 @@ pub(crate) fn init(cx: &mut App) {
         KeyBinding::new("shift-alt-down", AddCursorBelow, Some(CONTEXT)),
         KeyBinding::new("home", MoveHome, Some(CONTEXT)),
         KeyBinding::new("end", MoveEnd, Some(CONTEXT)),
+        #[cfg(not(target_os = "macos"))]
+        KeyBinding::new("ctrl-home", MoveToStart, Some(CONTEXT)),
+        #[cfg(not(target_os = "macos"))]
+        KeyBinding::new("ctrl-end", MoveToEnd, Some(CONTEXT)),
+        #[cfg(not(target_os = "macos"))]
+        KeyBinding::new("ctrl-shift-home", SelectToStart, Some(CONTEXT)),
+        #[cfg(not(target_os = "macos"))]
+        KeyBinding::new("ctrl-shift-end", SelectToEnd, Some(CONTEXT)),
         KeyBinding::new("shift-home", SelectToStartOfLine, Some(CONTEXT)),
         KeyBinding::new("shift-end", SelectToEndOfLine, Some(CONTEXT)),
         #[cfg(target_os = "macos")]
@@ -2697,7 +2705,7 @@ impl<M: InputModeKind> InputBaseState<M> {
         M::clear_inline_completion(self, cx);
 
         self.cursor_line_end_affinity = line_end_affinity;
-        let offset = offset.clamp(0, self.text.len());
+        let offset = self.cursor_boundary(offset, Bias::Left);
         let word_range = self.selected_word_range;
         Self::extend_selection(self.active_selection_mut(), offset, word_range);
 
@@ -2718,12 +2726,11 @@ impl<M: InputModeKind> InputBaseState<M> {
         self.undo_manager.break_transaction_coalescing();
         M::clear_inline_completion(self, cx);
 
-        let len = self.text.len();
         let new_selections: Vec<CursorSelection> = self
             .selections
             .iter()
             .map(|sel| {
-                let offset = f(self, sel).clamp(0, len);
+                let offset = self.cursor_boundary(f(self, sel), Bias::Left);
                 let mut new_sel = *sel;
                 Self::extend_selection(&mut new_sel, offset, None);
                 new_sel
@@ -2797,25 +2804,31 @@ impl<M: InputModeKind> InputBaseState<M> {
         offset
     }
 
-    pub(super) fn previous_boundary(&self, offset: usize) -> usize {
-        let mut offset = self.text.clip_offset(offset.saturating_sub(1), Bias::Left);
-        if let Some(ch) = self.text.char_at(offset) {
-            if ch == '\r' {
-                offset -= 1;
+    /// Clip a cursor/selection offset without splitting a CRLF newline. This does
+    /// not alter the rope or its byte/UTF-16 conversion used for exact source APIs.
+    pub(super) fn cursor_boundary(&self, offset: usize, bias: Bias) -> usize {
+        let offset = self.text.clip_offset(offset, bias);
+        if offset > 0
+            && self.text.char_at(offset - 1) == Some('\r')
+            && self.text.char_at(offset) == Some('\n')
+        {
+            if bias == Bias::Left {
+                offset - 1
+            } else {
+                offset + 1
             }
+        } else {
+            offset
         }
+    }
 
+    pub(super) fn previous_boundary(&self, offset: usize) -> usize {
+        let offset = self.cursor_boundary(offset.saturating_sub(1), Bias::Left);
         self.clamp_offset_to_visible_backward(offset)
     }
 
     pub(super) fn next_boundary(&self, offset: usize) -> usize {
-        let mut offset = self.text.clip_offset(offset + 1, Bias::Right);
-        if let Some(ch) = self.text.char_at(offset) {
-            if ch == '\r' {
-                offset += 1;
-            }
-        }
-
+        let offset = self.cursor_boundary(offset.saturating_add(1), Bias::Right);
         self.clamp_offset_to_visible_forward(offset)
     }
 
@@ -3963,6 +3976,45 @@ mod tests {
                 f(crate::input::InputState::new(window, cx))
             })
         }
+    }
+
+    #[gpui::test]
+    fn textarea_cursor_treats_crlf_as_one_newline(cx: &mut TestAppContext) {
+        cx.update(crate::init);
+        let view = InputView::build_textarea(cx, |state| state);
+        let mut cx = VisualTestContext::from_window(view.window_handle.into(), cx);
+        cx.update(|window, cx| {
+            view.input.update(cx, |state, cx| {
+                for original in ["\r\nlast", "\u{feff}first\r\nlast\n", "first\nlast\r\n"] {
+                    state.set_value(original, window, cx);
+                    let newline = original.find('\n').unwrap();
+                    let end = if original.as_bytes()[newline.saturating_sub(1)] == b'\r' {
+                        newline - 1
+                    } else {
+                        newline
+                    };
+                    state.end(&MoveEnd, window, cx);
+                    assert_eq!(state.cursor(), end);
+                    state.right(&MoveRight, window, cx);
+                    assert_eq!(state.cursor(), newline + 1);
+                    state.left(&MoveLeft, window, cx);
+                    assert_eq!(state.cursor(), end);
+                    state.select_to_end_of_line(&SelectToEndOfLine, window, cx);
+                    assert_eq!(state.selected_range(), end..end);
+                    state.move_to_end(&MoveToEnd, window, cx);
+                    assert_eq!(state.cursor(), original.len());
+                    state.move_to_start(&MoveToStart, window, cx);
+                    assert_eq!(state.cursor(), 0);
+                    assert_eq!(state.value().as_bytes(), original.as_bytes());
+                }
+                // A lone CR is an ordinary character; it must not skip its neighbour.
+                state.set_value("a\rb", window, cx);
+                state.right(&MoveRight, window, cx);
+                assert_eq!(state.cursor(), 1);
+                state.right(&MoveRight, window, cx);
+                assert_eq!(state.cursor(), 2);
+            })
+        });
     }
 
     #[gpui::test]


### PR DESCRIPTION
End can place a text-input cursor between CR and LF; subsequent typing splits the newline. Ctrl+Home/End also lacked non-macOS document bindings.

Clip cursor and selection movement outside CRLF pairs, including the new multi-cursor movement/selection paths. Left/Right cross CRLF as one newline; a standalone CR remains an ordinary character. The rope and byte/UTF-16 APIs are unchanged. Add standard document navigation/selection bindings and a focused regression.

Validation on this branch (43c733d5), adapted to the multi-cursor implementation in cbdf5baa:

- Linux and Windows full workspace test jobs pass; the Linux log confirms `textarea_cursor_treats_crlf_as_one_newline` passes among 838 base tests.
- macOS lint, workspace tests and component doc-test step pass.
- GPUI Shell Core, Component Shell, all three Standard Runtime jobs and documentation build pass.
- Changed Rust files pass rustfmt checking locally.

The pinned-version counterpart additionally passed native GPUI key-dispatch tests for LF/BOM/CRLF/mixed input, exact source-write payloads and actual muninn Linux Ctrl+End typing/save plus Ctrl+Home/End/Right/Left save checks in Tessera. Canonical BOM and all eight original CRLF pairs were retained.

[CI run](https://github.com/longbridge/gpui-kit/actions/runs/34032397004)
