### PR TITLE
website: Preserve docs sidebar scroll position across navigation

### DIFF
--- a/website/src/components/Sidebar.astro
+++ b/website/src/components/Sidebar.astro
@@ -61,3 +61,69 @@ function renderItems(items: SidebarItem[], depth = 0): any[] {
     ))}
   </nav>
 </aside>
+
+<script is:inline>
+  (function () {
+    const sidebar = document.querySelector('.docs-sidebar');
+    if (!sidebar) return;
+
+    const section = window.location.pathname.match(/(?:^|\/)(docs|base|shell)(?:\/|$)/)?.[1] || 'docs';
+    const key = 'gpui-kit:sidebar-scroll:' + section;
+
+    // 1. Restore the last known scroll position for this section.
+    let isRestoring = true;
+    try {
+      const saved = sessionStorage.getItem(key);
+      if (saved !== null) {
+        sidebar.scrollTop = Number(saved);
+      }
+    } catch {}
+
+    // 2. Ensure the active item is visible; if off-screen (e.g. direct link or refresh), scroll it into center.
+    const active = sidebar.querySelector('.sidebar-item.active');
+    if (active) {
+      const cRect = sidebar.getBoundingClientRect();
+      const aRect = active.getBoundingClientRect();
+      const isVisible = aRect.top >= cRect.top && aRect.bottom <= cRect.bottom;
+      if (!isVisible) {
+        sidebar.scrollTop = active.offsetTop - (sidebar.clientHeight / 2) + (active.offsetHeight / 2);
+      }
+    }
+
+    requestAnimationFrame(function () {
+      delete sidebar.dataset.scrollbarVisible;
+      isRestoring = false;
+    });
+
+    // 3. Synchronize scroll position and manage transient scrollbar visibility.
+    let hideTimer;
+    function saveScroll() {
+      try {
+        sessionStorage.setItem(key, String(sidebar.scrollTop));
+      } catch {}
+    }
+
+    sidebar.addEventListener(
+      'scroll',
+      function () {
+        if (!isRestoring) {
+          sidebar.dataset.scrollbarVisible = '';
+          window.clearTimeout(hideTimer);
+          hideTimer = window.setTimeout(function () {
+            delete sidebar.dataset.scrollbarVisible;
+          }, 800);
+        }
+        saveScroll();
+      },
+      { passive: true },
+    );
+
+    sidebar.addEventListener('click', function (e) {
+      if (e.target && e.target.closest('a')) {
+        saveScroll();
+      }
+    });
+
+    window.addEventListener('pagehide', saveScroll);
+  })();
+</script>

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -79,27 +79,6 @@ const structuredData = [
   <SiteFooter lang={lang} />
 </BaseLayout>
 
-<script>
-  // The sidebar scrollbar is transparent at rest and appears only while the
-  // reader is scrolling it, so a long navigation tree does not carry a
-  // permanent rail beside it.
-  const sidebar = document.querySelector<HTMLElement>('.docs-sidebar');
-  if (sidebar) {
-    let hideTimer: number | undefined;
-    sidebar.addEventListener(
-      'scroll',
-      () => {
-        sidebar.dataset.scrollbarVisible = '';
-        window.clearTimeout(hideTimer);
-        hideTimer = window.setTimeout(() => {
-          delete sidebar.dataset.scrollbarVisible;
-        }, 800);
-      },
-      { passive: true },
-    );
-  }
-</script>
-
 <style is:global>
   @import '../styles/global.css';
 </style>


### PR DESCRIPTION
## Description

In the documentation website, navigating between documentation pages caused the sidebar (`aside.docs-sidebar`) to lose its scroll position and reset to the top due to multi-page application (MPA) full-page transitions.

This pull request persists the sidebar scroll position across navigations:
- Restores the sidebar's `scrollTop` synchronously from `sessionStorage` using an inline script right after `<aside>`, avoiding visual jump/flash before initial paint.
- Keeps scroll position isolated per section (`docs`, `base`, `shell`) so navigation across distinct sections does not interfere.
- When an active menu item is off-screen (such as entering via external link, search modal, or direct refresh), smoothly scrolls it to center; if already visible (e.g. clicking directly in the sidebar), preserves the exact scroll position with zero offset/jitter.
- Co-locates transient scrollbar visibility and cleanup logic within `Sidebar.astro`, removing duplicate script from `DocsLayout.astro`.

## How to Test

1. Run `bun run dev` inside `website/`.
2. Open `/docs/components` in browser.
3. Scroll down the left sidebar to bottom items (e.g., `Tree`, `VirtualList`).
4. Click `VirtualList`, then click `Tree`: verify the sidebar maintains its exact scroll position without resetting to top or shifting.
5. Directly visit `/docs/components/input` in a new tab: verify the active item is automatically scrolled into view.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.

*(Rust Story and platform performance tests are not applicable to this website-only change.)*