### PR TITLE
text: Fix inline-code heading layout and list alignment

### DIFF
--- a/crates/base/src/text/inline.rs
+++ b/crates/base/src/text/inline.rs
@@ -166,6 +166,8 @@ pub(super) struct Inline {
     links: Rc<Vec<(Range<usize>, LinkMark)>>,
     highlights: Vec<(Range<usize>, InlineHighlight)>,
     styled_text: StyledText,
+    /// The resolved style from a parent deferred layout, when there is one.
+    text_style: Option<TextStyle>,
     paint_origin: Option<Point<Pixels>>,
     selection_bounds: Option<Bounds<Pixels>>,
     selection_source: Option<(Arc<Mutex<InlineState>>, Range<usize>)>,
@@ -209,12 +211,19 @@ impl Inline {
             highlights,
             text: text.clone(),
             styled_text: StyledText::new(text),
+            text_style: None,
             paint_origin: None,
             selection_bounds: None,
             selection_source: None,
             link_click_handler,
             state,
         }
+    }
+
+    /// Use the resolved style captured by a deferred parent layout.
+    pub(super) fn text_style(mut self, text_style: TextStyle) -> Self {
+        self.text_style = Some(text_style);
+        self
     }
 
     /// Preserve the shared inline-flow baseline through GPUI's element-bound snapping.
