### PR TITLE
select: Clear the search query when the menu closes

### DIFF
--- a/crates/component/src/select.rs
+++ b/crates/component/src/select.rs
@@ -192,22 +192,46 @@ where
                             .delegate
                             .on_will_change(&mut selection, &changes);
 
-                        let new_selection = weak_confirm.update(cx, |this, cx| {
+                        let confirmed = weak_confirm.update(cx, |this, cx| {
                             this.state.selection = selection;
 
                             let final_value =
                                 this.state.selection.first().map(|(_, i)| i.value().clone());
 
-                            cx.emit(SelectEvent::Confirm(final_value));
+                            cx.emit(SelectEvent::Confirm(final_value.clone()));
                             cx.notify();
                             this.set_open(false, cx);
                             this.focus(window, cx);
 
-                            this.state.selection.clone()
+                            (this.state.selection.clone(), final_value)
                         });
 
-                        // Sync snapshot and fire on_confirm directly — same re-entrancy guard.
-                        if let Ok(new_selection) = new_selection {
+                        // Clear the query through list_state directly — an entity-handle
+                        // update here would re-enter the ListState lock held above.
+                        // The committed index pointed into the filtered view, so resolve
+                        // the confirmed value in the restored full list; otherwise the
+                        // cursor and the mark would disagree on the next open.
+                        if let Ok((mut new_selection, final_value)) = confirmed {
+                            if !list_state.query_input.read(cx).value().is_empty() {
+                                list_state.set_query("", window, cx);
+                            }
+
+                            if let Some(ix) = final_value
+                                .as_ref()
+                                .and_then(|value| list_state.delegate().delegate.position(value))
+                            {
+                                list_state.set_selected_index(Some(ix), window, cx);
+                                if let Some((slot, _)) = new_selection.first_mut() {
+                                    *slot = ix;
+                                }
+                                _ = weak_confirm.update(cx, |this, cx| {
+                                    if let Some((slot, _)) = this.state.selection.first_mut() {
+                                        *slot = ix;
+                                    }
+                                    cx.notify();
+                                });
+                            }
+
                             list_state
                                 .delegate_mut()
                                 .update_selection_snapshot(new_selection.clone());
@@ -219,7 +243,7 @@ where
                     }
                 });
             },
