### PR TITLE
shell: let native component adapters reuse built-in state

### DIFF
--- a/crates/shell/src/component_registry.rs
+++ b/crates/shell/src/component_registry.rs
@@ -188,11 +188,22 @@ impl ComponentId {
 }
 
 #[derive(Clone)]
-pub struct ComponentPayload(Arc<dyn Any + Send + Sync>);
+pub struct ComponentPayload(Arc<dyn Any + Send + Sync>, Option<Arc<str>>);
 
 impl ComponentPayload {
     pub fn new<T: Any + Send + Sync>(value: T) -> Self {
-        Self(Arc::new(value))
+        Self(Arc::new(value), None)
+    }
+
+    /// Adds an opt-in, quoted label to render snapshots. Adapters should use
+    /// public UI labels or stable IDs here, never private retained state.
+    pub fn with_debug_label(mut self, label: impl Into<Arc<str>>) -> Self {
+        self.1 = Some(label.into());
+        self
+    }
+
+    pub fn debug_label(&self) -> Option<&str> {
+        self.1.as_deref()
     }
 
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
@@ -722,6 +733,19 @@ impl<'a> MaterializeRequest<'a> {
         };
         self.runtime
             .with_component_state::<T, R>(*handle, kind, body)
+    }
+
+    /// Clones a built-in GPUI state entity supplied by the script. The runtime
+    /// checks ownership, liveness, the declared kind and the Rust entity type.
+    /// This preserves the existing script state's methods and subscriptions.
+    pub fn native_state<T: 'static>(
+        &self,
+        argument: &ComponentArgument,
+    ) -> anyhow::Result<gpui::Entity<T>> {
+        let ComponentArgument::Entity { kind, handle } = argument else {
+            anyhow::bail!("component argument is not native state");
+        };
+        self.runtime.native_component_state::<T>(*handle, kind)
     }
 
     /// Returns an opaque capability that may update state later from a GPUI event.
@@ -2261,6 +2285,15 @@ impl FrozenComponentRegistry {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn payload_debug_labels_are_opt_in_and_preserve_the_typed_value() {
+        let payload = super::ComponentPayload::new(42_u32);
+        assert_eq!(payload.debug_label(), None);
+        let labeled = payload.clone().with_debug_label("public choice");
+        assert_eq!(labeled.debug_label(), Some("public choice"));
+        assert_eq!(labeled.downcast_ref::<u32>(), Some(&42));
+        assert_eq!(payload.debug_label(), None);
+    }
     use super::*;
     use gpui::div;
 

--- a/crates/shell/src/engine/quickjs/mod.rs
+++ b/crates/shell/src/engine/quickjs/mod.rs
@@ -1566,6 +1566,24 @@ impl ShellRuntime {
         self.entities.borrow().kind(handle)
     }
 
+    pub(crate) fn native_component_state<T: 'static>(
+        &self,
+        handle: EntityHandle,
+        kind: &'static str,
+    ) -> anyhow::Result<gpui::Entity<T>> {
+        let entities = self
+            .entities
+            .try_borrow()
+            .map_err(|_| anyhow!("native entity store is already borrowed"))?;
+        anyhow::ensure!(
+            entities.kind(handle) == Some(kind),
+            "native state is released, foreign or has the wrong kind"
+        );
+        entities
+            .native_state(handle)
+            .ok_or_else(|| anyhow!("native state does not match the requested Rust entity type"))
+    }
+
     pub(crate) fn with_component_state<T: std::any::Any, R>(
         &self,
         handle: u64,

--- a/crates/shell/src/entities.rs
+++ b/crates/shell/src/entities.rs
@@ -351,6 +351,21 @@ impl EntityStore {
         }
     }
 
+    /// Typed native state access for registered component adapters. Script
+    /// views and adapter-owned opaque values are deliberately not included.
+    pub(crate) fn native_state<T: 'static>(&self, handle: EntityHandle) -> Option<Entity<T>> {
+        let entity: &dyn std::any::Any = match self.record(handle)? {
+            Record::Input { state, .. } => state,
+            Record::Textarea { state, .. } => state,
+            Record::Calendar { state, .. } => state,
+            Record::Slider { state, .. } => state,
+            Record::Otp { state, .. } => state,
+            Record::Dock { area, .. } => area,
+            _ => return None,
+        };
+        entity.downcast_ref::<Entity<T>>().cloned()
+    }
+
     /// Creates a multi-line text state and returns its handle.
     ///
     /// `rows` is offered at construction because the layout default is a single
@@ -1416,6 +1431,16 @@ mod tests {
         assert!(store.input(textarea).is_none());
         assert!(store.textarea(textarea).is_some());
 
+        assert_eq!(store.native_state::<InputState>(input), store.input(input));
+        assert_eq!(
+            store.native_state::<TextareaState>(textarea),
+            store.textarea(textarea)
+        );
+        assert!(store.native_state::<InputState>(textarea).is_none());
+        assert!(store.native_state::<TextareaState>(input).is_none());
+        let other_store = EntityStore::try_new().expect("another store");
+        assert!(other_store.native_state::<InputState>(input).is_none());
+
         // Subscribing reaches both through the one method, which is the part
         // that would silently stop working if a variant were forgotten there.
         assert!(context.update(|window, cx| store.subscribe_input(
@@ -1428,6 +1453,7 @@ mod tests {
 
         assert!(store.release(textarea));
         assert!(store.textarea(textarea).is_none());
+        assert!(store.native_state::<TextareaState>(textarea).is_none());
         assert!(store.input(input).is_some());
     }
 

--- a/crates/shell/src/spec.rs
+++ b/crates/shell/src/spec.rs
@@ -1354,6 +1354,11 @@ impl SpecArena {
                 out.push_str(&format!(" {:?} \u{d7}{}", spec.id(), spec.item_count()))
             }
             Component::ChildView(spec) => out.push_str(&format!(" #{}", spec.handle())),
+            Component::Registered(spec) => {
+                if let Some(label) = spec.payload().debug_label() {
+                    out.push_str(&format!(" {label:?}"));
+                }
+            }
             Component::Slider(handle)
             | Component::SliderTrack(handle)
             | Component::SliderIndicator(handle)


### PR DESCRIPTION
## Description

Native component adapters could not reuse the shell's existing InputState, CalendarState and other built-in state handles. Add `MaterializeRequest::native_state<T>` with runtime ownership, liveness, kind and Rust type checks so adapters preserve existing JavaScript state methods and subscriptions.

Also add opt-in, quoted payload labels to render snapshots so native composite controls retain readable identities and option labels. No retained state is logged automatically.

## How to Test

- `cargo test --offline -p gpui-shell --lib`: 696 passed, 1 ignored.
- Downstream gpui-omarchy/Longbridge integration covers text editing, calendar selection, slider/OTP interaction, and native selection groups.

## Checklist

- [x] Read CONTRIBUTING.md and followed the existing adapter boundary.
- [x] Reviewed the changes and verified tests.
- [ ] Manual story and cross-platform checks (no story UI changed).
