### PR TITLE
website: fix docs sidebar hover background clipped on left edge

### DIFF
--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -850,7 +850,7 @@ html.dark .astro-code span {
   height: calc(100vh - var(--nav-height));
   overflow-y: auto;
   flex-shrink: 0;
-  padding: 1.5rem 1rem 1.5rem 0;
+  padding: 1.5rem 1rem 1.5rem 0.5rem;
   border-right: 1px solid var(--border);
   scrollbar-gutter: stable;
 }
@@ -1202,7 +1202,7 @@ html[lang^="zh"] :is(
     width: auto;
     height: auto;
     max-height: 60vh;
-    padding: 1rem 0;
+    padding: 1rem 0.5rem;
     border-right: 0;
     border-bottom: 1px solid var(--border);
   }


### PR DESCRIPTION
closes: #3043 

## Description

In the docs sidebar, hovering a top-level item cuts off the left edge of the hover background (including the border-radius). Nested (indented) items render fine.

Root cause: .sidebar-item uses margin-inline: -0.5rem, but .docs-sidebar has zero left padding combined with overflow-y: auto (which also clips horizontally). Nested items survive only because their parent ul has padding-left: 0.75rem.

## Screenshot

before
<img width="327" height="128" alt="image" src="https://github.com/user-attachments/assets/7270ee61-9e2c-4e25-97d2-8a244c463ae0" />

after
<img width="437" height="58" alt="image" src="https://github.com/user-attachments/assets/7fd58810-6baf-4036-ac2c-40c7ac05e74e" />


## Break Changes

None.

## How to Test

1. cd website && bun install && bunx --bun astro dev`n2. Open any docs page, hover a top-level sidebar item
3. Repeat at mobile width

## Checklist

- [x] I have read the CONTRIBUTING document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)