### PR TITLE
theme: Fall back to an installed monospace font when the default is missing

### DIFF
--- a/crates/component/src/theme/mod.rs
+++ b/crates/component/src/theme/mod.rs
@@ -17,6 +17,7 @@ use std::{
 };
 
 mod color;
+mod mono_font;
 mod motion;
 mod registry;
 mod schema;
@@ -108,6 +109,11 @@ pub struct Theme {
     /// - macOS: `Menlo`
     /// - Windows: `Consolas`
     /// - Linux: `DejaVu Sans Mono`
+    ///
+    /// When that default is not installed, [`Theme::change`] swaps it for the
+    /// first installed alternative (`Monaco`, `Cascadia Mono`, `Noto Sans Mono`
+    /// and the like) and finally `.SystemUIFont`, so a missing font cannot
+    /// crash text layout. A family set explicitly is used as-is.
     pub mono_font_family: SharedString,
     /// The monospace font size for the application, default is 13px.
     pub mono_font_size: Pixels,
@@ -243,7 +249,7 @@ impl Theme {
             cx.set_global(theme);
         }
 
-        let theme = {
+        {
             let theme = cx.global_mut::<Theme>();
             theme.mode = mode;
             if mode.is_dark() {
@@ -251,8 +257,9 @@ impl Theme {
             } else {
                 theme.apply_config(&theme.light_theme.clone());
             }
-            theme.clone()
-        };
+        }
+        mono_font::resolve_default_mono_font(cx);
+        let theme = cx.global::<Theme>().clone();
 
         let base_theme = theme.base_theme();
         cx.set_global(base_theme);
@@ -617,14 +624,7 @@ impl From<&ThemeColor> for Theme {
             transparent: Hsla::transparent_black(),
             font_family: ".SystemUIFont".into(),
             font_size: px(16.),
-            mono_font_family: if cfg!(target_os = "macos") {
-                // https://en.wikipedia.org/wiki/Menlo_(typeface)
-                "Menlo".into()
-            } else if cfg!(target_os = "windows") {
-                "Consolas".into()
-            } else {
-                "DejaVu Sans Mono".into()
-            },
+            mono_font_family: mono_font::default_mono_font_family(),
             mono_font_size: px(13.),
             radius: px(6.),
             radius_lg: px(8.),

--- a/crates/component/src/theme/mono_font.rs
+++ b/crates/component/src/theme/mono_font.rs
@@ -1,0 +1,117 @@
+//! Keeps the theme's default monospace family on a font the machine has.
+//!
+//! GPUI panics on the first line it lays out in a family it cannot find, and
+//! `Font::fallbacks` does not help there: it is a cascade list for missing
+//! glyphs, consulted only after the family itself has loaded. The theme's
+//! platform default is a bare name, so a machine without that font would crash
+//! on its first code block. This probe swaps the default for an installed
+//! alternative before any text is laid out.
+//!
+//! Only the platform default is probed. A family the application or a theme
+//! file chose explicitly is used as-is: it is usually embedded through
+//! `add_fonts`, and Windows lists families under their localized names, so an
+//! English name for a CJK font would look missing when it is not.
+
+use gpui::{App, SharedString};
+use gpui_base::TypographyTokens;
+use std::sync::OnceLock;
+
+/// Monospace families tried, in order, when the platform default is missing.
+const MONO_FONT_ALTERNATES: &[&str] = if cfg!(target_os = "macos") {
+    &["Monaco", "Courier New"]
+} else if cfg!(target_os = "windows") {
+    &["Cascadia Mono", "Courier New"]
+} else {
+    &["Noto Sans Mono", "Liberation Mono", "Ubuntu Mono"]
+};
+
+/// The virtual family GPUI resolves on every platform; the last resort when
+/// neither the default nor an alternate is installed.
+const SYSTEM_UI_FONT: &str = ".SystemUIFont";
+
+/// The monospace family the theme picks when none is configured.
+pub(super) fn default_mono_font_family() -> SharedString {
+    TypographyTokens::default().mono
+}
+
+/// Replaces the platform-default monospace family on the global theme with one
+/// that is installed. A family chosen explicitly is left alone.
+pub(super) fn resolve_default_mono_font(cx: &mut App) {
+    if cx.global::<super::Theme>().mono_font_family != default_mono_font_family() {
+        return;
+    }
+    let family = installed_default_mono_font_family(cx);
+    cx.global_mut::<super::Theme>().mono_font_family = family;
+}
+
+/// The installed stand-in for the platform default, resolved once per process.
+///
+/// Enumerating fonts costs around a hundred milliseconds on macOS, and the
+/// answer only depends on the system fonts, which do not change while the
+/// process runs.
+fn installed_default_mono_font_family(cx: &App) -> SharedString {
+    static RESOLVED: OnceLock<SharedString> = OnceLock::new();
+    RESOLVED
+        .get_or_init(|| {
+            let default = default_mono_font_family();
+            let family = first_installed(
+                &default,
+                MONO_FONT_ALTERNATES,
+                &cx.text_system().all_font_names(),
+            );
+            if family != default {
+                tracing::warn!(
+                    "Monospace font {default:?} is not installed, using {family:?} instead."
+                );
+            }
+            family
+        })
+        .clone()
+}
+
+/// `default` when it is installed, else the first installed alternate, else
+/// `.SystemUIFont`.
+fn first_installed(default: &str, alternates: &[&str], installed: &[String]) -> SharedString {
+    std::iter::once(default)
+        .chain(alternates.iter().copied())
+        .find(|candidate| installed.iter().any(|name| name == candidate))
+        .unwrap_or(SYSTEM_UI_FONT)
+        .to_string()
+        .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(names: &[&str]) -> Vec<String> {
+        names.iter().map(|name| name.to_string()).collect()
+    }
+
+    #[test]
+    fn keeps_the_default_when_it_is_installed() {
+        let installed = names(&["Monaco", "Menlo", ".SystemUIFont"]);
+        assert_eq!(
+            first_installed("Menlo", &["Monaco"], &installed),
+            SharedString::from("Menlo")
+        );
+    }
+
+    #[test]
+    fn falls_through_the_alternates_in_order() {
+        let installed = names(&["Courier New", "Monaco", ".SystemUIFont"]);
+        assert_eq!(
+            first_installed("Menlo", &["Monaco", "Courier New"], &installed),
+            SharedString::from("Monaco")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_system_font_when_nothing_is_installed() {
+        let installed = names(&["Helvetica", ".SystemUIFont"]);
+        assert_eq!(
+            first_installed("Menlo", &["Monaco"], &installed),
+            SharedString::from(".SystemUIFont")
+        );
+    }
+}

--- a/crates/component/src/theme/schema.rs
+++ b/crates/component/src/theme/schema.rs
@@ -53,6 +53,10 @@ pub struct ThemeConfig {
     /// - macOS: `Menlo`
     /// - Windows: `Consolas`
     /// - Linux: `DejaVu Sans Mono`
+    ///
+    /// The default falls back to an installed monospace font, then to
+    /// `.SystemUIFont`, when the machine lacks it. A family named here is used
+    /// as-is, so name one that is installed or embedded with `add_fonts`.
     #[serde(rename = "mono_font.family")]
     pub mono_font_family: Option<SharedString>,
     /// The monospace font size, default is 13.

--- a/website/component/editor.md
+++ b/website/component/editor.md
@@ -148,7 +148,10 @@ cx.subscribe(&editor, |this, state, event: &InputEvent, cx| {
 The editor paints its code in the theme's monospace font — `mono_font_family` at
 `mono_font_size` — with rows 1.5 times the font size. That is only the default:
 a text style set on the editor refines over it, and the gutter and row height
-follow the size.
+follow the size. The theme's platform default (`Menlo`, `Consolas`, `DejaVu Sans
+Mono`) is checked against the installed fonts when the theme loads and swapped
+for an installed monospace font, or `.SystemUIFont`, when it is missing; a
+family you set yourself is used as-is.
 
 ```rust
 Editor::new(&editor).text_sm()

--- a/website/zh-CN/component/editor.md
+++ b/website/zh-CN/component/editor.md
@@ -119,6 +119,8 @@ editor.update(cx, |state, cx| {
 
 Editor 默认使用主题中的等宽字体 —— `mono_font_family` 和 `mono_font_size`，行高为字号的
 1.5 倍。这只是默认值：在 Editor 上设置的文本样式会覆盖它，gutter 和行高都跟随字号变化。
+主题加载时会核对平台默认等宽字体（`Menlo`、`Consolas`、`DejaVu Sans Mono`）是否已安装，
+缺失时换成已安装的等宽字体，再不行退到 `.SystemUIFont`；你自己指定的字体族则原样使用。
 
 ```rust
 Editor::new(&editor).text_sm()


### PR DESCRIPTION
## Description

`Theme` defaults `mono_font_family` to a bare platform name (`Menlo`, `Consolas`, `DejaVu Sans Mono`). On a machine without that font, GPUI panics on the first line it lays out in it:

```
failed to resolve font 'Menlo' or any of the fallbacks: .ZedMono, .ZedSans, Helvetica, Segoe UI, Ubuntu, Adwaita Sans, Cantarell, Noto Sans, DejaVu Sans, Arial
```

`Font::fallbacks` cannot help here: `resolve_font` only tries the family itself and GPUI's private fallback stack, and the cascade list is applied after the family has loaded.

`Theme::change` now checks the platform default against `text_system().all_font_names()` and swaps it for the first installed alternate (`Monaco`, `Cascadia Mono`, `Noto Sans Mono`, …) or `.SystemUIFont`. Only the default is probed: a family set by the application or a theme file is used as-is, since it is usually embedded through `add_fonts`, and Windows lists families under localized names. The probe runs once per process (about 100 ms on macOS) and logs a warning when it substitutes.

The whole change was written with Claude Code and reviewed by the author.

## How to Test

- `cargo test -p gpui-component --lib theme` — includes 3 new unit tests for the candidate walk.
- `cargo clippy -p gpui-component --all-targets -- --deny warnings`
- On macOS with Menlo installed, `gpui_component::init` keeps `Menlo`. Temporarily pointing the default at a nonexistent family resolved to `Monaco`; a later `Theme::change` took 0.1 ms thanks to the cached probe.

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes. (No story exercises a missing font; verified through a temporary example instead.)
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific). (Only macOS was tested.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
