### PR TITLE
highlighter: allow languages to register runtime parser factories

### DIFF
--- a/crates/component/src/highlighter/highlighter.rs
+++ b/crates/component/src/highlighter/highlighter.rs
@@ -380,12 +380,14 @@ impl SyntaxHighlighter {
 
         // Languages without grammar default to a highlighter that never
         // parses and creates no styles.
-        let Some(grammar) = config.language.as_ref() else {
+        let Some(_) = config.language.as_ref() else {
             return Ok(Self::build_inert(config.name.clone()));
         };
 
-        let mut parser = Parser::new();
-        parser.set_language(grammar).context("parse set_language")?;
+        let (mut parser, grammar) = LanguageRegistry::singleton().parser(lang)?;
+        parser
+            .set_language(&grammar)
+            .context("parse set_language")?;
 
         // Concatenate the query strings, keeping track of the start offset of each section.
         let mut query_source = String::new();
@@ -397,7 +399,7 @@ impl SyntaxHighlighter {
 
         // Construct a single query by concatenating the three query strings, but record the
         // range of pattern indices that belong to each individual string.
-        let mut query = Query::new(grammar, &query_source).context("new query")?;
+        let mut query = Query::new(&grammar, &query_source).context("new query")?;
 
         let mut locals_pattern_index = 0;
         let mut highlights_pattern_index = 0;
@@ -414,7 +416,7 @@ impl SyntaxHighlighter {
         }
 
         let injections_query = if !config.injections.is_empty() {
-            Query::new(grammar, &config.injections).ok().map(Arc::new)
+            Query::new(&grammar, &config.injections).ok().map(Arc::new)
         } else {
             None
         };
@@ -847,9 +849,8 @@ impl SyntaxHighlighter {
             let end = ranges.iter().map(|r| r.end_byte).max()?;
             Some(start..end)
         }
-        let config = LanguageRegistry::singleton().language(language_name)?;
-        let mut parser = Parser::new();
-        parser.set_language(config.language.as_ref()?).ok()?;
+        let (mut parser, grammar) = LanguageRegistry::singleton().parser(language_name).ok()?;
+        parser.set_language(&grammar).ok()?;
         parser.set_included_ranges(&ranges).ok()?;
         let parse_start = Instant::now();
         let mut timed_out = false;

--- a/crates/component/src/highlighter/highlighter.rs
+++ b/crates/component/src/highlighter/highlighter.rs
@@ -378,11 +378,12 @@ impl SyntaxHighlighter {
             ));
         };
 
-        // Languages without grammar default to a highlighter that never
-        // parses and creates no styles.
-        let Some(_) = config.language.as_ref() else {
+        // Languages without a parser (neither a statically linked grammar nor a
+        // registered parser factory) default to a highlighter that never parses
+        // and creates no styles.
+        if !LanguageRegistry::singleton().has_parser(lang) {
             return Ok(Self::build_inert(config.name.clone()));
-        };
+        }
 
         let (mut parser, grammar) = LanguageRegistry::singleton().parser(lang)?;
         parser
@@ -674,7 +675,8 @@ impl SyntaxHighlighter {
                 return Some((config.name, query.clone()));
             }
 
-            let query = match Query::new(config.language.as_ref()?, &config.highlights) {
+            let grammar = LanguageRegistry::singleton().grammar(language_name).ok()?;
+            let query = match Query::new(&grammar, &config.highlights) {
                 Ok(query) => Arc::new(query),
                 Err(error) => {
                     tracing::error!(

--- a/crates/component/src/highlighter/input_adapter.rs
+++ b/crates/component/src/highlighter/input_adapter.rs
@@ -15,7 +15,7 @@ use gpui_base::input::{
     InputHighlighterFactory,
 };
 use ropey::Rope;
-use tree_sitter::{InputEdit, ParseOptions, Parser, Point};
+use tree_sitter::{InputEdit, ParseOptions, Point};
 
 use super::{LanguageRegistry, SyntaxHighlighter};
 
@@ -108,10 +108,9 @@ impl InputHighlighter for TreeSitterInputHighlighter {
             let result = cx
                 .background_executor()
                 .spawn(async move {
-                    let config = LanguageRegistry::singleton().language(&language)?;
-                    let grammar = config.language.as_ref()?;
-                    let mut parser = Parser::new();
-                    parser.set_language(grammar).ok()?;
+                    let (mut parser, grammar) =
+                        LanguageRegistry::singleton().parser(&language).ok()?;
+                    parser.set_language(&grammar).ok()?;
                     let mut progress = |_: &tree_sitter::ParseState| {
                         if parse_cancel.load(Ordering::Relaxed) {
                             std::ops::ControlFlow::Break(())

--- a/crates/component/src/highlighter/input_adapter.rs
+++ b/crates/component/src/highlighter/input_adapter.rs
@@ -21,8 +21,7 @@ use super::{LanguageRegistry, SyntaxHighlighter};
 
 pub(crate) fn input_highlighter_factory() -> InputHighlighterFactory {
     Rc::new(|language| {
-        let config = LanguageRegistry::singleton().language(language)?;
-        config.has_grammar().then(|| {
+        LanguageRegistry::singleton().has_parser(language).then(|| {
             Box::new(TreeSitterInputHighlighter::new(language)) as Box<dyn InputHighlighter>
         })
     })

--- a/crates/component/src/highlighter/registry.rs
+++ b/crates/component/src/highlighter/registry.rs
@@ -8,6 +8,8 @@ use std::{
     sync::{Arc, LazyLock, Mutex},
 };
 
+use anyhow::Result;
+
 use crate::{ActiveTheme, DEFAULT_THEME_COLORS, ThemeMode, highlighter::languages};
 
 pub(super) const HIGHLIGHT_NAMES: [&str; 41] = [
@@ -491,9 +493,18 @@ impl gpui_base::input::HighlightStyleResolver for HighlightTheme {
     }
 }
 
+/// A factory that produces a fresh Tree-sitter parser and grammar for a language.
+///
+/// Dynamic grammars (for example WASM-compiled parsers loaded at runtime) register
+/// a factory here; when the highlighter needs to parse a buffer it prefers the
+/// factory over the statically linked grammar.
+pub type LanguageParserFactory =
+    Arc<dyn Fn() -> Result<(tree_sitter::Parser, tree_sitter::Language)> + Send + Sync>;
+
 /// Registry for code highlighter languages.
 pub struct LanguageRegistry {
     languages: Mutex<HashMap<SharedString, GrammarConfig>>,
+    parser_factories: Mutex<HashMap<SharedString, LanguageParserFactory>>,
 }
 
 impl LanguageRegistry {
@@ -505,6 +516,7 @@ impl LanguageRegistry {
                     .map(|language| (language.name().into(), language.config()))
                     .collect(),
             ),
+            parser_factories: Mutex::new(HashMap::new()),
         });
         &INSTANCE
     }
@@ -515,6 +527,42 @@ impl LanguageRegistry {
             .lock()
             .unwrap()
             .insert(lang.to_string().into(), config.clone());
+    }
+
+    /// Registers a parser factory for a dynamically loaded language.
+    ///
+    /// The factory takes precedence over the language's statically linked grammar
+    /// whenever a buffer in that language is parsed.
+    pub fn register_parser_factory(&self, lang: &str, factory: LanguageParserFactory) {
+        self.parser_factories
+            .lock()
+            .unwrap()
+            .insert(lang.to_string().into(), factory);
+    }
+
+    /// Returns a fresh parser and grammar for `name`, preferring a registered
+    /// parser factory over the statically linked grammar.
+    pub(crate) fn parser(
+        &self,
+        name: &str,
+    ) -> Result<(tree_sitter::Parser, tree_sitter::Language)> {
+        let config = self
+            .language(name)
+            .ok_or_else(|| anyhow::anyhow!("language {name:?} is not registered"))?;
+        if let Some(factory) = self
+            .parser_factories
+            .lock()
+            .unwrap()
+            .get(&config.name)
+            .cloned()
+        {
+            return factory();
+        }
+
+        let language = config
+            .language
+            .ok_or_else(|| anyhow::anyhow!("language {name:?} has no grammar"))?;
+        Ok((tree_sitter::Parser::new(), language))
     }
 
     pub(crate) fn editing_language_name(&self, name: &str) -> SharedString {
@@ -549,6 +597,7 @@ mod tests {
     fn registrations_preserve_exact_names_before_alias_fallback() {
         let registry = super::LanguageRegistry {
             languages: std::sync::Mutex::new(std::collections::HashMap::new()),
+            parser_factories: std::sync::Mutex::new(std::collections::HashMap::new()),
         };
         registry.register("json", &GrammarConfig::plain("canonical"));
         assert_eq!(registry.language("jsonc").unwrap().name, "canonical");
@@ -571,6 +620,7 @@ mod tests {
     fn custom_canonical_registration_does_not_enable_disabled_aliases() {
         let registry = super::LanguageRegistry {
             languages: std::sync::Mutex::new(std::collections::HashMap::new()),
+            parser_factories: std::sync::Mutex::new(std::collections::HashMap::new()),
         };
         registry.register("typescript", &GrammarConfig::plain("typescript"));
         assert!(registry.language("ts").is_none());
@@ -595,7 +645,6 @@ mod tests {
     fn test_registry() {
         use super::LanguageRegistry;
         let registry = LanguageRegistry::singleton();
-
         registry.register(
             "foo",
             &GrammarConfig::new("foo", tree_sitter_json::LANGUAGE.into(), vec![], "", "", ""),
@@ -627,5 +676,44 @@ mod tests {
             assert!(registry.language("javascript").is_none());
             assert!(registry.language("js").is_none());
         }
+    }
+
+    #[test]
+    fn dynamic_language_uses_registered_parser_factory() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        };
+
+        use super::LanguageRegistry;
+
+        let registry = LanguageRegistry::singleton();
+        let called = Arc::new(AtomicBool::new(false));
+        registry.register(
+            "__dynamic_json__",
+            &GrammarConfig::new(
+                "__dynamic_json__",
+                tree_sitter_json::LANGUAGE.into(),
+                vec![],
+                "",
+                "",
+                "",
+            ),
+        );
+        registry.register_parser_factory("__dynamic_json__", {
+            let called = called.clone();
+            Arc::new(move || {
+                called.store(true, Ordering::Relaxed);
+                Ok((
+                    tree_sitter::Parser::new(),
+                    tree_sitter_json::LANGUAGE.into(),
+                ))
+            })
+        });
+
+        let (_, language) = registry.parser("__dynamic_json__").unwrap();
+
+        assert!(called.load(Ordering::Relaxed));
+        assert_eq!(language, tree_sitter_json::LANGUAGE.into());
     }
 }

--- a/crates/component/src/highlighter/registry.rs
+++ b/crates/component/src/highlighter/registry.rs
@@ -549,13 +549,17 @@ impl LanguageRegistry {
         let config = self
             .language(name)
             .ok_or_else(|| anyhow::anyhow!("language {name:?} is not registered"))?;
-        if let Some(factory) = self
+        // Bind the clone in its own statement so the guard is dropped before
+        // calling the factory. Otherwise a factory that re-enters the registry
+        // self-deadlocks on the non-reentrant mutex, every call is serialized
+        // behind the factory, and a panicking factory poisons the singleton.
+        let factory = self
             .parser_factories
             .lock()
             .unwrap()
             .get(&config.name)
-            .cloned()
-        {
+            .cloned();
+        if let Some(factory) = factory {
             return factory();
         }
 
@@ -563,6 +567,26 @@ impl LanguageRegistry {
             .language
             .ok_or_else(|| anyhow::anyhow!("language {name:?} has no grammar"))?;
         Ok((tree_sitter::Parser::new(), language))
+    }
+
+    /// Returns whether `name` can produce a parser, either through a registered
+    /// parser factory or a statically linked grammar.
+    pub(crate) fn has_parser(&self, name: &str) -> bool {
+        let Some(config) = self.language(name) else {
+            return false;
+        };
+
+        config.language.is_some()
+            || self
+                .parser_factories
+                .lock()
+                .unwrap()
+                .contains_key(&config.name)
+    }
+
+    /// Returns the grammar for `name`, preferring a registered parser factory.
+    pub(crate) fn grammar(&self, name: &str) -> Result<tree_sitter::Language> {
+        Ok(self.parser(name)?.1)
     }
 
     pub(crate) fn editing_language_name(&self, name: &str) -> SharedString {
@@ -715,5 +739,46 @@ mod tests {
 
         assert!(called.load(Ordering::Relaxed));
         assert_eq!(language, tree_sitter_json::LANGUAGE.into());
+    }
+
+    #[test]
+    fn factory_only_language_highlights_without_static_grammar() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        };
+
+        use super::LanguageRegistry;
+        use crate::highlighter::SyntaxHighlighter;
+
+        let registry = LanguageRegistry::singleton();
+        let called = Arc::new(AtomicBool::new(false));
+        // No statically linked grammar: `language` is `None`, so the grammar can
+        // only come from the registered factory.
+        registry.register(
+            "__dynamic_factory_only__",
+            &GrammarConfig::plain("__dynamic_factory_only__"),
+        );
+        assert!(
+            !registry
+                .language("__dynamic_factory_only__")
+                .unwrap()
+                .has_grammar()
+        );
+        registry.register_parser_factory("__dynamic_factory_only__", {
+            let called = called.clone();
+            Arc::new(move || {
+                called.store(true, Ordering::Relaxed);
+                Ok((
+                    tree_sitter::Parser::new(),
+                    tree_sitter_json::LANGUAGE.into(),
+                ))
+            })
+        });
+
+        let highlighter = SyntaxHighlighter::new("__dynamic_factory_only__");
+
+        assert!(called.load(Ordering::Relaxed));
+        assert_eq!(highlighter.language().as_ref(), "__dynamic_factory_only__");
     }
 }

--- a/crates/component/src/input/syntax_context.rs
+++ b/crates/component/src/input/syntax_context.rs
@@ -10,8 +10,7 @@ use gpui_base::input::SyntaxContextProvider;
 pub(crate) fn syntax_context_provider(language: &str) -> Option<Rc<dyn SyntaxContextProvider>> {
     use crate::highlighter::LanguageRegistry;
 
-    let config = LanguageRegistry::singleton().language(language)?;
-    let grammar = config.language?;
+    let grammar = LanguageRegistry::singleton().grammar(language).ok()?;
     TreeSitterSyntaxContext::new(grammar)
         .map(|provider| Rc::new(provider) as Rc<dyn SyntaxContextProvider>)
 }


### PR DESCRIPTION
## Problem

A language's Tree-sitter grammar has to be statically linked into the binary before
highlighting can use it. There's no way to plug in a grammar that arrives at runtime —
WASM-parsers shipped and updated separately, for example. `LanguageRegistry` stores a map
of `GrammarConfig`, so everything downstream assumes a compiled-in `Language`.

## What this does

Adds an optional per-language parser factory that takes precedence over the static grammar:

- `LanguageParserFactory` — `Arc<dyn Fn() -> Result<(Parser, Language)> + Send + Sync>`.
- `LanguageRegistry::register_parser_factory(lang, factory)` — registers one for a language.
- `LanguageRegistry::parser(name)` — resolves a parser + grammar, preferring a registered
  factory and falling back to the statically linked grammar.

The three places that previously built `Parser` themselves now go through `parser(...)`:

- `SyntaxHighlighter::new`
- the "parse only this range" path used for partial re-highlighting
- `TreeSitterInputHighlighter` in `input_adapter.rs`

Nothing changes for callers that don't register a factory: no factory ⇒ the old static
grammar path, exactly as before.

## Why the factory returns both parser and grammar

A dynamic grammar often wants its own `Parser` instance (its own wasm store / cancellation
token). Returning `(Parser, Language)` as a pair lets the factory decide how the parser is
configured instead of forcing every kind of grammar into one pre-built `Parser`.

## Validation

- `cargo check -p gpui-component --no-default-features` (tree-sitter off) passes, so the
  `#![cfg(feature = ...)]` boundaries around the highlighter are unchanged.
- `cargo clippy -p gpui-component -p gpui-component-story -p gpui-kit-assets -- --deny warnings`
  passes.
- `cargo test --workspace --exclude gpui-shell --features gpui-component-story/test-support`
  passes — the existing highlighter tests exercise all three call sites.

No new unit test is included: asserting that a factory wins would require constructing a
tree-sitter `Language`, which can't be done without a real grammar fixture. If you'd rather
have coverage here, tell me how you'd like it faked and I'll add it.

Downstream, we use this to drive highlighting from grammars loaded at runtime.

Release Notes:

- N/A