@@ -555,7 +564,10 @@ impl Element for Inline {
         window: &mut Window,
         cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
-        let text_style = window.text_style();
+        let text_style = self
+            .text_style
+            .clone()
+            .unwrap_or_else(|| window.text_style());
         let runs = text_runs(self.text.len(), &text_style, &self.highlights);
 
         self.styled_text = StyledText::new(self.text.clone()).with_runs(runs);
@@ -920,9 +932,9 @@ pub(super) mod test_draw {
 #[cfg(test)]
 pub(super) mod test_fonts {
     use gpui::{
-        Bounds, DevicePixels, Font, FontId, FontMetrics, FontRun, GlyphId, LineLayout, Pixels,
-        PlatformTextSystem, RenderGlyphParams, ShapedGlyph, ShapedRun, Size, TextRenderingMode,
-        point, px, size,
+        Bounds, DevicePixels, Font, FontId, FontMetrics, FontRun, FontWeight, GlyphId, LineLayout,
+        Pixels, PlatformTextSystem, RenderGlyphParams, ShapedGlyph, ShapedRun, Size,
+        TextRenderingMode, point, px, size,
     };
     use std::borrow::Cow;
 
@@ -930,6 +942,8 @@ pub(super) mod test_fonts {
     pub(crate) const MONO: &str = "Mono";
     const BODY_ID: FontId = FontId(1);
     const MONO_ID: FontId = FontId(2);
+    const BOLD_BODY_ID: FontId = FontId(3);
+    const BOLD_MONO_ID: FontId = FontId(4);
     const UNITS_PER_EM: f32 = 1000.;
 
     pub(crate) struct WideMonoTextSystem;
@@ -937,7 +951,13 @@ pub(super) mod test_fonts {
     impl WideMonoTextSystem {
         /// Advance of one glyph in `font_id`, in em units.
         fn advance_units(font_id: FontId) -> f32 {
-            if font_id == MONO_ID { 1000. } else { 500. }
+            match font_id {
+                MONO_ID => 1000.,
+                BOLD_MONO_ID => 1250.,
+                BODY_ID => 500.,
+                BOLD_BODY_ID => 750.,
+                _ => 500.,
+            }
         }
 
         /// Width of `text` shaped entirely in `family` at `font_size`.
@@ -957,11 +977,17 @@ pub(super) mod test_fonts {
         }
 
         fn font_id(&self, descriptor: &Font) -> anyhow::Result<FontId> {
-            Ok(if descriptor.family.as_ref() == MONO {
-                MONO_ID
-            } else {
-                BODY_ID
-            })
+            Ok(
+                match (
+                    descriptor.family.as_ref() == MONO,
+                    descriptor.weight == FontWeight::BOLD,
+                ) {
+                    (true, true) => BOLD_MONO_ID,
+                    (true, false) => MONO_ID,
+                    (false, true) => BOLD_BODY_ID,
+                    (false, false) => BODY_ID,
+                },
+            )
         }
 
         fn font_metrics(&self, _font_id: FontId) -> FontMetrics {
@@ -1043,7 +1069,8 @@ pub(super) mod test_fonts {
                 font_size,
                 width: position,
                 ascent: font_size * (metrics.ascent / UNITS_PER_EM),
-                descent: font_size * (metrics.descent / UNITS_PER_EM),
+                // Native backends normalize the signed font metric for shaped lines.
+                descent: font_size * (-metrics.descent / UNITS_PER_EM),
                 runs: shaped_runs,
                 len: text.len(),
             }

--- a/crates/base/src/text/inline_flow.rs
+++ b/crates/base/src/text/inline_flow.rs
@@ -60,9 +60,18 @@ pub(super) enum InlineFlowItem {
     },
 }
 
-#[derive(Default)]
 pub(crate) struct InlineFlowLayoutState {
     layout: Arc<Mutex<Option<InlineFlowLayout>>>,
+    typography: InlineFlowTypography,
+}
+
+/// Resolved before `request_measured_layout`, while the parent's text-style
+/// and rem stacks are still active.
+#[derive(Clone)]
+struct InlineFlowTypography {
+    text_style: TextStyle,
+    rem_size: Pixels,
+    line_height: Pixels,
 }
 
 #[derive(Default)]
@@ -221,8 +230,14 @@ impl Element for InlineFlow {
         cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
         let measure_items = self.items.iter().map(MeasureItem::from).collect::<Vec<_>>();
-        let line_height = window.line_height();
-        let rem_size = window.rem_size();
+        // A measured-layout callback runs after the parent's text-style stack
+        // is gone. Capture every resolved typography input while this element
+        // is still requested under its Markdown block (notably headings).
+        let typography = InlineFlowTypography {
+            text_style: window.text_style(),
+            rem_size: window.rem_size(),
+            line_height: window.line_height(),
+        };
         let image_sizes = measure_items
             .iter()
             .enumerate()
@@ -232,43 +247,54 @@ impl Element for InlineFlow {
                     url,
                     *width,
                     *height,
-                    line_height,
-                    rem_size,
+                    typography.line_height,
+                    typography.rem_size,
                     window,
                     cx,
                 )),
                 MeasureItem::Text { .. } | MeasureItem::Object { .. } => None,
             })
             .collect::<Vec<_>>();
-        let objects = prepare_objects(&measure_items, &window.text_style(), window, cx);
-        let layout_state = InlineFlowLayoutState::default();
+        let objects = prepare_objects(&measure_items, &typography.text_style, window, cx);
+        let layout_state = InlineFlowLayoutState {
+            layout: Arc::default(),
+            typography: typography.clone(),
+        };
         let layout_ref = layout_state.layout.clone();
+        let layout_typography = typography.clone();
 
         let layout_id = window.request_measured_layout(Default::default(), {
             move |known_dimensions, available_space, window, cx| {
-                let text_style = window.text_style();
-                let wrap_width = if text_style.white_space == WhiteSpace::Normal {
-                    known_dimensions.width.or(match available_space.width {
-                        AvailableSpace::Definite(width) => Some(width),
-                        _ => None,
-                    })
-                } else {
-                    None
-                };
-                let layout = layout_measured_flow(
-                    &measure_items,
-                    &image_sizes,
-                    &objects,
-                    &text_style,
-                    wrap_width,
-                    window,
-                    cx,
-                );
-                let size = layout.size;
-                if let Ok(mut state) = layout_ref.lock() {
-                    *state = Some(layout);
-                }
-                size
+                window.with_rem_size(Some(layout_typography.rem_size), |window| {
+                    window.with_text_style(
+                        Some(layout_typography.text_style.subtract(&Default::default())),
+                        |window| {
+                            let wrap_width =
+                                if layout_typography.text_style.white_space == WhiteSpace::Normal {
+                                    known_dimensions.width.or(match available_space.width {
+                                        AvailableSpace::Definite(width) => Some(width),
+                                        _ => None,
+                                    })
+                                } else {
+                                    None
+                                };
+                            let layout = layout_measured_flow(
+                                &measure_items,
+                                &image_sizes,
+                                &objects,
+                                &layout_typography.text_style,
+                                wrap_width,
+                                window,
+                                cx,
+                            );
+                            let size = layout.size;
+                            if let Ok(mut state) = layout_ref.lock() {
+                                *state = Some(layout);
+                            }
+                            size
+                        },
+                    )
+                })
             }
         });
 
@@ -290,6 +316,8 @@ impl Element for InlineFlow {
             .ok()
             .and_then(|layout| layout.as_ref().map(|layout| layout.fragments.clone()))
             .unwrap_or_default();
+        let typography = request_layout.typography.clone();
+        let text_style = &typography.text_style;
         let mut elements = Vec::with_capacity(fragments.len());
 
         for fragment in fragments {
@@ -371,8 +399,7 @@ impl Element for InlineFlow {
                         Pixels::ZERO
                     };
                     let background = if is_code {
-                        let style = window.text_style();
-                        let runs = text_runs(text.len(), &style, &highlights);
+                        let runs = text_runs(text.len(), text_style, &highlights);
                         let line = shape_line(text.clone(), font_size, &runs, window);
                         let baseline =
                             (fragment_size.height - line.ascent - line.descent) / 2. + line.ascent;
@@ -417,25 +444,33 @@ impl Element for InlineFlow {
                         self.link_click_handler.clone(),
                     )
                     .selection_source(source_state.clone(), source_range)
+                    .text_style(text_style.clone())
                     .selection_bounds(Bounds::new(
                         point(bounds.left(), bounds.top() + selection_bounds.top()),
                         size(bounds.size.width, selection_bounds.size.height),
                     ))
                     .paint_origin(bounds.origin + origin + point(padding, Pixels::ZERO));
                     let mut element = div()
+                        .font(text_style.font())
+                        .text_color(text_style.color)
+                        .when_some(text_style.background_color, |this, color| {
+                            this.text_bg(color)
+                        })
                         .text_size(font_size)
                         .line_height(fragment_size.height)
                         .child(inline)
                         .into_any_element();
-                    element.prepaint_as_root(
-                        bounds.origin + origin + point(padding, Pixels::ZERO),
-                        size(
-                            AvailableSpace::Definite(fragment_size.width - padding * 2.),
-                            AvailableSpace::Definite(fragment_size.height),
-                        ),
-                        window,
-                        cx,
-                    );
+                    window.with_rem_size(Some(typography.rem_size), |window| {
+                        element.prepaint_as_root(
+                            bounds.origin + origin + point(padding, Pixels::ZERO),
+                            size(
+                                AvailableSpace::Definite(fragment_size.width - padding * 2.),
+                                AvailableSpace::Definite(fragment_size.height),
+                            ),
+                            window,
+                            cx,
+                        );
+                    });
                     elements.push((element, background));
                 }
                 PositionedFragment::Image {
@@ -670,12 +705,17 @@ fn layout_measured_flow(
     for line_range in line_ranges {
         let mut line_fragments = Vec::new();
         let mut line_width = Pixels::ZERO;
-        let body_font = window.text_system().resolve_font(&text_style.font());
-        let body_baseline = window
-            .text_system()
-            .baseline_offset(body_font, font_size, line_height);
+        // `LineLayout` is the metric source used by the text paint path. Its
+        // descent is normalized positive by native backends, whereas
+        // `FontMetrics::descent` remains signed. Start with the same shaped
+        // body metrics used below for every text fragment rather than mixing
+        // those two conventions through `TextSystem::baseline_offset`.
+        let body_runs = text_runs(1, text_style, &[]);
+        let body_line = shape_line(" ".into(), font_size, &body_runs, window);
+        let (body_line_height, body_baseline) =
+            shaped_line_height_and_baseline(&body_line, line_height, window);
         let mut line_ascent = body_baseline;
-        let mut line_descent = line_height - body_baseline;
+        let mut line_descent = body_line_height - body_baseline;
         let mut item_start = 0;
 
         for (item_ix, item) in items.iter().enumerate() {
@@ -721,11 +761,8 @@ fn layout_measured_flow(
                         let width = shaped_line.width() + padding;
                         // Keep the glyph paint layer large enough for ascenders and descenders.
                         // The compact code background is painted independently.
-                        let segment_line_height = window
-                            .pixel_snap(line_height.max(shaped_line.ascent + shaped_line.descent));
-                        let baseline =
-                            (segment_line_height - shaped_line.ascent - shaped_line.descent) / 2.
-                                + shaped_line.ascent;
+                        let (segment_line_height, baseline) =
+                            shaped_line_height_and_baseline(&shaped_line, line_height, window);
                         line_ascent = line_ascent.max(baseline);
                         line_descent = line_descent.max(segment_line_height - baseline);
                         line_width += width;
@@ -1111,6 +1148,21 @@ fn shape_line(
     window.text_system().shape_line(text, font_size, runs, None)
 }
 
+/// Returns the line box and baseline from the shaped metrics used by GPUI text
+/// painting. `ShapedLine::descent` is positive; do not substitute the signed
+/// `FontMetrics::descent` exposed by `TextSystem::baseline_offset` here.
+fn shaped_line_height_and_baseline(
+    shaped_line: &ShapedLine,
+    requested_line_height: Pixels,
+    window: &Window,
+) -> (Pixels, Pixels) {
+    let line_height =
+        window.pixel_snap(requested_line_height.max(shaped_line.ascent + shaped_line.descent));
+    let baseline =
+        (line_height - shaped_line.ascent - shaped_line.descent) / 2. + shaped_line.ascent;
+    (line_height, baseline)
+}
+
 pub(super) fn slice_ranges<T, U>(
     ranges: &[(Range<usize>, T)],
     start: usize,
@@ -1381,12 +1433,15 @@ mod tests {
         }
     }
     #[test]
-    fn inline_code_size_is_relative_and_shares_the_body_baseline() {
+    fn inline_code_size_is_relative_and_uses_the_native_body_baseline() {
         use super::super::inline::test_fonts::{BODY, MONO, WideMonoTextSystem};
         use gpui::{Empty, TestApp};
+
         let mut app = TestApp::with_text_system(Arc::new(WideMonoTextSystem));
         let mut window = app.open_window(|_, _| Empty);
-        for body_size in [16., 24.] {
+        // These are the 16px body size and the example-markdown preview's
+        // 1.25x/1.5x inherited text-size zooms.
+        for body_size in [16., 20., 24.] {
             let style = TextStyle {
                 font_family: BODY.into(),
                 font_size: AbsoluteLength::Pixels(px(body_size)),
@@ -1430,16 +1485,63 @@ mod tests {
                     WideMonoTextSystem::width_of("code", MONO, px(body_size * 0.875))
                         + px(INLINE_CODE_PADDING * 2.)
                 );
-                let baseline = |family, fragment: &(&str, Pixels, Pixels, Size<Pixels>)| {
-                    let font = window.text_system().resolve_font(&gpui::font(family));
-                    fragment.2
-                        + window
-                            .text_system()
-                            .baseline_offset(font, fragment.1, fragment.3.height)
-                };
-                assert!(
-                    (baseline(BODY, &text_fragments[0]) - baseline(MONO, &text_fragments[1])).abs()
-                        < px(0.01)
+
+                // GPUI paints shaped lines with positive `LineLayout::descent`.
+                // Derive the ordinary body glyph baseline directly from that
+                // native-compatible shaped line, rather than `baseline_offset`,
+                // whose FontMetrics descent is intentionally signed.
+                let body_runs = text_runs(1, &style, &[]);
+                let body_line = shape_line("a".into(), px(body_size), &body_runs, window);
+                let body_line_height = window.pixel_snap(
+                    window
+                        .line_height()
+                        .max(body_line.ascent + body_line.descent),
+                );
+                let plain_body_baseline = (body_line_height - body_line.ascent - body_line.descent)
+                    / 2.
+                    + body_line.ascent;
+                let mut painted_glyph_baseline =
+                    |fragment: &(&str, Pixels, Pixels, Size<Pixels>)| {
+                        let runs = if fragment.0 == "code" {
+                            text_runs(
+                                fragment.0.len(),
+                                &style,
+                                &[(
+                                    0..fragment.0.len(),
+                                    InlineHighlight {
+                                        font_family: Some(MONO.into()),
+                                        font_size_scale: Some(0.875),
+                                        ..Default::default()
+                                    },
+                                )],
+                            )
+                        } else {
+                            text_runs(fragment.0.len(), &style, &[])
+                        };
+                        let shaped = shape_line(fragment.0.into(), fragment.1, &runs, window);
+                        fragment.2
+                            + (fragment.3.height - shaped.ascent - shaped.descent) / 2.
+                            + shaped.ascent
+                    };
+
+                // `origin` is passed unchanged to Inline::paint_origin, so this
+                // checks the first body glyph's painted row position, not only
+                // the enclosing paragraph height. It must agree with a normal
+                // body line and with the adjacent inline-code glyph baseline.
+                assert_eq!(
+                    text_fragments[0].2,
+                    Pixels::ZERO,
+                    "{body_size}px body origin"
+                );
+                assert_eq!(
+                    painted_glyph_baseline(&text_fragments[0]),
+                    plain_body_baseline,
+                    "{body_size}px body glyph baseline"
+                );
+                assert_eq!(
+                    painted_glyph_baseline(&text_fragments[1]),
+                    plain_body_baseline,
+                    "{body_size}px code glyph baseline"
                 );
             });
         }

--- a/crates/base/src/text/text_view.rs
+++ b/crates/base/src/text/text_view.rs
@@ -1920,6 +1920,182 @@ mod tests {
         assert_eq!(selected.trim(), "[`code`](https://example.com) after");
     }
 
+    /// Inline-code Markdown takes the deferred `InlineFlow` path. Its layout
+    /// must use the heading's resolved typography rather than the ambient body
+    /// style that remains after the heading's style stack has been popped.
+    ///
+    /// This is a real request-layout → measured-layout → prepaint → paint test:
+    /// the deterministic text system makes bold glyphs wider than body glyphs.
+    /// Before the fix, the code heading was allocated using normal body metrics
+    /// but its fragments painted bold, so the wrapped heading text crossed into
+    /// the following paragraph.
+    #[test]
+    fn inline_code_heading_reserves_painted_wrapped_lines_and_list_baseline() {
+        use crate::text::inline::test_fonts::{MONO, WideMonoTextSystem};
+        use gpui::{TestApp, rems};
+
+        const MARKDOWN: &str = "The same words with inline code.\n\nThe same words with `inline code`.\n\n- The same words with inline code.\n- The same words with `inline code`.\n\n# Heading with inline code\n# Heading with `inline code`\n\nthis is a test";
+
+        struct MarkdownRoot {
+            text_view: Entity<TextViewState>,
+            width: Pixels,
+            preview_zoom: f32,
+        }
+
+        impl Render for MarkdownRoot {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                div()
+                    .w(self.width)
+                    // Match example-markdown: preview zoom changes TextView's
+                    // inherited text size, not the window rem size.
+                    .text_size(rems(self.preview_zoom))
+                    .child(crate::TextSelectionLayer)
+                    .child(TextView::new(&self.text_view).selectable(true))
+            }
+        }
+
+        fn draw(
+            app: &mut TestApp,
+            width: Pixels,
+            preview_zoom: f32,
+        ) -> (Bounds<Pixels>, Vec<Bounds<Pixels>>, String) {
+            let mut window = app.open_window(|_, cx| MarkdownRoot {
+                text_view: cx.new(|cx| TextViewState::markdown(MARKDOWN, cx)),
+                width,
+                preview_zoom,
+            });
+            window.draw();
+            app.run_until_parked();
+            window.draw();
+            window.update(|root, _, cx| {
+                root.text_view.update(cx, |state, cx| state.select_all(cx));
+            });
+            window.draw();
+            window.read(|root, cx| {
+                let state = root.text_view.read(cx);
+                (
+                    state.bounds(),
+                    state.selection_adapter.text_bounds(),
+                    state.selected_text(),
+                )
+            })
+        }
+
+        let mut app = TestApp::with_text_system(Arc::new(WideMonoTextSystem));
+        app.update(|cx| {
+            crate::init(cx);
+            crate::Theme::global_mut(cx).tokens.typography.mono = MONO.into();
+        });
+
+        for (case, width, preview_zoom) in [
+            // At the root 16px size the plain heading fits, while bold inline
+            // fragments need their own measured widths.
+            ("default-16px", px(600.), 1.),
+            // A narrow view exercises intentional heading wrapping.
+            ("narrow-16px", px(320.), 1.),
+            // Preview zoom applies through `.text_size(rems(zoom))`.
+            ("zoom-1.25", px(600.), 1.25),
+        ] {
+            let (view_bounds, text_bounds, selected_text) = draw(&mut app, width, preview_zoom);
+            assert!(
+                text_bounds.len() > 8,
+                "{case}: expected all markdown fragments"
+            );
+            assert_eq!(
+                selected_text.trim(),
+                "The same words with inline code.\nThe same words with inline code.\nThe same words with inline code.\nThe same words with inline code.\nHeading with inline code\nHeading with inline code\nthis is a test",
+                "{case}: wrapped inline-code text was lost or duplicated"
+            );
+            let following = text_bounds.last().expect("following paragraph must paint");
+            let painted_bottom = text_bounds
+                .iter()
+                .map(|bounds| bounds.bottom())
+                .max()
+                .expect("markdown must paint text");
+            // This is intentionally not a fragment-count or selection-only
+            // assertion: `text_bounds` are the shaped Inline layouts produced
+            // during paint. No painted wrapped line may reach the following
+            // paragraph's origin, and the TextView allocation must contain the
+            // complete painted document.
+            assert!(
+                text_bounds[..text_bounds.len() - 1]
+                    .iter()
+                    .all(|bounds| bounds.bottom() <= following.top()),
+                "{case}: heading/list text painted through the following paragraph;                  following={following:?}, text_bounds={text_bounds:?}, view={view_bounds:?}"
+            );
+            assert!(
+                painted_bottom <= view_bounds.bottom(),
+                "{case}: TextView height did not reserve its painted text;                  painted_bottom={painted_bottom:?}, view={view_bounds:?}"
+            );
+        }
+    }
+
+    /// The code-bearing list item takes `InlineFlow`; the plain item takes the
+    /// ordinary text path. Their first body glyphs must begin at the same row
+    /// position relative to their own TextView origins.
+    #[test]
+    fn inline_code_list_body_paint_origin_matches_plain_list_item() {
+        use crate::text::inline::test_fonts::{MONO, WideMonoTextSystem};
+        use gpui::{TestApp, rems};
+
+        struct ListRoot {
+            plain: Entity<TextViewState>,
+            code: Entity<TextViewState>,
+            preview_zoom: f32,
+        }
+
+        impl Render for ListRoot {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                div()
+                    .w(px(600.))
+                    .text_size(rems(self.preview_zoom))
+                    .child(crate::TextSelectionLayer)
+                    .child(TextView::new(&self.plain).selectable(true))
+                    .child(TextView::new(&self.code).selectable(true))
+            }
+        }
+
+        fn draw(app: &mut TestApp, preview_zoom: f32) -> (Pixels, Pixels) {
+            let mut window = app.open_window(|_, cx| ListRoot {
+                plain: cx.new(|cx| TextViewState::markdown("- plain body words", cx)),
+                code: cx.new(|cx| TextViewState::markdown("- plain `code` words", cx)),
+                preview_zoom,
+            });
+            window.draw();
+            app.run_until_parked();
+            window.draw();
+            window.read(|root, cx| {
+                let first_body_line_top = |view: &Entity<TextViewState>| {
+                    let view = view.read(cx);
+                    let painted_line = view
+                        .selection_adapter
+                        .text_bounds()
+                        .into_iter()
+                        .next()
+                        .expect("list item should paint its first body line");
+                    painted_line.top() - view.bounds().top()
+                };
+                (
+                    first_body_line_top(&root.plain),
+                    first_body_line_top(&root.code),
+                )
+            })
+        }
+
+        let mut app = TestApp::with_text_system(Arc::new(WideMonoTextSystem));
+        app.update(|cx| {
+            crate::init(cx);
+            crate::Theme::global_mut(cx).tokens.typography.mono = MONO.into();
+        });
+        for (case, preview_zoom) in [("16px", 1.), ("zoom-1.25", 1.25), ("zoom-1.5", 1.5)] {
+            let (plain_origin, code_origin) = draw(&mut app, preview_zoom);
+            assert_eq!(
+                code_origin, plain_origin,
+                "{case}: code list body paint origin {code_origin:?} must match plain {plain_origin:?}"
+            );
+        }
+    }
+
     #[gpui::test]
     fn markdown_link_opens_url_without_handler(cx: &mut TestAppContext) {
         cx.update(crate::init);


### PR DESCRIPTION
## Summary

Markdown containing inline code uses a different rendering path, and that path has two bugs:

- **Incorrect wrapping:** it could measure text using one font style, then paint it using another—for example, measuring normal text but drawing bold. Words wrapped inside a box that hadn’t reserved enough height, so the heading overlapped the next paragraph.
- **Misaligned bullets:** it mixed two font-metric conventions when calculating the baseline, shifting list text downward relative to its bullet.

The fix makes measurement and painting use the same typography and baseline calculations.

- Preserve inherited typography across deferred inline-flow measurement and painting, preventing inline-code headings from wrapping outside their allocated height and overlapping following text.
- Use shaped-line metrics consistently for baselines, fixing inline-code list text sitting below its bullet.
- Add regressions for wrapping, preview zoom, painted bounds, and native-compatible font metrics.

## Before / after

<img width="1878" height="404" alt="markdown-inline-size-bug" src="https://github.com/user-attachments/assets/7b5c8262-33aa-4a43-b4a6-594b39588a54" />

**Original on the left; patched on the right**, in `example-markdown`. The original wraps “with” into the following paragraph and misaligns list text. The patch preserves reading order, block height, and baseline alignment.


## Validation
- `cargo test -p gpui-base --lib` — **925 passed**
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p example-markdown`
- Visual comparison in the example app.
