### PR TITLE
Reveal an offscreen textarea caret after editing

### DIFF
--- a/crates/base/src/input/base/element.rs
+++ b/crates/base/src/input/base/element.rs
@@ -536,16 +536,15 @@ impl<M: InputModeKind> TextElement<M> {
                 // Vertical cursor-follow is suppressed while auto-scroll manages the y axis,
                 // to prevent fighting the background scroll task.
                 if !auto_scrolling {
-                    // If we change the scroll_offset.y, GPUI will render and trigger the next run loop.
-                    // So, here we just adjust offset by `line_height` for move smooth.
+                    // An edit can move the caret many rows beyond a manually
+                    // scrolled viewport. Reveal it in this layout; a one-row
+                    // step leaves it offscreen until another edit arrives.
                     scroll_offset.y = if scroll_offset.y + cursor_pos.y
                         > bounds.size.height - top_bottom_margin
                     {
-                        // cursor is out of bottom
-                        scroll_offset.y - line_height
+                        bounds.size.height - top_bottom_margin - cursor_pos.y
                     } else if scroll_offset.y + cursor_pos.y < top_bottom_margin {
-                        // cursor is out of top
-                        (scroll_offset.y + line_height).min(px(0.))
+                        (top_bottom_margin - cursor_pos.y).min(px(0.))
                     } else {
                         scroll_offset.y
                     };

--- a/crates/base/src/input/base/state.rs
+++ b/crates/base/src/input/base/state.rs
@@ -2880,6 +2880,9 @@ impl<M: InputModeKind> EntityInputHandler for InputBaseState<M> {
         self.update_fold_candidates_incremental(&range, new_text);
         M::refresh_language_features(self, window, cx);
         self.selected_range = (new_offset..new_offset).into();
+        // Replacement can leave the caret at the same offset while the user
+        // has scrolled it out of view. An accepted edit still needs reveal.
+        self.last_selected_range = None;
         self.ime_marked_range.take();
         self.update_preferred_column();
         self.update_search(cx);
@@ -2987,6 +2990,7 @@ impl<M: InputModeKind> EntityInputHandler for InputBaseState<M> {
                 .unwrap_or_else(|| range.start + new_text.len()..range.start + new_text.len())
                 .into();
         }
+        self.last_selected_range = None;
         if self.is_multi_line() {
             self.mode.update_auto_grow(&self.display_map);
         }
@@ -3300,6 +3304,105 @@ mod tests {
             Self::build_with(cx, move |window, cx| {
                 f(crate::input::InputState::new(window, cx))
             })
+        }
+    }
+
+    #[gpui::test]
+    fn edit_reveals_far_off_pasted_caret(cx: &mut TestAppContext) {
+        use gpui::{point, size};
+        cx.update(crate::init);
+        let view = InputView::build_textarea(cx, |state| state.auto_grow(2, 8));
+        let mut context = VisualTestContext::from_window(view.window_handle.into(), cx);
+        let cx = &mut context;
+        let input = view.input;
+        let draw = |cx: &mut VisualTestContext| {
+            cx.run_until_parked();
+            cx.update(|window, cx| {
+                let _ = window.draw(cx);
+            });
+        };
+        cx.update(|window, cx| input.update(cx, |input, cx| input.focus(window, cx)));
+        for width in [720., 320.] {
+            cx.simulate_resize(size(px(width), px(400.)));
+            for wrapped in [false, true] {
+                let pasted = if wrapped {
+                    "wrapped pasted content ".repeat(200) + "END"
+                } else {
+                    (0..100)
+                        .map(|i| format!("Line {i:03} pasted content\n"))
+                        .collect::<String>()
+                        + "END"
+                };
+                for edit in ["insert", "replace", "delete", "ime"] {
+                    cx.update(|window, cx| {
+                        input.update(cx, |input, cx| input.set_value("", window, cx))
+                    });
+                    draw(cx);
+                    cx.update(|window, cx| {
+                        cx.write_to_clipboard(gpui::ClipboardItem::new_string(pasted.clone()));
+                        window.dispatch_action(Box::new(Paste), cx);
+                    });
+                    draw(cx);
+                    input.update(cx, |input, cx| {
+                        input.set_scroll_offset(point(px(0.), px(0.)), cx)
+                    });
+                    draw(cx);
+                    assert_eq!(
+                        input.read_with(cx, |input, _| input.scroll_offset().y),
+                        px(0.),
+                        "reading old text can scroll independently"
+                    );
+                    let end = pasted.len();
+                    let expected = match edit {
+                        "insert" => {
+                            cx.simulate_input("X");
+                            format!("{pasted}X")
+                        }
+                        "replace" => {
+                            cx.update(|window, cx| {
+                                input.update(cx, |input, cx| {
+                                    input.replace_text_in_range(Some(end - 1..end), "Y", window, cx)
+                                })
+                            });
+                            format!("{}Y", &pasted[..end - 1])
+                        }
+                        "delete" => {
+                            cx.update(|window, cx| {
+                                input.update(cx, |input, cx| {
+                                    input.replace_text_in_range(Some(end - 1..end), "", window, cx)
+                                })
+                            });
+                            pasted[..end - 1].to_string()
+                        }
+                        _ => {
+                            cx.update(|window, cx| {
+                                input.update(cx, |input, cx| {
+                                    input.replace_and_mark_text_in_range(
+                                        None,
+                                        "拼",
+                                        Some(1..1),
+                                        window,
+                                        cx,
+                                    )
+                                })
+                            });
+                            format!("{pasted}拼")
+                        }
+                    };
+                    draw(cx);
+                    input.read_with(cx, |input, _| {
+                        assert_eq!(input.value().as_ref(), expected);
+                        assert_eq!(input.selected_range(), expected.len()..expected.len(), "editing preserves the caret at the new text end");
+                        let (mut caret, _) = input.cursor_layout().expect("one edit must lay out the far-off caret");
+                        caret.origin.y += input.scroll_offset().y;
+                        let viewport = input.input_bounds();
+                        assert!(caret.top() >= viewport.top() && caret.bottom() <= viewport.bottom(), "width={width}, wrapped={wrapped}, edit={edit}: caret={caret:?}, viewport={viewport:?}, offset={:?}", input.scroll_offset());
+                    });
+                    cx.update(|window, cx| {
+                        input.update(cx, |input, cx| input.unmark_text(window, cx))
+                    });
+                }
+            }
         }
     }
 


### PR DESCRIPTION
After a long paste in an auto-growing textarea, the caret can be far below the visible viewport. Editing previously moved the viewport by only one line, leaving the new text offscreen. Reveal the caret directly after accepted edits, including same-length replacement and IME composition whose caret offset does not change. Manual scrolling remains stable until another edit.

The regression uses the existing InputView and clipboard Paste action at two widths with newline-separated and wrapped text. It checks insertion, replacement, deletion, composition, text/range correctness, and manual scrolling.

Validation:
- Actual-owner regression failed before the fix: caret y=2575.95, viewport=0..400, scroll=-26 after an edit. It passes with the fix.
- `cargo test -p gpui-base --lib input:: --locked`: 153 passed.
- Native downstream Tcode app on macOS 26.6.2 arm64, isolated signed bundle: baseline first edit leaves the end of a long paste offscreen; fixed first edit reveals ENDX. Verified light/dark, normal/narrow widths, manual scroll, replacement and deletion via accessibility controls and visual caret inspection.
- Native Story gallery and native IME picker verification are still pending; composition is covered through the real input handler regression. Retained final screenshots and final lint checks will be added before readiness.

AI assistance: implementation and tests were AI-generated and iterated against failing production-path regressions, with independent agent review. Human review/testing required by CONTRIBUTING is still pending; this PR remains a draft.

Downstream issue: https://github.com/Tryanks/tcode/issues/356
