### PR TITLE
table: Stop keyboard row navigation when `row_selectable` is off

### DIFF
--- a/crates/component/src/table/state.rs
+++ b/crates/component/src/table/state.rs
@@ -859,6 +859,9 @@ where
         }
 
         // Row selection mode
+        if !self.row_selectable {
+            return;
+        }
         let mut selected_row = self.selected_row.unwrap_or(0);
         if selected_row > 0 {
             selected_row = selected_row.saturating_sub(1);
@@ -901,6 +904,9 @@ where
         }
 
         // Row selection mode
+        if !self.row_selectable {
+            return;
+        }
         let selected_row = match self.selected_row {
             Some(selected_row) if selected_row < rows_count.saturating_sub(1) => selected_row + 1,
             Some(selected_row) => {
@@ -981,6 +987,9 @@ where
         }
 
         // Row selection mode
+        if !self.row_selectable {
+            return;
+        }
         let current = self.selected_row.unwrap_or(0);
         let target = current.saturating_sub(step);
         self.set_selected_row(target, cx);
@@ -1013,6 +1022,9 @@ where
         }
 
         // Row selection mode
+        if !self.row_selectable {
+            return;
+        }
         let current = self.selected_row.unwrap_or(0);
         let max_row = rows_count.saturating_sub(1);
         let target = (current + step).min(max_row);

--- a/crates/kit/tests/collections.rs
+++ b/crates/kit/tests/collections.rs
@@ -5,7 +5,7 @@ use gpui_kit::component::{
 };
 use gpui_kit::test::TestWindowExt;
 use gpui_kit::{
-    App, AppContext, Context, Entity, TestAppContext, Window, div, prelude::*, px, size,
+    App, AppContext, Context, Entity, Focusable, TestAppContext, Window, div, prelude::*, px, size,
 };
 
 struct Files {
@@ -113,6 +113,35 @@ fn table_selects_rows_and_keyboard_scrolls_virtualized_content(cx: &mut TestAppC
         );
         assert!(window.find(("row", 1usize)).visible());
         assert!(window.try_find(("row", 32usize)).is_none());
+    })
+    .unwrap();
+}
+#[gpui_kit::test]
+fn table_keyboard_leaves_rows_unselected_when_rows_are_not_selectable(cx: &mut TestAppContext) {
+    cx.update(gpui_kit::init);
+    let handle = cx.open_window(size(px(640.), px(320.)), |window, cx| Records {
+        table: cx.new(|cx| TableState::new(Rows, window, cx).row_selectable(false)),
+    });
+    let table = cx
+        .update_window(handle.into(), |root, _, cx| {
+            root.downcast::<Records>().unwrap().read(cx).table.clone()
+        })
+        .unwrap();
+    cx.update_window(handle.into(), |_, window, cx| {
+        window.render_frame(cx);
+        window.click(("row", 1usize), cx);
+        assert!(table.focus_handle(cx).is_focused(window));
+        assert_eq!(table.read(cx).selected_row(), None);
+        for key in ["down", "down", "pagedown", "up", "pageup"] {
+            window.press(key, cx);
+            assert_eq!(
+                table.read(cx).selected_row(),
+                None,
+                "`{key}` moved the row selection"
+            );
+            assert_eq!(window.find(("row", 0usize)).selected(), Some(false));
+        }
+        assert!(window.find(("row", 0usize)).visible());
     })
     .unwrap();
 }


### PR DESCRIPTION
## Summary

- Up/Down/PageUp/PageDown still moved and scrolled the selected row when `row_selectable(false)`, unlike mouse clicks and column navigation.
- Guard the row branch of the four keyboard actions with `row_selectable`, matching `on_row_left_click`. `set_selected_row()` is unchanged.

Closes #3022

## Test plan

- [x] New headless test `table_keyboard_leaves_rows_unselected_when_rows_are_not_selectable` fails on `main` (`down` selects row 0) and passes with the fix
- [x] `cargo test -p gpui-kit --features "test-support component" --test collections`
- [x] `cargo clippy -p gpui-component -p gpui-kit --all-targets -- -D warnings`
