### PR TITLE
docs: document editor search panel and searchable API

### DIFF
--- a/website/base/primitives/editor.md
+++ b/website/base/primitives/editor.md
@@ -19,6 +19,13 @@ The base and styled editors share keyboard and mouse behavior. See
 [Keyboard shortcuts and column selection](../../docs/components/editor.md#keyboard-shortcuts-and-column-selection)
 for the macOS, Linux, and Windows bindings, multi-cursor editing, and column-selection details.
 
+## Search
+
+The editor has a built-in search panel. Press `Ctrl-F` (Windows/Linux) or
+`Cmd-F` (macOS) while the editor is focused to open it. See
+[Search](../../docs/components/editor.md#search) for the programmatic API
+(`open_search`, `close_search`, `set_searchable`) and read-only behavior.
+
 ## Import
 
 ```rust

--- a/website/docs/components/editor.md
+++ b/website/docs/components/editor.md
@@ -86,6 +86,35 @@ them. In particular, Ctrl+Alt+Up / Down is not bound by default on Linux because
 some desktops use it to switch workspaces. The shortcuts above refer to logical
 modifiers after any keyboard remapping.
 
+## Search
+
+The editor has a built-in search panel. Press `Ctrl-F` (Windows/Linux) or
+`Cmd-F` (macOS) while the editor is focused to open it. `Enter` jumps to the
+next match, `Shift+Enter` to the previous one, `Escape` closes the panel.
+
+```rust
+// Open the find panel programmatically
+editor.update(cx, |state, cx| {
+    state.open_search(false, cx);
+});
+
+// Close it
+editor.update(cx, |state, cx| {
+    state.close_search(cx);
+});
+```
+
+Search is enabled by default for `Editor`. To disable it:
+
+```rust
+editor.update(cx, |state, cx| {
+    state.set_searchable(false, cx);
+});
+```
+
+A read-only editor can still be searched — the replace UI is hidden
+automatically.
+
 ## Decorations
 
 ```rust

--- a/website/zh-CN/base/primitives/editor.md
+++ b/website/zh-CN/base/primitives/editor.md
@@ -13,6 +13,11 @@ order: 16
 Base 与样式组件共享键盘和鼠标行为。各平台快捷键、多光标编辑和矩形列选的细节请参阅
 [快捷键与矩形列选](../../docs/components/editor.md#快捷键与矩形列选)。
 
+## 搜索
+
+编辑器内置搜索面板。编辑器聚焦时按 `Ctrl-F`（Windows/Linux）或 `Cmd-F`（macOS）打开。编程式 API（`open_search`、`close_search`、`set_searchable`）与只读行为参见
+[搜索](../../docs/components/editor.md#搜索)。
+
 ## 导入
 
 ```rust

--- a/website/zh-CN/docs/components/editor.md
+++ b/website/zh-CN/docs/components/editor.md
@@ -67,6 +67,32 @@ Linux 额外支持与 Ghostty 一致的 Ctrl+Alt+左键拖动列选，以及 Alt
 
 Linux 桌面可能在编辑器收到事件之前拦截快捷键。部分桌面使用 Ctrl+Alt+↑ / ↓ 切换工作区，因此 Linux 默认不绑定这一组合。以上快捷键指键盘重映射后的逻辑修饰键。
 
+## 搜索
+
+编辑器内置搜索面板。编辑器聚焦时按 `Ctrl-F`（Windows/Linux）或 `Cmd-F`（macOS）打开。`Enter` 跳到下一个匹配，`Shift+Enter` 跳到上一个，`Escape` 关闭面板。
+
+```rust
+// 以代码方式打开查找面板
+editor.update(cx, |state, cx| {
+    state.open_search(false, cx);
+});
+
+// 关闭它
+editor.update(cx, |state, cx| {
+    state.close_search(cx);
+});
+```
+
+`Editor` 默认启用搜索。如需禁用：
+
+```rust
+editor.update(cx, |state, cx| {
+    state.set_searchable(false, cx);
+});
+```
+
+只读编辑器仍可搜索——替换界面会自动隐藏。
+
 ## 文本装饰
 
 ```rust


### PR DESCRIPTION
Closes #3001 

## Description
The Editor has a built-in search panel (`Ctrl-F` / `Cmd-F`) and a programmatic search API (`open_search`, `close_search`, `set_searchable`), but none of it is documented. 

This adds a `Search` section to the Editor docs covering keyboard shortcuts, the programmatic API, how to disable search, and read-only behavior.

Updated all 4 editor doc files (EN + ZH, component + base) to stay in sync.

> For the chinese language, I've verified that the docs are synced using google translate. Still if you want please verify it once  and let me know if any changes.

## Screenshot
N/A

## Break Changes
None

## How to Test

Verify the new `Search` section renders in:
- `website/docs/components/editor.md`
- `website/zh-CN/docs/components/editor.md`
- `website/base/primitives/editor.md`
- `website/zh-CN/base/primitives/editor.md`

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
