### PR TITLE
chore: Refresh the recipes lock for the `0.6.1` version bump

### DIFF
--- a/examples/ai_recipes/Cargo.lock
+++ b/examples/ai_recipes/Cargo.lock
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-base"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-component"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2318,7 +2318,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-component-macros"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2328,7 +2328,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-kit"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "gpui-base",
  "gpui-component",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "gpui-kit-assets"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "gpui-pre",


### PR DESCRIPTION
## Description

`Version 0.6.1` bumped the workspace crates but left `examples/ai_recipes/Cargo.lock` pinning the workspace path dependencies at `0.6.0`. The recipes verification step runs `cargo check --locked`, which refuses to regenerate the lock, so the macOS CI job fails before it reaches Lint or any of the test steps:

```
error: cannot update the lock file examples/ai_recipes/Cargo.lock because --locked was passed to prevent this
```

Every open pull request inherits the failure, because `pull_request` runs test the merge with `main`.

## Changes

- Regenerated `examples/ai_recipes/Cargo.lock` with `cargo update -p gpui-kit --manifest-path examples/ai_recipes/Cargo.toml`. The diff is five version numbers: `gpui-base`, `gpui-component`, `gpui-component-macros`, `gpui-kit` and `gpui-kit-assets`, all `0.6.0` to `0.6.1`.

## Testing

- `python3 script/check-ai rust` (the failing CI step) now reports `PASS: rust`; it fails on `main` without this change.
- `python3 script/check-ai docs` passes.

Implemented with AI assistance.