### PR TITLE
input: collection-owned tracked range decorations

### DIFF
--- a/crates/base/src/input/base/element.rs
+++ b/crates/base/src/input/base/element.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 use super::{
-    InputBaseState, TextDecoration,
+    InputBaseState, RangeDecorationStyle, TextDecoration,
     layout::{LastLayout, WhitespaceIndicators},
     mode::LayoutMode,
 };
@@ -651,147 +651,132 @@ impl<M: InputModeKind> TextElement<M> {
         last_layout: &LastLayout,
         bounds: &Bounds<Pixels>,
     ) -> Option<Path<Pixels>> {
+        let corners = Self::layout_range_corners(&range, last_layout)?;
+        let points = frame_outline_points(&corners);
+        let origin = bounds.origin + point(last_layout.line_number_width, px(0.));
+        let mut builder = gpui::PathBuilder::fill();
+        builder.move_to(origin + *points.first()?);
+        for point in points.iter().skip(1) {
+            builder.line_to(origin + *point);
+        }
+        builder.close();
+        builder.build().ok()
+    }
+
+    /// Project a buffer range through the visible (non-folded) shaped lines.
+    /// Half-open intersections give soft-wrap ends their trailing affinity and
+    /// prevent ranges on later lines from painting an earlier line's first glyph.
+    fn layout_range_corners(
+        range: &Range<usize>,
+        last_layout: &LastLayout,
+    ) -> Option<Vec<Corners<Point<Pixels>>>> {
+        let range = range.start.max(last_layout.visible_range_offset.start)
+            ..range.end.min(last_layout.visible_range_offset.end);
         if range.is_empty() {
             return None;
         }
 
-        if range.start < last_layout.visible_range_offset.start
-            || range.end > last_layout.visible_range_offset.end
-        {
-            return None;
-        }
-
-        let line_height = last_layout.line_height;
-        let visible_top = last_layout.visible_top;
-        let lines = &last_layout.lines;
-        let line_number_width = last_layout.line_number_width;
-
-        let start_ix = range.start;
-        let end_ix = range.end;
-
-        // Start from visible_top (which already accounts for all lines before visible range)
-        let mut offset_y = visible_top;
-        let mut line_corners = vec![];
-
-        // Iterate only over visible (non-hidden) buffer lines
-        for (prev_lines_offset, line) in last_layout
+        let mut y = last_layout.visible_top;
+        let mut corners = Vec::new();
+        for (&line_offset, line) in last_layout
             .visible_line_byte_offsets
             .iter()
-            .zip(lines.iter())
+            .zip(last_layout.lines.iter())
         {
-            let prev_lines_offset = *prev_lines_offset;
-            let line_size = line.size(line_height);
-            let line_wrap_width = line_size.width;
-
-            let line_origin = point(px(0.), offset_y);
-
-            let line_cursor_start = line.position_for_index(
-                start_ix.saturating_sub(prev_lines_offset),
-                last_layout,
-                false,
-            );
-            // The end of a range closes the row it lands on: a range ending exactly on a soft
-            // wrap boundary highlights to the end of that row instead of opening a zero-width
-            // sliver at the start of the next one.
-            let line_cursor_end = line.position_for_index(
-                end_ix.saturating_sub(prev_lines_offset),
-                last_layout,
-                true,
-            );
-
-            if line_cursor_start.is_some() || line_cursor_end.is_some() {
-                let start = line_cursor_start
-                    .unwrap_or_else(|| line.position_for_index(0, last_layout, false).unwrap());
-
-                let end = line_cursor_end.unwrap_or_else(|| {
-                    line.position_for_index(line.len(), last_layout, false)
-                        .unwrap()
-                });
-
-                // Split the selection into multiple items
-                let wrapped_lines =
-                    (end.y / line_height).ceil() as usize - (start.y / line_height).ceil() as usize;
-
-                let mut end_x = end.x;
-                if wrapped_lines > 0 {
-                    end_x = line_wrap_width;
-                }
-
-                // Ensure at least 6px width for the selection for empty lines.
-                end_x = end_x.max(start.x + px(6.));
-
-                line_corners.push(Corners {
-                    top_left: line_origin + point(start.x, start.y),
-                    top_right: line_origin + point(end_x, start.y),
-                    bottom_left: line_origin + point(start.x, start.y + line_height),
-                    bottom_right: line_origin + point(end_x, start.y + line_height),
-                });
-
-                // wrapped lines
-                for i in 1..=wrapped_lines {
-                    let indent = line.wrap_indent;
-                    let start = point(indent, start.y + i as f32 * line_height);
-                    let mut end = point(end.x, end.y + i as f32 * line_height);
-                    if i < wrapped_lines {
-                        end.x = line_size.width;
-                    }
-
-                    line_corners.push(Corners {
-                        top_left: line_origin + point(start.x, start.y),
-                        top_right: line_origin + point(end.x, start.y),
-                        bottom_left: line_origin + point(start.x, start.y + line_height),
-                        bottom_right: line_origin + point(end.x, start.y + line_height),
+            let mut offset = line_offset;
+            let alignment = last_layout.alignment_offset(line.longest_width);
+            for (row, shaped) in line.wrapped_lines.iter().enumerate() {
+                let end = offset + shaped.len;
+                let start_ix = range.start.max(offset);
+                let end_ix = range.end.min(end);
+                let is_last = row + 1 == line.wrapped_lines.len();
+                // A selected newline has a one-space cell, including empty lines.
+                // A wrap boundary is not a newline and must not get such a cell.
+                let newline = is_last && range.start <= end && range.end > end;
+                if start_ix < end_ix || newline {
+                    let indent = if row == 0 { px(0.) } else { line.wrap_indent };
+                    let left = alignment + indent + shaped.x_for_index(start_ix.min(end) - offset);
+                    let right = alignment
+                        + indent
+                        + if newline {
+                            shaped.width + last_layout.space_width
+                        } else {
+                            shaped.x_for_index(end_ix - offset)
+                        };
+                    corners.push(Corners {
+                        top_left: point(left, y),
+                        top_right: point(right, y),
+                        bottom_left: point(left, y + last_layout.line_height),
+                        bottom_right: point(right, y + last_layout.line_height),
                     });
                 }
-            }
-
-            if line_cursor_start.is_some() && line_cursor_end.is_some() {
-                break;
-            }
-
-            offset_y += line_size.height;
-        }
-
-        let mut points = vec![];
-        if line_corners.is_empty() {
-            return None;
-        }
-
-        // Fix corners to make sure the left to right direction
-        for corners in &mut line_corners {
-            if corners.top_left.x > corners.top_right.x {
-                std::mem::swap(&mut corners.top_left, &mut corners.top_right);
-                std::mem::swap(&mut corners.bottom_left, &mut corners.bottom_right);
+                offset = end;
+                y += last_layout.line_height;
             }
         }
+        (!corners.is_empty()).then_some(corners)
+    }
 
-        for corners in &line_corners {
-            points.push(corners.top_right);
-            points.push(corners.bottom_right);
-            points.push(corners.bottom_left);
+    fn layout_range_decorations(
+        &self,
+        last_layout: &LastLayout,
+        bounds: &Bounds<Pixels>,
+        cx: &App,
+    ) -> (Vec<(Path<Pixels>, Hsla)>, Vec<(Path<Pixels>, Hsla)>) {
+        let state = self.state.read(cx);
+        let mut fills = Vec::new();
+        let mut frames = Vec::new();
+        // Query separate buffer spans across folds instead of scanning annotations
+        // in the hidden text between the first and last visible buffer offsets.
+        let mut visible_spans: Vec<Range<usize>> = Vec::new();
+        for (&offset, line) in last_layout
+            .visible_line_byte_offsets
+            .iter()
+            .zip(last_layout.lines.iter())
+        {
+            let end = (offset + line.len() + 1).min(last_layout.visible_range_offset.end);
+            if let Some(previous) = visible_spans.last_mut().filter(|span| span.end == offset) {
+                previous.end = end;
+            } else if offset < end {
+                visible_spans.push(offset..end);
+            }
         }
-
-        let mut rev_line_corners = line_corners.iter().rev().peekable();
-        while let Some(corners) = rev_line_corners.next() {
-            points.push(corners.top_left);
-            if let Some(next) = rev_line_corners.peek() {
-                if next.top_left.x != corners.top_left.x {
-                    points.push(point(next.top_left.x, corners.top_left.y));
+        for decoration in state.extras.range_decorations(&visible_spans) {
+            match decoration.style() {
+                RangeDecorationStyle::Fill => {
+                    let color = decoration
+                        .color()
+                        .unwrap_or(state.editor_style.foreground.opacity(0.12));
+                    if let Some(path) =
+                        Self::layout_match_range(decoration.range().clone(), last_layout, bounds)
+                    {
+                        fills.push((path, color));
+                    }
+                }
+                RangeDecorationStyle::Frame => {
+                    let color = decoration.color().unwrap_or(state.editor_style.foreground);
+                    let Some(corners) = Self::layout_range_corners(decoration.range(), last_layout)
+                    else {
+                        continue;
+                    };
+                    let points = frame_outline_points(&corners);
+                    let Some(first) = points.first().copied() else {
+                        continue;
+                    };
+                    let origin = bounds.origin + point(last_layout.line_number_width, px(0.));
+                    let mut builder = gpui::PathBuilder::stroke(px(1.));
+                    builder.move_to(origin + first);
+                    for point in points.iter().skip(1) {
+                        builder.line_to(origin + *point);
+                    }
+                    builder.close();
+                    if let Ok(path) = builder.build() {
+                        frames.push((path, color));
+                    }
                 }
             }
         }
-
-        // print_points_as_svg_path(&line_corners, &points);
-
-        let path_origin = bounds.origin + point(line_number_width, px(0.));
-        let first_p = *points.get(0).unwrap();
-        let mut builder = gpui::PathBuilder::fill();
-        builder.move_to(path_origin + first_p);
-        for p in points.iter().skip(1) {
-            builder.line_to(path_origin + *p);
-        }
-
-        builder.build().ok()
+        (fills, frames)
     }
 
     fn layout_search_matches(
@@ -1634,6 +1619,8 @@ pub(super) struct PrepaintState {
     hover_highlight_path: Option<Path<Pixels>>,
     search_match_paths: Vec<(Path<Pixels>, bool)>,
     document_color_paths: Vec<(Path<Pixels>, Hsla)>,
+    range_decoration_fills: Vec<(Path<Pixels>, Hsla)>,
+    range_decoration_frames: Vec<(Path<Pixels>, Hsla)>,
     hover_definition_hitbox: Option<Hitbox>,
     indent_guides_path: Option<Path<Pixels>>,
     bounds: Bounds<Pixels>,
@@ -1703,6 +1690,38 @@ fn print_points_as_svg_path(
         }
     }
 }
+
+fn frame_outline_points(corners: &[Corners<Point<Pixels>>]) -> Vec<Point<Pixels>> {
+    let rects = corners
+        .iter()
+        .map(|corners| (corners.top_left, corners.bottom_right))
+        .collect::<Vec<_>>();
+    let mut points = Vec::with_capacity(rects.len() * 4);
+    let first = rects[0];
+    let last = rects[rects.len() - 1];
+    points.push(first.0);
+    points.push(point(first.1.x, first.0.y));
+    for pair in rects.windows(2) {
+        let current = pair[0];
+        let next = pair[1];
+        points.push(current.1);
+        points.push(point(next.1.x, current.1.y));
+        points.push(point(next.1.x, next.1.y));
+    }
+    if points.last() != Some(&last.1) {
+        points.push(last.1);
+    }
+    points.push(point(last.0.x, last.1.y));
+    for pair in rects.windows(2).rev() {
+        let current = pair[1];
+        let next = pair[0];
+        points.push(point(current.0.x, current.0.y));
+        points.push(point(next.0.x, current.0.y));
+        points.push(point(next.0.x, next.0.y));
+    }
+    points
+}
+
 impl<M: InputModeKind> Element for TextElement<M> {
     type RequestLayoutState = ();
     type PrepaintState = PrepaintState;
@@ -2068,6 +2087,8 @@ impl<M: InputModeKind> Element for TextElement<M> {
         let hover_highlight_path = self.layout_hover_highlight(&last_layout, &mut bounds, cx);
         let document_color_paths =
             self.layout_document_colors(&document_colors, &last_layout, &bounds, cx);
+        let (range_decoration_fills, range_decoration_frames) =
+            self.layout_range_decorations(&last_layout, &bounds, cx);
 
         let state = self.state.read(cx);
         let line_numbers = if state.mode.line_number() {
@@ -2148,6 +2169,8 @@ impl<M: InputModeKind> Element for TextElement<M> {
             hover_highlight_path,
             hover_definition_hitbox,
             document_color_paths,
+            range_decoration_fills,
+            range_decoration_frames,
             indent_guides_path,
             fold_icon_layout,
             ghost_first_line,
@@ -2275,6 +2298,14 @@ impl<M: InputModeKind> Element for TextElement<M> {
         // Paint indent guides
         if let Some(path) = prepaint.indent_guides_path.take() {
             window.paint_path(path, editor_style.border.opacity(0.85));
+        }
+
+        // Application decorations sit below the user's selection.
+        for (path, color) in &prepaint.range_decoration_fills {
+            window.paint_path(path.clone(), *color);
+        }
+        for (path, color) in &prepaint.range_decoration_frames {
+            window.paint_path(path.clone(), *color);
         }
 
         // Paint selections
@@ -2736,6 +2767,317 @@ fn split_runs_by_bg_segments(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::input::{EditorMode, EditorState, FoldRange, RangeDecoration, Redo, Undo};
+    use gpui::{
+        AppContext as _, Context, EntityInputHandler as _, Render, TestAppContext,
+        VisualTestContext, div,
+    };
+
+    struct DecorationHarness(Entity<EditorState>);
+
+    impl Render for DecorationHarness {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().child(self.0.clone())
+        }
+    }
+
+    fn decoration_editor(
+        cx: &mut TestAppContext,
+        text: &str,
+        wrap: bool,
+    ) -> (Entity<EditorState>, gpui::WindowHandle<DecorationHarness>) {
+        cx.update(crate::init);
+        let mut editor = None;
+        let window = cx.open_window(size(px(240.), px(140.)), |window, cx| {
+            let state = cx.new(|cx| {
+                EditorState::new(window, cx)
+                    .soft_wrap(wrap)
+                    .folding(true)
+                    .default_value(text)
+            });
+            editor = Some(state.clone());
+            DecorationHarness(state)
+        });
+        (editor.unwrap(), window)
+    }
+
+    #[gpui::test]
+    fn geometric_decorations_clip_scrolled_viewport_and_cull_offscreen_ranges(
+        cx: &mut TestAppContext,
+    ) {
+        let text = "abcdefghij\n".repeat(100);
+        let (editor, window) = decoration_editor(cx, &text, false);
+        let mut cx = VisualTestContext::from_window(window.into(), cx);
+        cx.update(|window, cx| {
+            editor.update(cx, |state, cx| {
+                state.create_range_decorations_collection(
+                    vec![
+                        RangeDecoration::new(0..text.len()).with_style(RangeDecorationStyle::Fill),
+                        RangeDecoration::new(0..text.len()),
+                        RangeDecoration::new(0..3),
+                        RangeDecoration::new(text.len() - 3..text.len()),
+                    ],
+                    cx,
+                );
+            });
+            window.draw(cx).clear(cx);
+            editor.update(cx, |state, cx| {
+                let height = state.last_layout.as_ref().unwrap().line_height;
+                state.set_scroll_offset(point(px(0.), -height * 40.), cx);
+            });
+            // Deferred scroll is committed by prepaint and reflected next frame.
+            window.draw(cx).clear(cx);
+            window.draw(cx).clear(cx);
+            let state = editor.read(cx);
+            let layout = state.last_layout.as_ref().unwrap();
+            assert!(layout.visible_range_offset.start > 0);
+            assert!(layout.visible_range_offset.end < text.len());
+            let all =
+                TextElement::<EditorMode>::layout_range_corners(&(0..text.len()), layout).unwrap();
+            let clipped = TextElement::<EditorMode>::layout_range_corners(
+                &layout.visible_range_offset,
+                layout,
+            )
+            .unwrap();
+            assert_eq!(all, clipped);
+            assert!(!all.is_empty());
+            assert!(TextElement::<EditorMode>::layout_range_corners(&(0..3), layout).is_none());
+            // Also execute the production path building seam, not just the corner helper.
+            let (fills, frames) = TextElement::new(editor.clone()).layout_range_decorations(
+                layout,
+                &state.input_bounds,
+                cx,
+            );
+            assert_eq!(fills.len(), 1);
+            assert_eq!(frames.len(), 1);
+        });
+    }
+
+    #[gpui::test]
+    fn geometric_decorations_use_shaped_wrap_boundaries_and_newline_cells(cx: &mut TestAppContext) {
+        let text = "    héllo world héllo world héllo world héllo world\n\nlast";
+        let (editor, window) = decoration_editor(cx, text, true);
+        let mut cx = VisualTestContext::from_window(window.into(), cx);
+        cx.update(|window, cx| {
+            window.draw(cx).clear(cx);
+            let state = editor.read(cx);
+            let layout = state.last_layout.as_ref().unwrap();
+            let first = &layout.lines[0];
+            assert!(first.wrapped_lines.len() > 1);
+            assert!(first.wrap_indent > px(0.));
+            let boundary = first.wrapped_lines[0].len;
+            let first_row =
+                TextElement::<EditorMode>::layout_range_corners(&(0..boundary), layout).unwrap();
+            assert_eq!(
+                first_row.len(),
+                1,
+                "a wrap end must not open the next visual row"
+            );
+            assert_eq!(first_row[0].top_right.x, first.wrapped_lines[0].width);
+            let rest =
+                TextElement::<EditorMode>::layout_range_corners(&(boundary..first.len()), layout)
+                    .unwrap();
+            assert_eq!(rest.len(), first.wrapped_lines.len() - 1);
+            assert_eq!(rest[0].top_left.y, layout.visible_top + layout.line_height);
+            for (index, corners) in rest.iter().enumerate() {
+                assert_eq!(
+                    corners.top_right.x,
+                    first.wrap_indent + first.wrapped_lines[index + 1].width
+                );
+                assert_eq!(
+                    corners.bottom_left.y - corners.top_left.y,
+                    layout.line_height
+                );
+            }
+            let blank_offset = text.find("\n\n").unwrap() + 1;
+            let blank = TextElement::<EditorMode>::layout_range_corners(
+                &(blank_offset..blank_offset + 1),
+                layout,
+            )
+            .unwrap();
+            assert_eq!(blank.len(), 1);
+            assert_eq!(
+                blank[0].top_right.x - blank[0].top_left.x,
+                layout.space_width
+            );
+            // A later-line decoration cannot paint the first row via saturating_sub.
+            let last_offset = text.rfind("last").unwrap();
+            let last =
+                TextElement::<EditorMode>::layout_range_corners(&(last_offset..text.len()), layout)
+                    .unwrap();
+            assert_eq!(last.len(), 1);
+            assert!(last[0].top_left.y > rest.last().unwrap().top_left.y);
+        });
+    }
+
+    #[gpui::test]
+    fn geometric_decorations_include_crlf_boundaries(cx: &mut TestAppContext) {
+        let text = "one\r\ntwo\r\nthree";
+        let (editor, window) = decoration_editor(cx, text, false);
+        let mut cx = VisualTestContext::from_window(window.into(), cx);
+        cx.update(|window, cx| {
+            editor.update(cx, |state, cx| {
+                state.create_range_decorations_collection(
+                    vec![
+                        RangeDecoration::new(0..8),
+                        RangeDecoration::new(3..5),
+                        RangeDecoration::new(4..5),
+                        RangeDecoration::new(5..8),
+                        RangeDecoration::new(9..10),
+                    ],
+                    cx,
+                );
+            });
+            window.draw(cx).clear(cx);
+            let state = editor.read(cx);
+            let layout = state.last_layout.as_ref().unwrap();
+            // Shaping retains '\r'; only '\n' needs an additional newline cell.
+            assert_eq!(layout.lines[0].len(), "one\r".len());
+            assert_eq!(layout.visible_line_byte_offsets, vec![0, 5, 10]);
+            let spanning =
+                TextElement::<EditorMode>::layout_range_corners(&(0..8), layout).unwrap();
+            assert_eq!(spanning.len(), 2);
+            for range in [3..5, 4..5, 9..10] {
+                let corners =
+                    TextElement::<EditorMode>::layout_range_corners(&range, layout).unwrap();
+                assert_eq!(corners.len(), 1);
+                assert!(corners[0].top_right.x > corners[0].top_left.x);
+            }
+            let (fills, frames) = TextElement::new(editor.clone()).layout_range_decorations(
+                layout,
+                &state.input_bounds,
+                cx,
+            );
+            assert!(fills.is_empty());
+            assert_eq!(frames.len(), 5);
+        });
+    }
+
+    #[gpui::test]
+    fn geometric_decorations_project_folds_without_changing_tracked_ranges(
+        cx: &mut TestAppContext,
+    ) {
+        let text = "top\nhidden one\nhidden two\nend\nlast";
+        let (editor, window) = decoration_editor(cx, text, false);
+        let mut cx = VisualTestContext::from_window(window.into(), cx);
+        cx.update(|window, cx| {
+            let hidden = 4..text.find("end").unwrap();
+            let collection = editor.update(cx, |state, cx| {
+                state.apply_highlighter_fold_candidates(vec![FoldRange::new(0, 3)], cx);
+                state.display_map.set_folded(0, true);
+                state.create_range_decorations_collection(
+                    vec![RangeDecoration::new(hidden.clone())],
+                    cx,
+                )
+            });
+            window.draw(cx).clear(cx);
+            {
+                let state = editor.read(cx);
+                let layout = state.last_layout.as_ref().unwrap();
+                assert_eq!(layout.visible_buffer_lines, vec![0, 3, 4]);
+                assert!(TextElement::<EditorMode>::layout_range_corners(&hidden, layout).is_none());
+                let (_, frames) = TextElement::new(editor.clone()).layout_range_decorations(
+                    layout,
+                    &state.input_bounds,
+                    cx,
+                );
+                assert!(frames.is_empty());
+                let spanning =
+                    TextElement::<EditorMode>::layout_range_corners(&(0..text.len()), layout)
+                        .unwrap();
+                assert_eq!(spanning.len(), 3);
+                assert_eq!(spanning[1].top_left.y, spanning[0].bottom_left.y);
+            }
+            assert_eq!(collection.get_ranges(cx), vec![hidden.clone()]);
+            editor.update(cx, |state, cx| {
+                state.display_map.set_folded(0, false);
+                cx.notify();
+            });
+            window.draw(cx).clear(cx);
+            let state = editor.read(cx);
+            let layout = state.last_layout.as_ref().unwrap();
+            let revealed =
+                TextElement::<EditorMode>::layout_range_corners(&hidden, layout).unwrap();
+            assert_eq!(revealed.len(), 2);
+            assert_eq!(collection.get_ranges(cx), vec![hidden]);
+        });
+    }
+
+    #[gpui::test]
+    fn geometric_decorations_track_edits_history_replacement_and_owner_lifetime(
+        cx: &mut TestAppContext,
+    ) {
+        let (editor, window) = decoration_editor(cx, "abc def", false);
+        let mut cx = VisualTestContext::from_window(window.into(), cx);
+        cx.update(|window, cx| {
+            let (first, second) = editor.update(cx, |state, cx| {
+                (
+                    state.create_range_decorations_collection(vec![RangeDecoration::new(4..7)], cx),
+                    state.create_range_decorations_collection(vec![RangeDecoration::new(0..3)], cx),
+                )
+            });
+            editor.update(cx, |state, cx| {
+                state.set_selected_range(0..0, cx);
+                state.replace_text_in_range(None, "\n", window, cx);
+            });
+            assert_eq!(first.get_ranges(cx), vec![5..8]);
+            editor.update(cx, |state, cx| state.undo(&Undo, window, cx));
+            assert_eq!(first.get_ranges(cx), vec![4..7]);
+            editor.update(cx, |state, cx| state.redo(&Redo, window, cx));
+            assert_eq!(first.get_ranges(cx), vec![5..8]);
+            first.clear(cx);
+            assert_eq!(second.get_ranges(cx), vec![1..4]);
+            first.append(vec![RangeDecoration::new(5..8)], cx);
+            editor.update(cx, |state, cx| state.replace_all("formatted", window, cx));
+            assert_eq!(first.get_ranges(cx), vec![0..9]);
+            editor.update(cx, |state, cx| state.undo(&Undo, window, cx));
+            // Annotations are transformed, not snapshotted in undo history.
+            assert_eq!(first.get_ranges(cx), vec![0..8]);
+            editor.update(cx, |state, cx| state.set_value("new", window, cx));
+            assert_eq!(first.get_ranges(cx), vec![0..3]);
+            let clone = first.clone();
+            first.dispose(cx);
+            clone.append(vec![RangeDecoration::new(0..1)], cx);
+            assert!(clone.get_ranges(cx).is_empty());
+            assert_eq!(second.get_ranges(cx), vec![0..3]);
+            editor.update(cx, |state, cx| state.set_value("", window, cx));
+            assert!(second.get_ranges(cx).is_empty());
+            window.draw(cx).clear(cx);
+        });
+    }
+
+    #[test]
+    fn frame_outline_is_continuous_across_different_line_widths() {
+        let corners = [
+            Corners {
+                top_left: point(px(2.), px(0.)),
+                top_right: point(px(20.), px(0.)),
+                bottom_left: point(px(2.), px(10.)),
+                bottom_right: point(px(20.), px(10.)),
+            },
+            Corners {
+                top_left: point(px(0.), px(10.)),
+                top_right: point(px(12.), px(10.)),
+                bottom_left: point(px(0.), px(20.)),
+                bottom_right: point(px(12.), px(20.)),
+            },
+        ];
+
+        assert_eq!(
+            frame_outline_points(&corners),
+            vec![
+                point(px(2.), px(0.)),
+                point(px(20.), px(0.)),
+                point(px(20.), px(10.)),
+                point(px(12.), px(10.)),
+                point(px(12.), px(20.)),
+                point(px(0.), px(20.)),
+                point(px(0.), px(10.)),
+                point(px(2.), px(10.)),
+                point(px(2.), px(0.)),
+            ]
+        );
+    }
 
     #[test]
     fn test_plain_text_decorations_include_unstyled_gaps() {

--- a/crates/base/src/input/base/kind.rs
+++ b/crates/base/src/input/base/kind.rs
@@ -29,7 +29,8 @@ use ropey::Rope;
 use super::decorations::DecorationCollections;
 use super::lsp::{ContextMenuContent, HoverDefinition, InlineCompletion};
 use crate::input::{
-    HighlightStyleResolver, InputEdit, InputHighlighter, SyntaxContext, TextDecoration,
+    HighlightStyleResolver, InputEdit, InputHighlighter, RangeDecoration, SyntaxContext,
+    TextDecoration,
 };
 use crate::input::{HoverPopoverState, Lsp};
 use gpui::Task;
@@ -79,6 +80,11 @@ impl MultiLineMode for EditorMode {}
 pub trait InputExtras: Default + 'static {
     /// Decoration ranges to paint, innermost collection first.
     fn decoration_layers(&self) -> Vec<&[TextDecoration]> {
+        Vec::new()
+    }
+
+    /// Geometric decorations intersecting visible, non-folded buffer spans.
+    fn range_decorations(&self, _ranges: &[std::ops::Range<usize>]) -> Vec<&RangeDecoration> {
         Vec::new()
     }
 
@@ -336,6 +342,7 @@ impl InputModeKind for TextareaMode {
 pub struct EditorExtras {
     pub(crate) lsp: Lsp,
     pub(crate) decorations: DecorationCollections,
+    pub(crate) range_decorations: DecorationCollections<RangeDecoration>,
     pub(crate) inline_completion: InlineCompletion,
     pub(crate) context_menu_content: ContextMenuContent,
     pub(crate) hover_popover: Option<HoverPopoverState>,
@@ -348,6 +355,7 @@ impl Default for EditorExtras {
         Self {
             lsp: Lsp::default(),
             decorations: DecorationCollections::default(),
+            range_decorations: DecorationCollections::default(),
             inline_completion: InlineCompletion::default(),
             context_menu_content: ContextMenuContent::default(),
             hover_popover: None,

--- a/crates/base/src/input/editor/decorations.rs
+++ b/crates/base/src/input/editor/decorations.rs
@@ -1,11 +1,68 @@
 use crate::input::EditorMode;
-use std::ops::Range;
+use std::{collections::BTreeMap, ops::Range};
 
-use gpui::{App, Context, HighlightStyle, WeakEntity};
+use gpui::{App, Context, HighlightStyle, Hsla, WeakEntity};
 use ropey::Rope;
 use sum_tree::Bias;
 
 use super::{InputBaseState, RopeExt as _};
+
+/// Geometric presentation for an editor range decoration.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum RangeDecorationStyle {
+    /// Fill the continuous visual range.
+    Fill,
+    /// Draw a continuous one-pixel frame around the visual range.
+    #[default]
+    Frame,
+}
+
+/// A geometric decoration over a UTF-8 byte range.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RangeDecoration {
+    range: Range<usize>,
+    style: RangeDecorationStyle,
+    color: Option<Hsla>,
+}
+
+impl RangeDecoration {
+    /// Create a frame using the editor foreground color.
+    pub fn new(range: Range<usize>) -> Self {
+        Self {
+            range,
+            style: RangeDecorationStyle::default(),
+            color: None,
+        }
+    }
+
+    /// The half-open UTF-8 byte range supplied to this decoration.
+    pub fn range(&self) -> &Range<usize> {
+        &self.range
+    }
+
+    /// The geometric paint style.
+    pub fn style(&self) -> RangeDecorationStyle {
+        self.style
+    }
+
+    /// An application-owned color override, or `None` for the editor fallback.
+    pub fn color(&self) -> Option<Hsla> {
+        self.color
+    }
+
+    /// Choose a fill or frame without changing text layout.
+    pub fn with_style(mut self, style: RangeDecorationStyle) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Override the editor foreground fallback with an application-owned color.
+    pub fn with_color(mut self, color: Hsla) -> Self {
+        self.color = Some(color);
+        self
+    }
+}
 
 /// A presentation style applied to a UTF-8 byte range in an input.
 ///
@@ -24,8 +81,8 @@ impl TextDecoration {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-struct TextDecorationCollectionId(usize);
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct DecorationCollectionId(usize);
 
 /// An independently managed collection of [`TextDecoration`]s.
 ///
@@ -34,7 +91,7 @@ struct TextDecorationCollectionId(usize);
 #[derive(Clone, Debug)]
 pub struct TextDecorationCollection {
     state: WeakEntity<InputBaseState<EditorMode>>,
-    id: TextDecorationCollectionId,
+    id: DecorationCollectionId,
 }
 
 impl TextDecorationCollection {
@@ -92,69 +149,281 @@ impl TextDecorationCollection {
     }
 }
 
-#[derive(Default)]
-pub(crate) struct DecorationCollections {
-    entries: Vec<(TextDecorationCollectionId, Vec<TextDecoration>)>,
+/// An independently managed collection of geometric range decorations.
+///
+/// Clones address the same collection. Dropping a handle does not clear it; use
+/// [`Self::clear`] to empty it or [`Self::dispose`] to release it permanently.
+/// Operations on a disposed collection or a dropped editor are harmless no-ops.
+#[derive(Clone, Debug)]
+pub struct RangeDecorationCollection {
+    state: WeakEntity<InputBaseState<EditorMode>>,
+    id: DecorationCollectionId,
 }
 
-impl DecorationCollections {
-    fn create(&mut self, decorations: Vec<TextDecoration>) -> TextDecorationCollectionId {
-        let id = TextDecorationCollectionId(self.entries.len());
-        self.entries.push((id, decorations));
+impl RangeDecorationCollection {
+    /// Replace only this owner's decorations, clipping ranges to UTF-8 boundaries.
+    pub fn set(&self, decorations: Vec<RangeDecoration>, cx: &mut App) {
+        let _ = self.state.update(cx, |state, cx| {
+            let decorations = normalize(&state.text, decorations);
+            if state.extras.range_decorations.set(self.id, decorations) {
+                cx.notify();
+            }
+        });
+    }
+
+    /// Append decorations, preserving their paint order.
+    pub fn append(&self, decorations: Vec<RangeDecoration>, cx: &mut App) {
+        let _ = self.state.update(cx, |state, cx| {
+            let decorations = normalize(&state.text, decorations);
+            if state.extras.range_decorations.append(self.id, decorations) {
+                cx.notify();
+            }
+        });
+    }
+
+    /// Empty this collection without invalidating its handles.
+    pub fn clear(&self, cx: &mut App) {
+        self.set(Vec::new(), cx);
+    }
+
+    /// Release this collection, invalidating all of its cloned handles.
+    pub fn dispose(&self, cx: &mut App) {
+        let _ = self.state.update(cx, |state, cx| {
+            if state
+                .extras
+                .range_decorations
+                .entries
+                .remove(&self.id)
+                .is_some()
+            {
+                cx.notify();
+            }
+        });
+    }
+
+    /// Read tracked UTF-8 byte ranges in insertion order.
+    pub fn get_ranges(&self, cx: &App) -> Vec<Range<usize>> {
+        self.state
+            .read_with(cx, |state, _| {
+                state
+                    .extras
+                    .range_decorations
+                    .get(self.id)
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|decoration| decoration.range.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// Both text styles and geometric decorations share normalization and edit affinity.
+pub(crate) trait TrackedDecoration {
+    fn range(&self) -> &Range<usize>;
+    fn range_mut(&mut self) -> &mut Range<usize>;
+}
+
+impl TrackedDecoration for TextDecoration {
+    fn range(&self) -> &Range<usize> {
+        &self.range
+    }
+    fn range_mut(&mut self) -> &mut Range<usize> {
+        &mut self.range
+    }
+}
+
+impl TrackedDecoration for RangeDecoration {
+    fn range(&self) -> &Range<usize> {
+        &self.range
+    }
+    fn range_mut(&mut self) -> &mut Range<usize> {
+        &mut self.range
+    }
+}
+
+/// A balanced interval index over stable insertion-order entries. Each midpoint
+/// stores the maximum end of its subtree, so one document-spanning decoration
+/// does not force a scan of every preceding decoration on each frame.
+struct DecorationIndex {
+    indices: Vec<usize>,
+    max_ends: Vec<usize>,
+}
+
+impl DecorationIndex {
+    fn new<T: TrackedDecoration>(decorations: &[T]) -> Self {
+        let mut indices: Vec<_> = (0..decorations.len()).collect();
+        indices.sort_unstable_by_key(|&ix| (decorations[ix].range().start, ix));
+        let mut index = Self {
+            max_ends: vec![0; indices.len()],
+            indices,
+        };
+        index.build(decorations, 0..decorations.len());
+        index
+    }
+
+    fn build<T: TrackedDecoration>(&mut self, decorations: &[T], span: Range<usize>) -> usize {
+        if span.is_empty() {
+            return 0;
+        }
+        let mid = span.start + span.len() / 2;
+        let end = decorations[self.indices[mid]]
+            .range()
+            .end
+            .max(self.build(decorations, span.start..mid))
+            .max(self.build(decorations, mid + 1..span.end));
+        self.max_ends[mid] = end;
+        end
+    }
+
+    // Returns the number of visited nodes, allowing deterministic complexity tests.
+    fn query<T: TrackedDecoration>(
+        &self,
+        decorations: &[T],
+        span: Range<usize>,
+        range: &Range<usize>,
+        matches: &mut Vec<usize>,
+    ) -> usize {
+        if span.is_empty() || range.is_empty() {
+            return 0;
+        }
+        let mid = span.start + span.len() / 2;
+        if self.max_ends[mid] <= range.start {
+            return 1;
+        }
+        let mut visited = 1 + self.query(decorations, span.start..mid, range, matches);
+        let ix = self.indices[mid];
+        let candidate = decorations[ix].range();
+        if candidate.start < range.end {
+            if candidate.end > range.start {
+                matches.push(ix);
+            }
+            visited += self.query(decorations, mid + 1..span.end, range, matches);
+        }
+        visited
+    }
+}
+
+struct DecorationEntries<T> {
+    decorations: Vec<T>,
+    index: DecorationIndex,
+}
+
+impl<T: TrackedDecoration> DecorationEntries<T> {
+    fn new(decorations: Vec<T>) -> Self {
+        let index = DecorationIndex::new(&decorations);
+        Self { decorations, index }
+    }
+
+    fn reindex(&mut self) {
+        self.index = DecorationIndex::new(&self.decorations);
+    }
+}
+
+pub(crate) struct DecorationCollections<T = TextDecoration> {
+    entries: BTreeMap<DecorationCollectionId, DecorationEntries<T>>,
+    next_id: usize,
+}
+
+impl<T> Default for DecorationCollections<T> {
+    fn default() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            next_id: 0,
+        }
+    }
+}
+
+impl<T: TrackedDecoration> DecorationCollections<T> {
+    fn create(&mut self, decorations: Vec<T>) -> DecorationCollectionId {
+        let id = DecorationCollectionId(self.next_id);
+        self.next_id += 1;
+        self.entries.insert(id, DecorationEntries::new(decorations));
         id
     }
 
-    fn set(&mut self, id: TextDecorationCollectionId, decorations: Vec<TextDecoration>) -> bool {
-        let Some((_, current)) = self
-            .entries
-            .iter_mut()
-            .find(|(entry_id, _)| *entry_id == id)
-        else {
+    fn set(&mut self, id: DecorationCollectionId, decorations: Vec<T>) -> bool {
+        let Some(current) = self.entries.get_mut(&id) else {
             return false;
         };
-        *current = decorations;
+        *current = DecorationEntries::new(decorations);
         true
     }
 
-    fn append(&mut self, id: TextDecorationCollectionId, decorations: Vec<TextDecoration>) -> bool {
-        let Some((_, current)) = self
-            .entries
-            .iter_mut()
-            .find(|(entry_id, _)| *entry_id == id)
-        else {
+    fn append(&mut self, id: DecorationCollectionId, decorations: Vec<T>) -> bool {
+        let Some(current) = self.entries.get_mut(&id) else {
             return false;
         };
-        current.extend(decorations);
+        current.decorations.extend(decorations);
+        current.reindex();
         true
     }
 
-    fn get(&self, id: TextDecorationCollectionId) -> Option<&[TextDecoration]> {
+    fn get(&self, id: DecorationCollectionId) -> Option<&[T]> {
         self.entries
-            .iter()
-            .find(|(entry_id, _)| *entry_id == id)
-            .map(|(_, decorations)| decorations.as_slice())
+            .get(&id)
+            .map(|entry| entry.decorations.as_slice())
     }
 
     pub(super) fn adjust_for_edit(&mut self, edited_range: &Range<usize>, inserted_len: usize) {
-        for (_, decorations) in &mut self.entries {
-            decorations.retain_mut(|decoration| {
-                decoration.range =
-                    adjust_range_for_edit(&decoration.range, edited_range, inserted_len);
-                !decoration.range.is_empty()
+        for entry in self.entries.values_mut() {
+            let len = entry.decorations.len();
+            if len == 0 || entry.index.max_ends[len / 2] <= edited_range.start {
+                continue;
+            }
+            let mut remap = Vec::with_capacity(len);
+            let mut retained = 0;
+            entry.decorations.retain_mut(|decoration| {
+                *decoration.range_mut() =
+                    adjust_range_for_edit(decoration.range(), edited_range, inserted_len);
+                let keep = !decoration.range().is_empty();
+                remap.push(if keep { retained } else { usize::MAX });
+                retained += usize::from(keep);
+                keep
             });
+            // Anchor transforms are monotone. Preserve start ordering and remap
+            // removed entries rather than sorting on every keystroke: O(n).
+            entry.index.indices.retain_mut(|ix| {
+                *ix = remap[*ix];
+                *ix != usize::MAX
+            });
+            entry.index.max_ends.resize(retained, 0);
+            entry.index.build(&entry.decorations, 0..retained);
         }
     }
 
     pub(super) fn clear(&mut self) {
-        for (_, decorations) in &mut self.entries {
-            decorations.clear();
+        for entry in self.entries.values_mut() {
+            *entry = DecorationEntries::new(Vec::new());
         }
     }
 
-    pub(super) fn iter(&self) -> impl Iterator<Item = &[TextDecoration]> {
+    pub(super) fn iter(&self) -> impl Iterator<Item = &[T]> {
         self.entries
-            .iter()
-            .map(|(_, decorations)| decorations.as_slice())
+            .values()
+            .map(|entry| entry.decorations.as_slice())
+    }
+
+    /// Query visible buffer spans (not the intervening folded-away text).
+    /// Rebuilds happen on mutations, never in layout/paint. Preserve owner/item
+    /// order after deduplicating ranges crossing multiple visible lines.
+    pub(super) fn intersecting(&self, ranges: &[Range<usize>]) -> Vec<&T> {
+        let mut result = Vec::new();
+        for entry in self.entries.values() {
+            let mut matches = Vec::new();
+            for range in ranges {
+                entry.index.query(
+                    &entry.decorations,
+                    0..entry.decorations.len(),
+                    range,
+                    &mut matches,
+                );
+            }
+            matches.sort_unstable();
+            matches.dedup();
+            result.extend(matches.into_iter().map(|ix| &entry.decorations[ix]));
+        }
+        result
     }
 }
 
@@ -204,21 +473,56 @@ fn adjust_range_for_edit(
     start..end
 }
 
-fn normalize(text: &Rope, decorations: Vec<TextDecoration>) -> Vec<TextDecoration> {
+fn normalize<T: TrackedDecoration>(text: &Rope, decorations: Vec<T>) -> Vec<T> {
     decorations
         .into_iter()
-        .filter_map(|decoration| {
-            let range = text.clip_offset(decoration.range.start, Bias::Left)
-                ..text.clip_offset(decoration.range.end, Bias::Right);
-            (!range.is_empty()).then_some(TextDecoration {
-                range,
-                style: decoration.style,
-            })
+        .filter_map(|mut decoration| {
+            // Reject reversed ranges before clipping, which could otherwise turn a
+            // reversed pair within a multibyte character into a nonempty range.
+            if decoration.range().is_empty() {
+                return None;
+            }
+            let range = text.clip_offset(decoration.range().start, Bias::Left)
+                ..text.clip_offset(decoration.range().end, Bias::Right);
+            if range.is_empty() {
+                return None;
+            }
+            *decoration.range_mut() = range;
+            Some(decoration)
         })
         .collect()
 }
 
 impl InputBaseState<EditorMode> {
+    /// Create an independently owned collection of geometric range decorations.
+    ///
+    /// Ranges use UTF-8 byte offsets and the same tracking as text decorations:
+    /// insertion at either edge does not expand the range, insertion inside does,
+    /// replacement clips overlapping anchors, and deletion removes empty ranges.
+    /// Undo, redo, whole-document replacement and formatting apply these same edit
+    /// transforms; decorations themselves are not undo history, so deleted ranges
+    /// are not resurrected by undo. Folding changes projection, not stored ranges.
+    ///
+    /// Fills paint behind frames; within each style, later collections/items paint
+    /// over earlier ones. Neither affects text layout, hit testing or focus. The
+    /// default color is the editor foreground (12% opacity for fills).
+    /// Collections live until explicitly disposed or the editor is dropped.
+    pub fn create_range_decorations_collection(
+        &mut self,
+        decorations: Vec<RangeDecoration>,
+        cx: &mut Context<Self>,
+    ) -> RangeDecorationCollection {
+        let id = self
+            .extras
+            .range_decorations
+            .create(normalize(&self.text, decorations));
+        cx.notify();
+        RangeDecorationCollection {
+            state: cx.entity().downgrade(),
+            id,
+        }
+    }
+
     /// Create an independently managed collection of text decorations.
     ///
     /// This follows Monaco's
@@ -253,6 +557,121 @@ impl InputBaseState<EditorMode> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn geometric_collections_share_utf8_normalization_and_edit_affinity() {
+        let mut collections = DecorationCollections::<RangeDecoration>::default();
+        let text = Rope::from("héllo world");
+        let first = collections.create(normalize(
+            &text,
+            vec![
+                RangeDecoration::new(2..4),
+                RangeDecoration::new(2..1),
+                RangeDecoration::new(100..200),
+            ],
+        ));
+        let second = collections.create(normalize(&text, vec![RangeDecoration::new(7..12)]));
+        assert_eq!(collections.get(first).unwrap()[0].range(), &(1..4));
+        assert_eq!(collections.get(first).unwrap().len(), 1);
+        collections.adjust_for_edit(&(1..1), 2);
+        assert_eq!(collections.get(first).unwrap()[0].range(), &(3..6));
+        collections.adjust_for_edit(&(6..6), 1);
+        assert_eq!(collections.get(first).unwrap()[0].range(), &(3..6));
+        collections.adjust_for_edit(&(4..4), 2);
+        assert_eq!(collections.get(first).unwrap()[0].range(), &(3..8));
+        collections.adjust_for_edit(&(3..8), 0);
+        assert!(collections.get(first).unwrap().is_empty());
+        assert!(!collections.get(second).unwrap().is_empty());
+        collections.entries.remove(&first);
+        let third = collections.create(vec![]);
+        assert_ne!(third, first);
+        assert!(!collections.set(first, vec![RangeDecoration::new(0..1)]));
+        assert!(collections.get(second).is_some());
+    }
+
+    #[test]
+    fn visible_query_preserves_layers_and_skips_folded_spans() {
+        let mut collections = DecorationCollections::<RangeDecoration>::default();
+        let first = collections.create(vec![
+            RangeDecoration::new(90..100),
+            RangeDecoration::new(0..100),
+            RangeDecoration::new(40..50), // hidden in a fold
+            RangeDecoration::new(0..5),
+        ]);
+        collections.create(vec![RangeDecoration::new(2..4)]);
+        let ranges = |collections: &DecorationCollections<RangeDecoration>| {
+            collections
+                .intersecting(&[0..5, 90..100])
+                .iter()
+                .map(|d| d.range().clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(ranges(&collections), vec![90..100, 0..100, 0..5, 2..4]);
+        collections.adjust_for_edit(&(0..0), 1);
+        assert_eq!(ranges(&collections), vec![91..101, 1..101, 1..6, 3..5]);
+        collections.set(first, vec![RangeDecoration::new(50..60)]);
+        assert_eq!(ranges(&collections), vec![3..5]);
+    }
+
+    #[test]
+    fn interval_index_culls_large_collections_even_with_a_spanning_range() {
+        let mut decorations: Vec<_> = (0..100_000)
+            .map(|ix| RangeDecoration::new(ix * 10..ix * 10 + 5))
+            .collect();
+        decorations.push(RangeDecoration::new(0..1_000_000));
+        let index = DecorationIndex::new(&decorations);
+        for query in [
+            0..1,
+            500_000..500_020,
+            999_990..1_000_001,
+            1_000_000..1_000_010,
+        ] {
+            let mut matches = Vec::new();
+            let visited = index.query(&decorations, 0..decorations.len(), &query, &mut matches);
+            matches.sort_unstable();
+            let expected: Vec<_> = decorations
+                .iter()
+                .enumerate()
+                .filter_map(|(ix, d)| {
+                    (d.range.start < query.end && d.range.end > query.start).then_some(ix)
+                })
+                .collect();
+            assert_eq!(matches, expected);
+            assert!(visited < 100, "visited {visited} nodes for {query:?}");
+        }
+    }
+
+    #[test]
+    fn interval_index_matches_linear_reference_for_overlaps_and_mutations() {
+        let mut collections = DecorationCollections::<RangeDecoration>::default();
+        let id = collections.create(
+            (0..512)
+                .map(|ix| {
+                    let start = (ix * 37) % 997;
+                    RangeDecoration::new(start..start + ix % 61 + 1)
+                })
+                .collect(),
+        );
+        for edit in [0..0, 300..450, 900..1100] {
+            collections.adjust_for_edit(&edit, 3);
+            for start in (0..1100).step_by(13) {
+                let query = start..start + 17;
+                let expected: Vec<_> = collections
+                    .get(id)
+                    .unwrap()
+                    .iter()
+                    .filter(|d| d.range.start < query.end && d.range.end > query.start)
+                    .map(|d| d.range.clone())
+                    .collect();
+                let actual: Vec<_> = collections
+                    .intersecting(&[query])
+                    .iter()
+                    .map(|d| d.range.clone())
+                    .collect();
+                assert_eq!(actual, expected);
+            }
+        }
+    }
 
     #[test]
     fn collections_are_independent_and_ranges_are_clipped() {

--- a/crates/base/src/input/editor/mod.rs
+++ b/crates/base/src/input/editor/mod.rs
@@ -38,6 +38,7 @@ impl InputModeKind for EditorMode {
     fn reset_annotations(state: &mut InputBaseState<Self>) {
         state.extras.hover_popover = None;
         state.extras.decorations.clear();
+        state.extras.range_decorations.clear();
     }
 
     fn editing_syntax_context(state: &InputBaseState<Self>, offset: usize) -> super::SyntaxContext {
@@ -50,6 +51,10 @@ impl InputModeKind for EditorMode {
         new_len: usize,
     ) {
         state.extras.decorations.adjust_for_edit(range, new_len);
+        state
+            .extras
+            .range_decorations
+            .adjust_for_edit(range, new_len);
     }
 
     fn refresh_language_features(
@@ -216,6 +221,10 @@ impl RenderOnce for Editor {
 impl crate::input::InputExtras for super::EditorExtras {
     fn decoration_layers(&self) -> Vec<&[super::TextDecoration]> {
         self.decorations.iter().collect()
+    }
+
+    fn range_decorations(&self, ranges: &[std::ops::Range<usize>]) -> Vec<&super::RangeDecoration> {
+        self.range_decorations.intersecting(ranges)
     }
 
     fn semantic_token_styles(

--- a/crates/base/src/input/mod.rs
+++ b/crates/base/src/input/mod.rs
@@ -70,7 +70,10 @@ pub(crate) fn init(cx: &mut App) {
 pub use crate::number_input::{NumberInputEvent, NumberStep};
 pub use base::{InputBase, InputContextMenuCapabilities, InputStyles};
 pub use cursor::Selection;
-pub use decorations::{TextDecoration, TextDecorationCollection};
+pub use decorations::{
+    RangeDecoration, RangeDecorationCollection, RangeDecorationStyle, TextDecoration,
+    TextDecorationCollection,
+};
 pub use diagnostics::{
     Diagnostic, DiagnosticEntry, DiagnosticRelatedInformation, DiagnosticSet, DiagnosticSeverity,
     DiagnosticSummary, DiagnosticTag, RelatedInformation,

--- a/crates/component/src/input/mod.rs
+++ b/crates/component/src/input/mod.rs
@@ -25,10 +25,11 @@ pub use gpui_base::input::{
     IndentInline, InputEdit, InputEvent, InputHighlighter, InputHighlighterFactory, InputState,
     Lsp, MaskPattern, MoveDown, MoveEnd, MoveHome, MoveLeft, MovePageDown, MovePageUp, MoveRight,
     MoveToEnd, MoveToEndOfLine, MoveToNextWord, MoveToPreviousWord, MoveToStart, MoveToStartOfLine,
-    MoveUp, Outdent, OutdentInline, Paste, Point, Redo, Replace, Rope, RopeExt, RopeLines, Search,
-    SelectAll, SelectToEnd, SelectToEndOfLine, SelectToNextWordEnd, SelectToPreviousWordStart,
-    SelectToStart, SelectToStartOfLine, Selection, ShowCharacterPalette, ShowDocumentHandler,
-    TabSize, TextDecoration, TextDecorationCollection, TextareaState, ToggleCodeActions, Undo,
+    MoveUp, Outdent, OutdentInline, Paste, Point, RangeDecoration, RangeDecorationCollection,
+    RangeDecorationStyle, Redo, Replace, Rope, RopeExt, RopeLines, Search, SelectAll, SelectToEnd,
+    SelectToEndOfLine, SelectToNextWordEnd, SelectToPreviousWordStart, SelectToStart,
+    SelectToStartOfLine, Selection, ShowCharacterPalette, ShowDocumentHandler, TabSize,
+    TextDecoration, TextDecorationCollection, TextareaState, ToggleCodeActions, Undo,
     WrappingIndent,
 };
 pub use gpui_base::input::{EditorMode, InputMode, InputModeKind, TextareaMode};

--- a/crates/story/src/stories/editor_story.rs
+++ b/crates/story/src/stories/editor_story.rs
@@ -15,6 +15,7 @@ pub struct EditorStory {
     editor_state: Entity<EditorState>,
     decorations_state: Entity<EditorState>,
     _decorations: TextDecorationCollection,
+    _range_decorations: RangeDecorationCollection,
     active_tab: usize,
     readonly: bool,
     font_family: Option<SharedString>,
@@ -131,10 +132,24 @@ impl EditorStory {
             )
         });
 
+        // Geometry is a separate owner from text styling. Both follow edits,
+        // including newlines inserted before these ranges.
+        let range_decorations = decorations_state.update(cx, |state, cx| {
+            state.create_range_decorations_collection(
+                vec![
+                    RangeDecoration::new(color_start..italic_start + italic_range.len())
+                        .with_style(RangeDecorationStyle::Fill),
+                    RangeDecoration::new(underline_start..decoration_text.len()),
+                ],
+                cx,
+            )
+        });
+
         Self {
             editor_state,
             decorations_state,
             _decorations: decorations,
+            _range_decorations: range_decorations,
             active_tab: 0,
             readonly: false,
             font_family: None,

--- a/website/base/primitives/editor.md
+++ b/website/base/primitives/editor.md
@@ -78,7 +78,14 @@ let decorations = editor.update(cx, |state, cx| {
 ```
 
 Decoration collections track ranges as the text changes. Keep the returned
-collection alive for as long as its decorations should remain active.
+handle to update or clear its entries; dropping it does not remove decorations.
+
+`create_range_decorations_collection` creates an independent collection of
+paint-only `RangeDecoration` fills or frames. Text and geometric collections
+share UTF-8 normalization and edit tracking. See
+[Geometric range decorations](../../component/editor.md#geometric-range-decorations)
+for ownership, boundary affinity, deletion, undo/redo, folding, layering, and
+indexing semantics; import the same types from `gpui_kit::base::input`.
 
 ## Highlighting and language features
 

--- a/website/component/editor.md
+++ b/website/component/editor.md
@@ -192,8 +192,65 @@ let decorations = editor.update(cx, |state, cx| {
 });
 ```
 
-Keep the returned `TextDecorationCollection` alive while the decorations are
-needed. Its ranges follow subsequent text edits.
+Keep the returned `TextDecorationCollection` to update or clear that owner's
+text styles. Ranges follow edits; dropping the handle does not remove decorations.
+
+### Geometric range decorations
+
+Use a separate `RangeDecorationCollection` for continuous fills or one-logical-pixel
+frames. These are paint-only annotations: they do not reserve inline space, add
+widgets, intercept pointer events, or change keyboard focus.
+
+```rust
+use gpui_kit::component::input::{RangeDecoration, RangeDecorationStyle};
+
+let review_ranges = editor.update(cx, |state, cx| {
+    state.create_range_decorations_collection(
+        vec![
+            RangeDecoration::new(0..8).with_style(RangeDecorationStyle::Fill),
+            RangeDecoration::new(12..24), // Frame is the default.
+        ],
+        cx,
+    )
+});
+
+review_ranges.set(vec![RangeDecoration::new(4..16)], cx);
+review_ranges.append(vec![RangeDecoration::new(20..28)], cx);
+let tracked_ranges = review_ranges.get_ranges(cx);
+review_ranges.clear(cx);   // Keep the collection available for reuse.
+review_ranges.dispose(cx); // Invalidate this handle and all its clones.
+```
+
+Each collection owns only its own entries, so separate extensions cannot overwrite
+one another. Dropping a handle leaves its collection in the editor; `dispose`
+releases it permanently. Calls on disposed collections or a dropped editor are
+no-ops. Individual decorations do not require an ID.
+
+Ranges are half-open UTF-8 **byte offsets**, not character indices or line numbers.
+Start/end offsets are clipped outward to valid character boundaries; empty,
+reversed, and entirely out-of-document ranges are discarded. Both text and
+geometric decorations share these tracking rules:
+
+- Inserting at either edge does not grow the range; inserting inside it does.
+- Replacements clip overlapping anchors to the replaced span; deleting an entire
+  range removes the decoration.
+- Undo/redo, `set_value`, and `replace_all` (including formatting) apply the same
+  edit transforms. Annotations are **not** snapshots in undo history: undoing a
+  deletion does not resurrect a removed decoration, and undoing a replacement
+  does not recover its former interior anchors. Reset the collection from your
+  semantic source when that distinction matters.
+- Folding changes only visual projection. Hidden-only ranges are not painted;
+  visible portions remain clipped to the viewport and follow soft-wrapped glyphs.
+
+Fills paint behind frames, and both sit below the selection and glyphs. Within
+one style, later collections/items paint over earlier ones. Without `with_color`,
+frames use the editor foreground and fills use that color at 12% opacity, so the
+fallback follows theme changes. An explicit color is owned by the application.
+
+Visible-range queries use an interval index and skip folded buffer spans; they
+do not scan every decoration per frame. Setting/appending entries rebuilds that
+collection's index; edits update affected collections linearly without re-sorting.
+The Editor showcase's **Decorations** tab demonstrates both collection types.
 
 ## Value and events
 

--- a/website/zh-CN/base/primitives/editor.md
+++ b/website/zh-CN/base/primitives/editor.md
@@ -51,7 +51,13 @@ Editor::new(&editor)
 
 ## 空白字符与装饰
 
-通过 `show_whitespaces(true)` 显示空白字符，通过 `create_decorations_collection` 创建随文本编辑自动跟踪范围的装饰集合。只要装饰仍需生效，就应保留返回的 collection。
+通过 `show_whitespaces(true)` 显示空白字符，通过 `create_decorations_collection` 创建随文本编辑自动跟踪范围的装饰集合。保留句柄用于更新或清空条目；丢弃句柄不会移除装饰。
+
+`create_range_decorations_collection` 创建独立的 `RangeDecoration` 填充或边框集合，只参与绘制。
+文本装饰和几何装饰共享 UTF-8 范围归一化与编辑跟踪。
+所有权、边界亲和性、删除、撤销重做、折叠、绘制顺序及索引语义参见
+[几何范围装饰](../../component/editor.md#几何范围装饰)；直接使用 Base 时，从
+`gpui_kit::base::input` 导入相同的类型。
 
 ## 高亮与语言功能
 

--- a/website/zh-CN/component/editor.md
+++ b/website/zh-CN/component/editor.md
@@ -159,7 +159,56 @@ let decorations = editor.update(cx, |state, cx| {
 });
 ```
 
-需要装饰存在多久，就应将返回的 `TextDecorationCollection` 保留多久；文本修改后，其 range 会自动跟随内容变化。
+保留返回的 `TextDecorationCollection`，以便更新或清空该调用方的文本样式。
+范围会跟随文本编辑；丢弃句柄不会移除装饰。
+
+### 几何范围装饰
+
+使用独立的 `RangeDecorationCollection` 绘制连续填充或一个逻辑像素宽的边框。
+它们只参与绘制，不预留行内空间、不添加 widget、不拦截鼠标事件，也不改变键盘焦点。
+
+```rust
+use gpui_kit::component::input::{RangeDecoration, RangeDecorationStyle};
+
+let review_ranges = editor.update(cx, |state, cx| {
+    state.create_range_decorations_collection(
+        vec![
+            RangeDecoration::new(0..8).with_style(RangeDecorationStyle::Fill),
+            RangeDecoration::new(12..24), // 默认为 Frame。
+        ],
+        cx,
+    )
+});
+
+review_ranges.set(vec![RangeDecoration::new(4..16)], cx);
+review_ranges.append(vec![RangeDecoration::new(20..28)], cx);
+let tracked_ranges = review_ranges.get_ranges(cx);
+review_ranges.clear(cx);   // 清空，但保留集合以便复用。
+review_ranges.dispose(cx); // 释放集合，使该句柄及其克隆全部失效。
+```
+
+每个集合只管理自己的条目，不同扩展不会互相覆盖。丢弃句柄后，集合仍保存在编辑器中；
+调用 `dispose` 才会永久释放它。对已释放集合或已销毁编辑器的调用不会产生效果。
+单个装饰不需要提供 ID。
+
+范围使用左闭右开的 UTF-8 **字节偏移量**，不是字符下标或行号。起止偏移量向外裁剪到有效
+字符边界；空范围、反向范围和完全超出文档的范围会被丢弃。文本装饰和几何装饰共享跟踪规则：
+
+- 在两端插入文字不会扩展范围，在内部插入则会扩展。
+- 替换文字时，重叠锚点裁剪到替换区域；删除整个范围会移除该装饰。
+- 撤销、重做、`set_value`、`replace_all`（包括格式化）都应用相同的编辑变换。
+  装饰**不是**撤销历史中的快照：撤销删除不会恢复已移除的装饰，撤销替换也不会恢复原先的
+  内部锚点。如果业务需要这种语义，请依据自己的语义数据重新设置集合。
+- 折叠只改变显示投影，不修改存储的范围。完全隐藏的范围不绘制；可见部分按视口裁剪，
+  并跟随软换行后的实际字形位置。
+
+填充绘制在边框下方，两者均位于选区和字形下方。同一种样式内，后创建的集合和后加入的
+条目覆盖先前的条目。不调用 `with_color` 时，边框使用编辑器前景色，填充使用其 12% 透明度
+版本，因此默认颜色会跟随主题变化；显式颜色由应用自行维护。
+
+可见范围查询使用区间索引并跳过折叠的缓冲区范围，不会逐帧扫描全部装饰。设置或追加条目
+会重建对应集合的索引；编辑文本时线性更新受影响的集合，不重新排序。
+Editor 展示页的 **Decorations** 标签演示了两种集合的组合使用。
 
 ## 值与事件
 


### PR DESCRIPTION
## Problem

Features that need editor affordances have nowhere to draw. There is a gutter rendered in `element.rs`, but nothing anchors a highlight to a byte range, so current-line emphasis, conflict regions, review hunks, or search-hit backgrounds end up needing a fork or a hack layered outside of `Input`.

This adds one annotation kind — a tracked geometric range — as a shared base, and deliberately leaves gutter lanes and inline widgets out for follow-up PRs. Those were part of the earlier revision of this PR; the review asked to do the shared base first and split the feature work, so they are removed here.

## 1. `RangeDecorationCollection` — collection-owned tracked ranges

- `EditorState::create_range_decorations_collection(decorations, cx)` returns an independent handle with `set` / `append` / `clear` / `dispose` / `get_ranges`. Each collection owns only its own entries, so separate extensions cannot overwrite one another, and dropping the handle does not clear it.
- `RangeDecoration::new(range)` with `.with_style(RangeDecorationStyle::{Fill, Frame})` and `.with_color(color)`. `Fill` paints behind the text, `Frame` outlines it — useful for current-line emphasis, conflict regions, or search-hit background.
- Public decoration IDs are gone; the collection handle owns lifetime.
- Text and geometric decorations share UTF-8 normalization and edit tracking via a common `TrackedDecoration` abstraction: insertion at either edge does not expand, insertion inside does, replacement clips overlapping anchors, and deletion removes empty ranges. Undo/redo, `set_value`, `replace_all` and formatting apply the same transforms. Decorations are **not** snapshots in undo history — a deleted decoration is not resurrected by undo.

## 2. Viewport clipping and folds

Ranges are clipped and projected through the actual shaped lines, so soft-wrapped continuations, wrap indents, CRLF, and folds are handled by clipping rather than disappearing when only part of a range is visible. Hidden buffer spans are skipped.

## 3. Indexing

An interval index (subtree max-end) is consulted once per visible, non-folded buffer span, so one document-spanning decoration does not force a full scan every frame. Setting/appending rebuilds that collection's index; edits update affected entries linearly without re-sorting.

## Note on the `crates/shell` and story changes

The `InputEvent::GutterMarkerMouseDown` variant and its exhaustive-match arms are removed along with gutter markers; `crates/shell` and the stories only drop those arms. Nothing else in those files changes.

## Follow-ups (not in this PR)

- Gutter lanes / markers, including the keyboard and accessibility contract, still to be designed.
- Real inline widgets with layout, hit testing and focus.

## Validation

- `cargo test -p gpui-base --locked` — 935 unit + 1 integration pass
- `cargo test -p gpui-component input:: --locked` — 32 pass
- `cargo test -p gpui-kit --features test-support --test input --locked` — 6 pass
- `cargo check -p gpui-component-story --locked`
- `cargo clippy -p gpui-base --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`, `git diff --check`

Five new window-layout tests cover scroll clipping, soft wrap/indent, CRLF, folds, and edit/collection lifetime, plus a 100,001-decoration index culling test. These are automated layout tests; no desktop manual pass.

Release Notes:

- N/A
