### PR TITLE
input: trigger pending re-highlight when switching editor language

### DIFF
--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -782,7 +782,7 @@ impl<M: InputModeKind> InputBaseState<M> {
             }
             _ => {}
         }
-        cx.notify();
+        self.refresh(cx);
     }
 
     fn reset_highlighter(&mut self, cx: &mut Context<Self>) {


### PR DESCRIPTION
Closes #2970 

## Description

`set_highlighter()` clears the cached highlighter when switching languages, but does not set the internal `_pending_update` flag. This means the next render never calls `update_highlighter()`, so the editor stays without syntax highlighting until the user edits the text (which triggers `update_highlighter(force: true)`).

The fix replaces `cx.notify()` with `self.refresh(cx)` — a method that already exists for exactly this purpose and sets `_pending_update = true` before notifying.

## Screenshot
N/A — behavioral fix, no visual change unless highlighting was broken.

## Break Changes
None.

## How to Test
1. Run `cargo run -p example-editor` in the gpui-kit repo
2. Open a `.rs` file (Rust highlighting appears)
3. Open a `.json` file — highlighting should switch to JSON immediately
4. Open a `.html` file — highlighting should switch to HTML immediately
5. Before this fix, steps 3–4 would show stale/no highlighting until the user typed in the editor

## Why the example-editor appeared to work without this fix
The example-editor calls `set_value()` after `set_highlighter()`. `set_value` internally sets `_pending_update = true` (via `reset_lsp_state()`), which accidentally triggers the re-highlight on the next render. This is a workaround, not correct behavior — `set_highlighter()` should work on its own. Every other caller that uses `set_highlighter()` without a subsequent `set_value()` hits this bug.



## Checklist
- [x] I have read the CONTRIBUTING document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [x] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
