### PR TITLE
text: prevent inline-code fragments from wrapping twice

### DIFF
--- a/crates/base/src/text/inline_flow.rs
+++ b/crates/base/src/text/inline_flow.rs
@@ -458,6 +458,8 @@ impl Element for InlineFlow {
                         })
                         .text_size(font_size)
                         .line_height(fragment_size.height)
+                        // Fragments are already wrapped, so this leaf must not wrap independently.
+                        .whitespace_nowrap()
                         .child(inline)
                         .into_any_element();
                     window.with_rem_size(Some(typography.rem_size), |window| {

--- a/crates/base/src/text/text_view.rs
+++ b/crates/base/src/text/text_view.rs
@@ -2096,6 +2096,68 @@ mod tests {
         }
     }
 
+    #[test]
+    fn inline_code_fragment_does_not_paint_past_its_reserved_row() {
+        use crate::text::inline::test_fonts::{MONO, WideMonoTextSystem};
+        use gpui::TestApp;
+
+        const TEXT_BACKGROUND: u32 = 0x20f0b0;
+
+        struct MarkdownRoot {
+            text_view: Entity<TextViewState>,
+        }
+
+        impl Render for MarkdownRoot {
+            fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+                div()
+                    .w(px(640.))
+                    .text_size(px(17.9))
+                    .text_bg(gpui::rgb(TEXT_BACKGROUND))
+                    .child(TextView::new(&self.text_view))
+            }
+        }
+
+        let mut app = TestApp::with_text_system(Arc::new(WideMonoTextSystem));
+        app.update(|cx| {
+            crate::init(cx);
+            crate::Theme::global_mut(cx).tokens.typography.mono = MONO.into();
+        });
+        let mut window = app.open_window(|_, cx| MarkdownRoot {
+            text_view: cx.new(|cx| TextViewState::markdown("`main` starts the paragraph", cx)),
+        });
+        window.draw();
+        app.run_until_parked();
+        window.draw();
+
+        let (view_bounds, painted) = window.update(|root, window, cx| {
+            let view_bounds = root
+                .text_view
+                .read(cx)
+                .bounds()
+                .scale(window.scale_factor());
+            let text_background: gpui::Background = gpui::rgb(TEXT_BACKGROUND).into();
+            let painted = window
+                .painted_quads()
+                .into_iter()
+                .filter(|quad| quad.background == text_background)
+                .map(|quad| quad.bounds)
+                .collect::<Vec<_>>();
+            (view_bounds, painted)
+        });
+
+        assert!(
+            !painted.is_empty(),
+            "the inherited text background must make actual text paint observable"
+        );
+        assert!(
+            painted
+                .iter()
+                .all(|bounds| bounds.bottom() <= view_bounds.bottom()),
+            "an inline-code fragment wrapped a second time after InlineFlow reserved one row; \
+             text background quads={painted:?}, reserved TextView bounds={view_bounds:?}"
+        );
+    }
+
     #[gpui::test]
     fn markdown_link_opens_url_without_handler(cx: &mut TestAppContext) {
         cx.update(crate::init);


### PR DESCRIPTION
## Description

Inline code can wrap its final character onto a second line while its background remains on the first line. This reproduces in `example-markdown` at 100% zoom with `asdfwWwwWMMMdmd`.

`InlineFlow` already shapes, wraps, and positions each fragment, but its nested text element can wrap it again when fractional-width rounding leaves a slightly narrower constraint. Apply `whitespace_nowrap()` to the existing fragment container so wrapping remains owned by `InlineFlow`. Long code still wraps through the parent flow; font sizes and padding are unchanged.

Add a full-Markdown regression that inspects actual painted output rather than caret bounds, which can miss the final-character wrap. The test fails without the production fix and passes with it.

## Screenshot

(before above, after below)

<img width="615" height="452" alt="image" src="https://github.com/user-attachments/assets/7aa5647c-efd6-4890-a7b0-b9476c51b634" />


## How to Test

Run `cargo run -p example-markdown` and enter `` `asdfwWwwWMMMdmd` ``. The final `d` should remain with the rest of the token.

Passed:
- `cargo fmt --check`
- `cargo test --locked -p gpui-base --lib` — 889 tests
- `cargo clippy --locked -p gpui-base --all-targets --all-features -- -D warnings`

## Checklist

- [x] Read and followed the contributing guidelines.
- [x] Reviewed the changes, including generated code, for accuracy.
- [x] Interactive story validation/screenshot.
- [ ] Windows/Linux validation (not run).