-            // on_cancel — restore cursor to committed index, close
+            // on_cancel — clear the query, restore cursor to committed index, close
             move |_final_selected_index, window, cx| {
                 cx.defer_in(window, {
                     let weak_cancel = weak_cancel.clone();
@@ -228,6 +252,9 @@ where
                             .upgrade()
                             .and_then(|e| e.read(cx).state.selection.first().map(|(ix, _)| *ix));
 
+                        if !list_state.query_input.read(cx).value().is_empty() {
+                            list_state.set_query("", window, cx);
+                        }
                         list_state.set_selected_index(committed_ix, window, cx);
 
                         _ = weak_cancel.update(cx, |this, cx| {
@@ -355,13 +382,7 @@ where
             return;
         }
 
-        let committed_ix = self.state.selection.first().map(|(ix, _)| *ix);
-        if self.selected_index(cx) != committed_ix {
-            self.state.list.update(cx, |list, cx| {
-                list.set_selected_index(committed_ix, window, cx);
-            });
-        }
-
+        self.clear_query_and_restore_cursor(window, cx);
         self.set_open(false, cx);
         cx.notify();
     }
@@ -373,6 +394,8 @@ where
 
         if self.state.open {
             self.state.list.focus_handle(cx).focus(window, cx);
+        } else {
+            self.clear_query_and_restore_cursor(window, cx);
         }
 
         cx.notify();
@@ -385,9 +408,24 @@ where
         }
 
         cx.stop_propagation();
+        self.clear_query_and_restore_cursor(window, cx);
         self.set_open(false, cx);
         self.focus(window, cx);
         cx.notify();
+    }
+
+    /// Drop the search query and move the cursor back to the committed
+    /// selection, so the next open shows every item. Call on every menu
+    /// close that does not go through the confirm/cancel callbacks.
+    fn clear_query_and_restore_cursor(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.state.clear_query(window, cx);
+
+        let committed_ix = self.state.selection.first().map(|(ix, _)| *ix);
+        self.state.list.update(cx, |list, cx| {
+            if list.selected_index() != committed_ix {
+                list.set_selected_index(committed_ix, window, cx);
+            }
+        });
     }
 
     fn set_open(&mut self, open: bool, cx: &mut Context<Self>) {
@@ -802,8 +840,13 @@ where
             .focus_handle(&focus_handle)
             .content_focus_handle(&content_focus_handle)
             .accessibility_value(accessibility_value)
-            .on_open_change(move |open, _, cx| {
-                open_state.update(cx, |state, cx| state.set_open(open, cx));
+            .on_open_change(move |open, window, cx| {
+                open_state.update(cx, |state, cx| {
+                    if !open {
+                        state.clear_query_and_restore_cursor(window, cx);
+                    }
+                    state.set_open(open, cx);
+                });
             })
             .size_full()
             .child(self.state)

--- a/crates/kit/tests/controls.rs
+++ b/crates/kit/tests/controls.rs
@@ -6,7 +6,9 @@ use gpui_kit::component::{
     tab::{Tab, TabBar},
 };
 use gpui_kit::test::{TestAppContextExt, TestWindowExt};
-use gpui_kit::{AppContext, Context, Entity, TestAppContext, Window, div, prelude::*, px, size};
+use gpui_kit::{
+    AnyWindowHandle, AppContext, Context, Entity, TestAppContext, Window, div, prelude::*, px, size,
+};
 use std::time::Duration;
 
 struct Form {
@@ -230,4 +232,96 @@ fn checkbox_click_cannot_fabricate_a_successful_state_change(cx: &mut TestAppCon
         assert_eq!(window.find("agree").checked(), Some(false));
     })
     .unwrap();
+}
+
+struct SearchableLanguageForm {
+    language: Entity<SelectState<SearchableVec<&'static str>>>,
+}
+impl Render for SearchableLanguageForm {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .child(Select::new(&self.language).id("language").w(px(240.)))
+    }
+}
+
+fn open_searchable_language(cx: &mut TestAppContext) -> AnyWindowHandle {
+    cx.update(gpui_kit::init);
+    let handle = cx.open_window(size(px(640.), px(480.)), |window, cx| {
+        let items = SearchableVec::new(vec!["Dutch", "English", "French", "Hungarian"]);
+        SearchableLanguageForm {
+            language: cx.new(|cx| {
+                SelectState::new(items, Some(IndexPath::new(1)), window, cx).searchable(true)
+            }),
+        }
+    });
+    handle.into()
+}
+
+async fn wait_select_closed(cx: &mut TestAppContext, handle: AnyWindowHandle) {
+    cx.wait_for(handle, Duration::from_millis(500), |window, _| {
+        window.find("language").expanded() == Some(false)
+    })
+    .await;
+}
+
+fn select_value(cx: &mut TestAppContext, handle: AnyWindowHandle) -> Option<String> {
+    cx.update_window(handle, |_, window, _| {
+        window.find("language").value().map(str::to_owned)
+    })
+    .unwrap()
+}
+
+/// Opens the menu and types the query. The list filters in a task.
+fn search_language(cx: &mut TestAppContext, handle: AnyWindowHandle, query: &str) {
+    cx.update_window(handle, |_, window, cx| {
+        window.render_frame(cx);
+        window.within("language").click("input", cx);
+        if !query.is_empty() {
+            window.input(query, cx);
+        }
+    })
+    .unwrap();
+    cx.run_until_parked();
+}
+
+fn press_language_keys(cx: &mut TestAppContext, handle: AnyWindowHandle, keys: &[&str]) {
+    cx.update_window(handle, |_, window, cx| {
+        window.render_frame(cx);
+        for key in keys {
+            window.press(key, cx);
+        }
+    })
+    .unwrap();
+}
+
+#[gpui_kit::test]
+async fn searchable_select_next_open_after_cancel_shows_all_items(cx: &mut TestAppContext) {
+    let handle = open_searchable_language(cx);
+
+    search_language(cx, handle, "hun");
+    press_language_keys(cx, handle, &["escape"]);
+    wait_select_closed(cx, handle).await;
+
+    // With an empty query, Down moves from English to French.
+    search_language(cx, handle, "");
+    press_language_keys(cx, handle, &["down", "enter"]);
+    wait_select_closed(cx, handle).await;
+    assert_eq!(select_value(cx, handle).as_deref(), Some("French"));
+}
+
+#[gpui_kit::test]
+async fn searchable_select_next_open_after_confirm_shows_all_items(cx: &mut TestAppContext) {
+    let handle = open_searchable_language(cx);
+
+    search_language(cx, handle, "hun");
+    press_language_keys(cx, handle, &["enter"]);
+    wait_select_closed(cx, handle).await;
+    assert_eq!(select_value(cx, handle).as_deref(), Some("Hungarian"));
+
+    // With an empty query, Up moves from Hungarian to French.
+    search_language(cx, handle, "");
+    press_language_keys(cx, handle, &["up", "enter"]);
+    wait_select_closed(cx, handle).await;
+    assert_eq!(select_value(cx, handle).as_deref(), Some("French"));
 }


### PR DESCRIPTION
Closes #3047 

## Description

A searchable `Select` kept its filter query after the menu closed, so the next open showed the old query and a filtered list. `clear_query` had one caller, `set_selected_value`.

Confirm now clears the query after committing and re-resolves the confirmed value via `position()`, so the cursor and mark land on the full-list row (a filtered index would point at the wrong item). Cancel clears before restoring the cursor to the committed index. A new `clear_query_and_restore_cursor` helper covers every other close: trigger `escape` (click-out), `on_blur`, trigger-toggle close, and base `on_open_change`. Confirm/cancel clear through the held `list_state` directly to avoid re-entering the `ListState` lock that `defer_in` holds.

## Screenshot
N/A

## Break Changes
None

## How to Test
Automated (mirrors the issue's repro: Dutch/English/French/Hungarian, type `hun`, close, reopen and navigate):

cargo test -p gpui-kit --features="test-support component" --test controls searchable_select

Both tests fail without the fix with the issue's exact signature (`left: Hungarian, right: French`) and pass with it. Also ran: full `--test controls` suite (6/6 pass), `cargo test -p gpui-component select` (all pass), `cargo fmt --check` (clean). Note: `cargo clippy` reports a pre-existing `nonminimal_bool` lint in `crates/base/src/calendar.rs`, untouched by this change.

Manual: open a `.searchable(true)` select, type part of an item name, press Enter (or Escape), reopen — the search field is empty and all items show with the mark on the current item.


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document and followed the guidelines.
- [x] Reviewed the changes in this PR and confirmed AI generated code (If any) is accurate.
- [ ] Passed `cargo run` for story tests related to the changes.
- [ ] Tested macOS, Windows and Linux platforms performance (if the change is platform-specific)
