### PR TITLE
highlighter: Update tree-sitter to remove workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10198,9 +10198,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.8"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/crates/component/Cargo.toml
+++ b/crates/component/Cargo.toml
@@ -138,7 +138,7 @@ instant.workspace = true
 # Native-only dependencies (not available on WASM)
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 smol.workspace = true
-tree-sitter = { version = "0.26", optional = true }
+tree-sitter = { version = "0.26.13", optional = true }
 tree-sitter-astro-next = { version="0.1.1", optional = true }
 tree-sitter-bash = { version = "0.23.3", optional = true }
 tree-sitter-c = { version = "0.24.1", optional = true }

--- a/crates/component/src/highlighter/highlighter.rs
+++ b/crates/component/src/highlighter/highlighter.rs
@@ -18,9 +18,6 @@ use tree_sitter::{
     InputEdit, ParseOptions, Parser, Point, Query, QueryCursor, StreamingIterator, Tree,
 };
 
-/// When a node spans more than this many bytes beyond the requested query
-/// range, we recurse into its children instead of querying it directly.
-const LARGE_NODE_THRESHOLD: usize = 8 * 1024;
 const MAX_INJECTION_RANGES: usize = 4096;
 const MAX_INJECTION_BYTES: usize = 512 * 1024;
 const MAX_INJECTION_LANGUAGE_BYTES: usize = 64;
@@ -986,41 +983,37 @@ impl SyntaxHighlighter {
             }
         }
 
-        let query_nodes = collect_query_nodes(root_node, &range);
+        let mut query_cursor = QueryCursor::new();
+        query_cursor.set_byte_range(range.clone());
 
-        for query_node in &query_nodes {
-            let mut query_cursor = QueryCursor::new();
-            query_cursor.set_byte_range(range.clone());
+        let mut matches = query_cursor.matches(query, root_node, TextProvider(source));
 
-            let mut matches = query_cursor.matches(&query, *query_node, TextProvider(&source));
+        while let Some(query_match) = matches.next() {
+            for cap in query_match.captures {
+                let node = cap.node;
 
-            while let Some(query_match) = matches.next() {
-                for cap in query_match.captures {
-                    let node = cap.node;
+                let Some(highlight_name) = query.capture_names().get(cap.index as usize) else {
+                    continue;
+                };
 
-                    let Some(highlight_name) = query.capture_names().get(cap.index as usize) else {
-                        continue;
-                    };
+                let node_range: Range<usize> = node.start_byte()..node.end_byte();
+                let highlight_name = SharedString::from(highlight_name.to_string());
 
-                    let node_range: Range<usize> = node.start_byte()..node.end_byte();
-                    let highlight_name = SharedString::from(highlight_name.to_string());
+                // Merge near range and same highlight name
+                let last_item = highlights.last();
+                let last_range = last_item.map(|item| &item.range).unwrap_or(&(0..0));
+                let last_highlight_name = last_item.map(|item| item.name.clone());
 
-                    // Merge near range and same highlight name
-                    let last_item = highlights.last();
-                    let last_range = last_item.map(|item| &item.range).unwrap_or(&(0..0));
-                    let last_highlight_name = last_item.map(|item| item.name.clone());
-
-                    if last_range == &node_range {
-                        // case:
-                        // last_range: 213..220, last_highlight_name: Some("property")
-                        // last_range: 213..220, last_highlight_name: Some("string")
-                        highlights.push(HighlightItem::new(
-                            node_range,
-                            last_highlight_name.unwrap_or(highlight_name),
-                        ));
-                    } else {
-                        highlights.push(HighlightItem::new(node_range, highlight_name.clone()));
-                    }
+                if last_range == &node_range {
+                    // case:
+                    // last_range: 213..220, last_highlight_name: Some("property")
+                    // last_range: 213..220, last_highlight_name: Some("string")
+                    highlights.push(HighlightItem::new(
+                        node_range,
+                        last_highlight_name.unwrap_or(highlight_name),
+                    ));
+                } else {
+                    highlights.push(HighlightItem::new(node_range, highlight_name.clone()));
                 }
             }
         }
@@ -1211,57 +1204,6 @@ pub(crate) fn unique_styles(
     }
 
     merged
-}
-
-/// Walk the tree and collect nodes suitable for querying, skipping subtrees
-/// that fall entirely outside the byte range. Nodes much larger than the
-/// query range are recursed into so that `QueryCursor` only visits the
-/// relevant portion of the tree.
-fn collect_query_nodes<'a>(
-    root: tree_sitter::Node<'a>,
-    range: &Range<usize>,
-) -> Vec<tree_sitter::Node<'a>> {
-    let mut nodes = Vec::new();
-    collect_query_nodes_inner(root, range, &mut nodes);
-    if nodes.is_empty() {
-        nodes.push(root);
-    }
-    nodes
-}
-
-fn collect_query_nodes_inner<'a>(
-    node: tree_sitter::Node<'a>,
-    range: &Range<usize>,
-    out: &mut Vec<tree_sitter::Node<'a>>,
-) {
-    // Skip nodes entirely outside the range.
-    if node.end_byte() <= range.start || node.start_byte() >= range.end {
-        return;
-    }
-
-    let node_span = node.end_byte() - node.start_byte();
-    let range_span = range.end - range.start;
-
-    // Use `goto_first_child_for_byte` to seek directly to the first
-    // overlapping child instead of iterating all children from the start.
-    if node_span > range_span + LARGE_NODE_THRESHOLD && node.child_count() > 0 {
-        let mut cursor = node.walk();
-        if cursor.goto_first_child_for_byte(range.start).is_some() {
-            loop {
-                let child = cursor.node();
-                if child.start_byte() >= range.end {
-                    break;
-                }
-                collect_query_nodes_inner(child, range, out);
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        return;
-    }
-
-    out.push(node);
 }
 
 /// Merge other style (Other on top)


### PR DESCRIPTION
## Description

Removes a workaround for large nodes introduced in #2128, fixed in upstream https://github.com/tree-sitter/tree-sitter/pull/5801
Backported to 0.26 https://github.com/tree-sitter/tree-sitter/pull/5855

## How to Test

Open large broken sql file in the editor example:

```sh
$ (echo ""; for i in $(seq 1 9999); do echo "('$i'),"; done; echo "('10000')"; echo ') as x(ix);') > test_broken.sql
$ cargo run --release -p example-editor
```

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
